### PR TITLE
Re-parse 2012 from sources-ks into individual county files, with VTD

### DIFF
--- a/2012/20121106__ks__general__allen__precinct.csv
+++ b/2012/20121106__ks__general__allen__precinct.csv
@@ -1,0 +1,735 @@
+county,precinct,office,district,party,candidate,votes,vtd
+ALLEN,Carlyle Township,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",123,000010
+ALLEN,Cottage Grove Township,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",110,000020
+ALLEN,Deer Creek Township,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",43,000030
+ALLEN,East Elm,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",202,000040
+ALLEN,Geneva Township,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",55,000050
+ALLEN,Humboldt Township,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",119,00006A
+ALLEN,Humboldt Township Rural Enclave,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",0,00006B
+ALLEN,Humboldt Township Split,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",0,00006C
+ALLEN,Humboldt Ward 1,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",316,000070
+ALLEN,Humboldt Ward 2,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",373,000080
+ALLEN,Iola Ward 1,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",598,000090
+ALLEN,Iola Ward 2,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",346,00010A
+ALLEN,Iola Ward 2 Exclave,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",0,00010B
+ALLEN,Iola Ward 3,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",352,000110
+ALLEN,Iola Ward 4,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",349,000120
+ALLEN,Marmaton Township,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",137,000140
+ALLEN,Marmaton Township,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",16,000140
+ALLEN,Marmaton Township,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",187,000140
+ALLEN,North Elmsmore,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",30,000150
+ALLEN,North Elmsmore,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",3,000150
+ALLEN,North Elmsmore,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",53,000150
+ALLEN,North Iola Part A,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",92,00016A
+ALLEN,North Iola Part B,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",0,00016C
+ALLEN,Osage Township,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",55,000170
+ALLEN,Osage Township,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",7,000170
+ALLEN,Osage Township,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",63,000170
+ALLEN,Salem Township,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",107,000180
+ALLEN,South Elmsmore,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",33,000190
+ALLEN,South Elmsmore,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",2,000190
+ALLEN,South Elmsmore,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",51,000190
+ALLEN,South Iola,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",226,00020A
+ALLEN,South Iola Enclave,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",0,00020B
+ALLEN,West Elm,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",387,000210
+ALLEN,Logan Township S12,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",84,120020
+ALLEN,Logan Township S15,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",0,120030
+ALLEN,Carlyle Township,Kansas Senate,12,Democratic,"Cassells, Denise",30,000010
+ALLEN,Carlyle Township,Kansas Senate,12,Republican,"Tyson, Caryn",108,000010
+ALLEN,Cottage Grove Township,Kansas Senate,12,Democratic,"Cassells, Denise",35,000020
+ALLEN,Cottage Grove Township,Kansas Senate,12,Republican,"Tyson, Caryn",86,000020
+ALLEN,Deer Creek Township,Kansas Senate,12,Democratic,"Cassells, Denise",17,000030
+ALLEN,Deer Creek Township,Kansas Senate,12,Republican,"Tyson, Caryn",37,000030
+ALLEN,East Elm,Kansas Senate,12,Democratic,"Cassells, Denise",91,000040
+ALLEN,East Elm,Kansas Senate,12,Republican,"Tyson, Caryn",147,000040
+ALLEN,Geneva Township,Kansas Senate,12,Democratic,"Cassells, Denise",19,000050
+ALLEN,Geneva Township,Kansas Senate,12,Republican,"Tyson, Caryn",43,000050
+ALLEN,Humboldt Township,Kansas Senate,12,Democratic,"Cassells, Denise",38,00006A
+ALLEN,Humboldt Township,Kansas Senate,12,Republican,"Tyson, Caryn",89,00006A
+ALLEN,Humboldt Township Rural Enclave,Kansas Senate,12,Democratic,"Cassells, Denise",0,00006B
+ALLEN,Humboldt Township Rural Enclave,Kansas Senate,12,Republican,"Tyson, Caryn",0,00006B
+ALLEN,Humboldt Township Split,Kansas Senate,12,Democratic,"Cassells, Denise",0,00006C
+ALLEN,Humboldt Township Split,Kansas Senate,12,Republican,"Tyson, Caryn",0,00006C
+ALLEN,Humboldt Ward 1,Kansas Senate,12,Democratic,"Cassells, Denise",154,000070
+ALLEN,Humboldt Ward 1,Kansas Senate,12,Republican,"Tyson, Caryn",223,000070
+ALLEN,Humboldt Ward 2,Kansas Senate,12,Democratic,"Cassells, Denise",153,000080
+ALLEN,Humboldt Ward 2,Kansas Senate,12,Republican,"Tyson, Caryn",261,000080
+ALLEN,Iola Ward 1,Kansas Senate,12,Democratic,"Cassells, Denise",231,000090
+ALLEN,Iola Ward 1,Kansas Senate,12,Republican,"Tyson, Caryn",453,000090
+ALLEN,Iola Ward 2,Kansas Senate,12,Democratic,"Cassells, Denise",145,00010A
+ALLEN,Iola Ward 2,Kansas Senate,12,Republican,"Tyson, Caryn",260,00010A
+ALLEN,Iola Ward 2 Exclave,Kansas Senate,12,Democratic,"Cassells, Denise",0,00010B
+ALLEN,Iola Ward 2 Exclave,Kansas Senate,12,Republican,"Tyson, Caryn",0,00010B
+ALLEN,Iola Ward 3,Kansas Senate,12,Democratic,"Cassells, Denise",166,000110
+ALLEN,Iola Ward 3,Kansas Senate,12,Republican,"Tyson, Caryn",254,000110
+ALLEN,Iola Ward 4,Kansas Senate,12,Democratic,"Cassells, Denise",161,000120
+ALLEN,Iola Ward 4,Kansas Senate,12,Republican,"Tyson, Caryn",254,000120
+ALLEN,Marmaton Township,Kansas Senate,12,Democratic,"Cassells, Denise",126,000140
+ALLEN,Marmaton Township,Kansas Senate,12,Republican,"Tyson, Caryn",207,000140
+ALLEN,North Elmsmore,Kansas Senate,12,Democratic,"Cassells, Denise",28,000150
+ALLEN,North Elmsmore,Kansas Senate,12,Republican,"Tyson, Caryn",58,000150
+ALLEN,North Iola Part A,Kansas Senate,12,Democratic,"Cassells, Denise",33,00016A
+ALLEN,North Iola Part A,Kansas Senate,12,Republican,"Tyson, Caryn",81,00016A
+ALLEN,North Iola Part A Rural Enclave,Kansas Senate,12,Democratic,"Cassells, Denise",0,00016B
+ALLEN,North Iola Part A Rural Enclave,Kansas Senate,12,Republican,"Tyson, Caryn",0,00016B
+ALLEN,North Iola Part B,Kansas Senate,12,Democratic,"Cassells, Denise",0,00016C
+ALLEN,North Iola Part B,Kansas Senate,12,Republican,"Tyson, Caryn",0,00016C
+ALLEN,Osage Township,Kansas Senate,12,Democratic,"Cassells, Denise",50,000170
+ALLEN,Osage Township,Kansas Senate,12,Republican,"Tyson, Caryn",74,000170
+ALLEN,Salem Township,Kansas Senate,12,Democratic,"Cassells, Denise",49,000180
+ALLEN,Salem Township,Kansas Senate,12,Republican,"Tyson, Caryn",80,000180
+ALLEN,South Elmsmore,Kansas Senate,12,Democratic,"Cassells, Denise",32,000190
+ALLEN,South Elmsmore,Kansas Senate,12,Republican,"Tyson, Caryn",53,000190
+ALLEN,South Iola,Kansas Senate,12,Democratic,"Cassells, Denise",82,00020A
+ALLEN,South Iola,Kansas Senate,12,Republican,"Tyson, Caryn",183,00020A
+ALLEN,South Iola Enclave,Kansas Senate,12,Democratic,"Cassells, Denise",0,00020B
+ALLEN,South Iola Enclave,Kansas Senate,12,Republican,"Tyson, Caryn",0,00020B
+ALLEN,West Elm,Kansas Senate,12,Democratic,"Cassells, Denise",153,000210
+ALLEN,West Elm,Kansas Senate,12,Republican,"Tyson, Caryn",295,000210
+ALLEN,Logan Township S12,Kansas Senate,12,Democratic,"Cassells, Denise",32,120020
+ALLEN,Logan Township S12,Kansas Senate,12,Republican,"Tyson, Caryn",64,120020
+ALLEN,Logan Township S15,Kansas Senate,15,Republican,"King, Jeff",0,120030
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+ALLEN,Carlyle Township,President / Vice President,,Democratic,"Obama, Barack",32,000010
+ALLEN,Carlyle Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+ALLEN,Carlyle Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+ALLEN,Carlyle Township,President / Vice President,,Republican,"Romney, Mitt",108,000010
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,Democratic,"Obama, Barack",37,000020
+ALLEN,Cottage Grove Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,Republican,"Romney, Mitt",90,000020
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,Democratic,"Obama, Barack",13,000030
+ALLEN,Deer Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+ALLEN,Deer Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000030
+ALLEN,Deer Creek Township,President / Vice President,,Republican,"Romney, Mitt",37,000030
+ALLEN,East Elm,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Barnett, Andre",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Bush, Kent W",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Christensen, Will",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Goode, Virgil",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Stein, Jill E",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+ALLEN,East Elm,President / Vice President,,Democratic,"Obama, Barack",107,000040
+ALLEN,East Elm,President / Vice President,,Libertarian,"Johnson, Gary",6,000040
+ALLEN,East Elm,President / Vice President,,Reform,"Baldwin, Chuck",2,000040
+ALLEN,East Elm,President / Vice President,,Republican,"Romney, Mitt",130,000040
+ALLEN,Geneva Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+ALLEN,Geneva Township,President / Vice President,,Democratic,"Obama, Barack",19,000050
+ALLEN,Geneva Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+ALLEN,Geneva Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+ALLEN,Geneva Township,President / Vice President,,Republican,"Romney, Mitt",47,000050
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Ayers, Avery L",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Barnett, Andre",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Bush, Kent W",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Christensen, Will",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Duncan, Richard A",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Goode, Virgil",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Knill, Dennis J",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Reed, Jill A.",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Rogers, Rick L",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Stein, Jill E",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,Democratic,"Obama, Barack",42,00006A
+ALLEN,Humboldt Township,President / Vice President,,Libertarian,"Johnson, Gary",5,00006A
+ALLEN,Humboldt Township,President / Vice President,,Reform,"Baldwin, Chuck",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,Republican,"Romney, Mitt",88,00006A
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Christensen, Will",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00006B
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Ayers, Avery L",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Barnett, Andre",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Barr, Roseanne C",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Bush, Kent W",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Christensen, Will",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Duncan, Richard A",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Goode, Virgil",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Hoefling, Tom",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Knill, Dennis J",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Reed, Jill A.",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Rogers, Rick L",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Stein, Jill E",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Thorne, Kevin M",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Warner, Gerald L.",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,Democratic,"Obama, Barack",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,Libertarian,"Johnson, Gary",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,Reform,"Baldwin, Chuck",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,Republican,"Romney, Mitt",0,00006C
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Goode, Virgil",1,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,Democratic,"Obama, Barack",149,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",5,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,Republican,"Romney, Mitt",229,000070
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",1,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,Democratic,"Obama, Barack",162,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",4,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",6,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,Republican,"Romney, Mitt",255,000080
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,Democratic,"Obama, Barack",231,000090
+ALLEN,Iola Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",17,000090
+ALLEN,Iola Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",6,000090
+ALLEN,Iola Ward 1,President / Vice President,,Republican,"Romney, Mitt",459,000090
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,Democratic,"Obama, Barack",177,00010A
+ALLEN,Iola Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",4,00010A
+ALLEN,Iola Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",2,00010A
+ALLEN,Iola Ward 2,President / Vice President,,Republican,"Romney, Mitt",229,00010A
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00010B
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Stein, Jill E",1,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,Democratic,"Obama, Barack",186,000110
+ALLEN,Iola Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",11,000110
+ALLEN,Iola Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+ALLEN,Iola Ward 3,President / Vice President,,Republican,"Romney, Mitt",239,000110
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,Democratic,"Obama, Barack",164,000120
+ALLEN,Iola Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",3,000120
+ALLEN,Iola Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+ALLEN,Iola Ward 4,President / Vice President,,Republican,"Romney, Mitt",254,000120
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+ALLEN,Marmaton Township,President / Vice President,,Democratic,"Obama, Barack",105,000140
+ALLEN,Marmaton Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000140
+ALLEN,Marmaton Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000140
+ALLEN,Marmaton Township,President / Vice President,,Republican,"Romney, Mitt",233,000140
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Barnett, Andre",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Bush, Kent W",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Christensen, Will",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Goode, Virgil",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Stein, Jill E",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+ALLEN,North Elmsmore,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+ALLEN,North Elmsmore,President / Vice President,,Democratic,"Obama, Barack",24,000150
+ALLEN,North Elmsmore,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+ALLEN,North Elmsmore,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+ALLEN,North Elmsmore,President / Vice President,,Republican,"Romney, Mitt",60,000150
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Barnett, Andre",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Bush, Kent W",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Christensen, Will",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Goode, Virgil",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Stein, Jill E",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,Democratic,"Obama, Barack",34,00016A
+ALLEN,North Iola Part A,President / Vice President,,Libertarian,"Johnson, Gary",1,00016A
+ALLEN,North Iola Part A,President / Vice President,,Reform,"Baldwin, Chuck",1,00016A
+ALLEN,North Iola Part A,President / Vice President,,Republican,"Romney, Mitt",83,00016A
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Christensen, Will",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00016B
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Ayers, Avery L",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Barnett, Andre",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Bush, Kent W",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Christensen, Will",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Duncan, Richard A",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Goode, Virgil",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Knill, Dennis J",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Reed, Jill A.",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Rogers, Rick L",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Stein, Jill E",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,Democratic,"Obama, Barack",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,Republican,"Romney, Mitt",0,00016C
+ALLEN,Osage Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+ALLEN,Osage Township,President / Vice President,,Democratic,"Obama, Barack",45,000170
+ALLEN,Osage Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000170
+ALLEN,Osage Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000170
+ALLEN,Osage Township,President / Vice President,,Republican,"Romney, Mitt",83,000170
+ALLEN,Salem Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+ALLEN,Salem Township,President / Vice President,,Democratic,"Obama, Barack",45,000180
+ALLEN,Salem Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+ALLEN,Salem Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+ALLEN,Salem Township,President / Vice President,,Republican,"Romney, Mitt",85,000180
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Barnett, Andre",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Bush, Kent W",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Christensen, Will",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Goode, Virgil",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Stein, Jill E",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+ALLEN,South Elmsmore,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+ALLEN,South Elmsmore,President / Vice President,,Democratic,"Obama, Barack",26,000190
+ALLEN,South Elmsmore,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+ALLEN,South Elmsmore,President / Vice President,,Reform,"Baldwin, Chuck",1,000190
+ALLEN,South Elmsmore,President / Vice President,,Republican,"Romney, Mitt",58,000190
+ALLEN,South Iola,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Ayers, Avery L",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Barnett, Andre",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Barr, Roseanne C",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Bush, Kent W",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Christensen, Will",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Duncan, Richard A",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Goode, Virgil",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Hoefling, Tom",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Knill, Dennis J",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Reed, Jill A.",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Rogers, Rick L",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Stein, Jill E",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Thorne, Kevin M",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Warner, Gerald L.",0,00020A
+ALLEN,South Iola,President / Vice President,,Democratic,"Obama, Barack",78,00020A
+ALLEN,South Iola,President / Vice President,,Libertarian,"Johnson, Gary",3,00020A
+ALLEN,South Iola,President / Vice President,,Reform,"Baldwin, Chuck",0,00020A
+ALLEN,South Iola,President / Vice President,,Republican,"Romney, Mitt",192,00020A
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Christensen, Will",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00020B
+ALLEN,West Elm,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Barnett, Andre",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Bush, Kent W",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Christensen, Will",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Goode, Virgil",3,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Stein, Jill E",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+ALLEN,West Elm,President / Vice President,,Democratic,"Obama, Barack",160,000210
+ALLEN,West Elm,President / Vice President,,Libertarian,"Johnson, Gary",9,000210
+ALLEN,West Elm,President / Vice President,,Reform,"Baldwin, Chuck",2,000210
+ALLEN,West Elm,President / Vice President,,Republican,"Romney, Mitt",289,000210
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Barnett, Andre",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Bush, Kent W",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Christensen, Will",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Goode, Virgil",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Stein, Jill E",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+ALLEN,Logan Township S12,President / Vice President,,Democratic,"Obama, Barack",33,120020
+ALLEN,Logan Township S12,President / Vice President,,Libertarian,"Johnson, Gary",1,120020
+ALLEN,Logan Township S12,President / Vice President,,Reform,"Baldwin, Chuck",2,120020
+ALLEN,Logan Township S12,President / Vice President,,Republican,"Romney, Mitt",68,120020
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Barnett, Andre",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Bush, Kent W",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Christensen, Will",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Goode, Virgil",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Stein, Jill E",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+ALLEN,Logan Township S15,President / Vice President,,Democratic,"Obama, Barack",0,120030
+ALLEN,Logan Township S15,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+ALLEN,Logan Township S15,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+ALLEN,Logan Township S15,President / Vice President,,Republican,"Romney, Mitt",0,120030
+ALLEN,Carlyle Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",19,000010
+ALLEN,Carlyle Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000010
+ALLEN,Carlyle Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",113,000010
+ALLEN,Cottage Grove Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",21,000020
+ALLEN,Cottage Grove Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000020
+ALLEN,Cottage Grove Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",100,000020
+ALLEN,Deer Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",13,000030
+ALLEN,Deer Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000030
+ALLEN,Deer Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",40,000030
+ALLEN,East Elm,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",70,000040
+ALLEN,East Elm,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,000040
+ALLEN,East Elm,United States House of Representatives,2,Republican,"Jenkins, Lynn",157,000040
+ALLEN,Geneva Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",13,000050
+ALLEN,Geneva Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000050
+ALLEN,Geneva Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,000050
+ALLEN,Humboldt Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",37,00006A
+ALLEN,Humboldt Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,00006A
+ALLEN,Humboldt Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",92,00006A
+ALLEN,Humboldt Township Rural Enclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00006B
+ALLEN,Humboldt Township Rural Enclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00006B
+ALLEN,Humboldt Township Rural Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00006B
+ALLEN,Humboldt Township Split,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00006C
+ALLEN,Humboldt Township Split,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00006C
+ALLEN,Humboldt Township Split,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00006C
+ALLEN,Humboldt Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",108,000070
+ALLEN,Humboldt Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",25,000070
+ALLEN,Humboldt Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",250,000070
+ALLEN,Humboldt Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",116,000080
+ALLEN,Humboldt Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",25,000080
+ALLEN,Humboldt Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",279,000080
+ALLEN,Iola Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",181,000090
+ALLEN,Iola Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",28,000090
+ALLEN,Iola Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",490,000090
+ALLEN,Iola Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",122,00010A
+ALLEN,Iola Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,00010A
+ALLEN,Iola Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",260,00010A
+ALLEN,Iola Ward 2 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00010B
+ALLEN,Iola Ward 2 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00010B
+ALLEN,Iola Ward 2 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00010B
+ALLEN,Iola Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",126,000110
+ALLEN,Iola Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",21,000110
+ALLEN,Iola Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",279,000110
+ALLEN,Iola Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",115,000120
+ALLEN,Iola Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",20,000120
+ALLEN,Iola Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",283,000120
+ALLEN,Marmaton Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",96,000140
+ALLEN,Marmaton Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",17,000140
+ALLEN,Marmaton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",234,000140
+ALLEN,North Elmsmore,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",19,000150
+ALLEN,North Elmsmore,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000150
+ALLEN,North Elmsmore,United States House of Representatives,2,Republican,"Jenkins, Lynn",65,000150
+ALLEN,North Iola Part A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",30,00016A
+ALLEN,North Iola Part A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,00016A
+ALLEN,North Iola Part A,United States House of Representatives,2,Republican,"Jenkins, Lynn",80,00016A
+ALLEN,North Iola Part A Rural Enclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00016B
+ALLEN,North Iola Part A Rural Enclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00016B
+ALLEN,North Iola Part A Rural Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00016B
+ALLEN,North Iola Part B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00016C
+ALLEN,North Iola Part B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00016C
+ALLEN,North Iola Part B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00016C
+ALLEN,Osage Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",39,000170
+ALLEN,Osage Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000170
+ALLEN,Osage Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",84,000170
+ALLEN,Salem Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",35,000180
+ALLEN,Salem Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000180
+ALLEN,Salem Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",92,000180
+ALLEN,South Elmsmore,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",27,000190
+ALLEN,South Elmsmore,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000190
+ALLEN,South Elmsmore,United States House of Representatives,2,Republican,"Jenkins, Lynn",56,000190
+ALLEN,South Iola,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",64,00020A
+ALLEN,South Iola,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,00020A
+ALLEN,South Iola,United States House of Representatives,2,Republican,"Jenkins, Lynn",199,00020A
+ALLEN,South Iola Enclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00020B
+ALLEN,South Iola Enclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00020B
+ALLEN,South Iola Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00020B
+ALLEN,West Elm,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",108,000210
+ALLEN,West Elm,United States House of Representatives,2,Libertarian,"Hawver, Dennis",23,000210
+ALLEN,West Elm,United States House of Representatives,2,Republican,"Jenkins, Lynn",326,000210
+ALLEN,Logan Township S12,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",24,120020
+ALLEN,Logan Township S12,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,120020
+ALLEN,Logan Township S12,United States House of Representatives,2,Republican,"Jenkins, Lynn",72,120020
+ALLEN,Logan Township S15,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120030
+ALLEN,Logan Township S15,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120030
+ALLEN,Logan Township S15,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120030

--- a/2012/20121106__ks__general__anderson__precinct.csv
+++ b/2012/20121106__ks__general__anderson__precinct.csv
@@ -1,0 +1,676 @@
+county,precinct,office,district,party,candidate,votes,vtd
+ANDERSON,Colony,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",73,000010
+ANDERSON,Colony,Kansas House of Representatives,5,Republican,"Jones, Kevin",112,000010
+ANDERSON,Garnett Precinct 1,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",306,00002A
+ANDERSON,Garnett Precinct 1,Kansas House of Representatives,5,Republican,"Jones, Kevin",180,00002A
+ANDERSON,Garnett Precinct 1 Exclave,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,00002B
+ANDERSON,Garnett Precinct 2,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",242,000030
+ANDERSON,Garnett Precinct 2,Kansas House of Representatives,5,Republican,"Jones, Kevin",209,000030
+ANDERSON,Garnett Precinct 3,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",228,000040
+ANDERSON,Garnett Precinct 3,Kansas House of Representatives,5,Republican,"Jones, Kevin",118,000040
+ANDERSON,Garnett Precinct 4,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",53,000050
+ANDERSON,Garnett Precinct 4,Kansas House of Representatives,5,Republican,"Jones, Kevin",31,000050
+ANDERSON,Greeley,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",86,000060
+ANDERSON,Greeley,Kansas House of Representatives,5,Republican,"Jones, Kevin",29,000060
+ANDERSON,Indian Creek Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",23,000080
+ANDERSON,Indian Creek Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",43,000080
+ANDERSON,Kincaid,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",14,000100
+ANDERSON,Kincaid,Kansas House of Representatives,4,Republican,"Read, Marty",23,000100
+ANDERSON,Lincoln Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",45,000110
+ANDERSON,Lincoln Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",50,000110
+ANDERSON,Lone Elm City,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",4,000120
+ANDERSON,Lone Elm City,Kansas House of Representatives,4,Republican,"Read, Marty",3,000120
+ANDERSON,Lone Elm Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",26,000130
+ANDERSON,Lone Elm Township,Kansas House of Representatives,4,Republican,"Read, Marty",46,000130
+ANDERSON,Monroe Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",98,00014A
+ANDERSON,Monroe Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",67,00014A
+ANDERSON,North Rich Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",9,000150
+ANDERSON,North Rich Township,Kansas House of Representatives,4,Republican,"Read, Marty",17,000150
+ANDERSON,Ozark Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",27,000160
+ANDERSON,Ozark Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",48,000160
+ANDERSON,Putnam Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",92,000170
+ANDERSON,Putnam Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",70,000170
+ANDERSON,Reeder Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",51,000180
+ANDERSON,Reeder Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",52,000180
+ANDERSON,Rich Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",13,000190
+ANDERSON,Rich Township,Kansas House of Representatives,4,Republican,"Read, Marty",52,000190
+ANDERSON,Walker Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",116,000200
+ANDERSON,Walker Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",63,000200
+ANDERSON,Washington Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",90,000210
+ANDERSON,Washington Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",42,000210
+ANDERSON,Welda Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",86,000220
+ANDERSON,Welda Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",45,000220
+ANDERSON,Westphalia City,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",35,000230
+ANDERSON,Westphalia City,Kansas House of Representatives,5,Republican,"Jones, Kevin",13,000230
+ANDERSON,Westphalia Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",57,000240
+ANDERSON,Westphalia Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",39,000240
+ANDERSON,Jackson Township H5,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",112,200010
+ANDERSON,Jackson Township H5,Kansas House of Representatives,5,Republican,"Jones, Kevin",86,200010
+ANDERSON,Jackson Township H9,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",0,200020
+ANDERSON,Jackson Township H9,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,200020
+ANDERSON,Colony,Kansas Senate,12,Democratic,"Cassells, Denise",58,000010
+ANDERSON,Colony,Kansas Senate,12,Republican,"Tyson, Caryn",118,000010
+ANDERSON,Garnett Precinct 1,Kansas Senate,12,Democratic,"Cassells, Denise",169,00002A
+ANDERSON,Garnett Precinct 1,Kansas Senate,12,Republican,"Tyson, Caryn",308,00002A
+ANDERSON,Garnett Precinct 1 Exclave,Kansas Senate,12,Democratic,"Cassells, Denise",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,Kansas Senate,12,Republican,"Tyson, Caryn",0,00002B
+ANDERSON,Garnett Precinct 2,Kansas Senate,12,Democratic,"Cassells, Denise",150,000030
+ANDERSON,Garnett Precinct 2,Kansas Senate,12,Republican,"Tyson, Caryn",287,000030
+ANDERSON,Garnett Precinct 3,Kansas Senate,12,Democratic,"Cassells, Denise",136,000040
+ANDERSON,Garnett Precinct 3,Kansas Senate,12,Republican,"Tyson, Caryn",196,000040
+ANDERSON,Garnett Precinct 4,Kansas Senate,12,Democratic,"Cassells, Denise",34,000050
+ANDERSON,Garnett Precinct 4,Kansas Senate,12,Republican,"Tyson, Caryn",49,000050
+ANDERSON,Greeley,Kansas Senate,12,Democratic,"Cassells, Denise",45,000060
+ANDERSON,Greeley,Kansas Senate,12,Republican,"Tyson, Caryn",64,000060
+ANDERSON,Indian Creek Township,Kansas Senate,12,Democratic,"Cassells, Denise",12,000080
+ANDERSON,Indian Creek Township,Kansas Senate,12,Republican,"Tyson, Caryn",55,000080
+ANDERSON,Kincaid,Kansas Senate,12,Democratic,"Cassells, Denise",10,000100
+ANDERSON,Kincaid,Kansas Senate,12,Republican,"Tyson, Caryn",23,000100
+ANDERSON,Lincoln Township,Kansas Senate,12,Democratic,"Cassells, Denise",28,000110
+ANDERSON,Lincoln Township,Kansas Senate,12,Republican,"Tyson, Caryn",63,000110
+ANDERSON,Lone Elm City,Kansas Senate,12,Democratic,"Cassells, Denise",4,000120
+ANDERSON,Lone Elm City,Kansas Senate,12,Republican,"Tyson, Caryn",3,000120
+ANDERSON,Lone Elm Township,Kansas Senate,12,Democratic,"Cassells, Denise",23,000130
+ANDERSON,Lone Elm Township,Kansas Senate,12,Republican,"Tyson, Caryn",50,000130
+ANDERSON,Monroe Township,Kansas Senate,12,Democratic,"Cassells, Denise",56,00014A
+ANDERSON,Monroe Township,Kansas Senate,12,Republican,"Tyson, Caryn",101,00014A
+ANDERSON,North Rich Township,Kansas Senate,12,Democratic,"Cassells, Denise",8,000150
+ANDERSON,North Rich Township,Kansas Senate,12,Republican,"Tyson, Caryn",16,000150
+ANDERSON,Ozark Township,Kansas Senate,12,Democratic,"Cassells, Denise",18,000160
+ANDERSON,Ozark Township,Kansas Senate,12,Republican,"Tyson, Caryn",57,000160
+ANDERSON,Putnam Township,Kansas Senate,12,Democratic,"Cassells, Denise",70,000170
+ANDERSON,Putnam Township,Kansas Senate,12,Republican,"Tyson, Caryn",88,000170
+ANDERSON,Reeder Township,Kansas Senate,12,Democratic,"Cassells, Denise",38,000180
+ANDERSON,Reeder Township,Kansas Senate,12,Republican,"Tyson, Caryn",63,000180
+ANDERSON,Rich Township,Kansas Senate,12,Democratic,"Cassells, Denise",18,000190
+ANDERSON,Rich Township,Kansas Senate,12,Republican,"Tyson, Caryn",45,000190
+ANDERSON,Walker Township,Kansas Senate,12,Democratic,"Cassells, Denise",61,000200
+ANDERSON,Walker Township,Kansas Senate,12,Republican,"Tyson, Caryn",113,000200
+ANDERSON,Washington Township,Kansas Senate,12,Democratic,"Cassells, Denise",48,000210
+ANDERSON,Washington Township,Kansas Senate,12,Republican,"Tyson, Caryn",74,000210
+ANDERSON,Welda Township,Kansas Senate,12,Democratic,"Cassells, Denise",47,000220
+ANDERSON,Welda Township,Kansas Senate,12,Republican,"Tyson, Caryn",80,000220
+ANDERSON,Westphalia City,Kansas Senate,12,Democratic,"Cassells, Denise",25,000230
+ANDERSON,Westphalia City,Kansas Senate,12,Republican,"Tyson, Caryn",23,000230
+ANDERSON,Westphalia Township,Kansas Senate,12,Democratic,"Cassells, Denise",27,000240
+ANDERSON,Westphalia Township,Kansas Senate,12,Republican,"Tyson, Caryn",67,000240
+ANDERSON,Jackson Township H5,Kansas Senate,12,Democratic,"Cassells, Denise",65,200010
+ANDERSON,Jackson Township H5,Kansas Senate,12,Republican,"Tyson, Caryn",133,200010
+ANDERSON,Jackson Township H9,Kansas Senate,12,Democratic,"Cassells, Denise",0,200020
+ANDERSON,Jackson Township H9,Kansas Senate,12,Republican,"Tyson, Caryn",0,200020
+ANDERSON,Colony,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Barnett, Andre",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Bush, Kent W",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Christensen, Will",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Goode, Virgil",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Stein, Jill E",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+ANDERSON,Colony,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+ANDERSON,Colony,President / Vice President,,Democratic,"Obama, Barack",53,000010
+ANDERSON,Colony,President / Vice President,,Libertarian,"Johnson, Gary",3,000010
+ANDERSON,Colony,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+ANDERSON,Colony,President / Vice President,,Republican,"Romney, Mitt",127,000010
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,Democratic,"Obama, Barack",144,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",10,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,Republican,"Romney, Mitt",327,00002A
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00002B
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,Democratic,"Obama, Barack",129,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",12,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,Republican,"Romney, Mitt",303,000030
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,Democratic,"Obama, Barack",119,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",7,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,Republican,"Romney, Mitt",218,000040
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Goode, Virgil",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Stein, Jill E",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,Democratic,"Obama, Barack",25,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",2,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,Republican,"Romney, Mitt",53,000050
+ANDERSON,Greeley,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Barnett, Andre",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Bush, Kent W",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Christensen, Will",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Goode, Virgil",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Stein, Jill E",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+ANDERSON,Greeley,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+ANDERSON,Greeley,President / Vice President,,Democratic,"Obama, Barack",43,000060
+ANDERSON,Greeley,President / Vice President,,Libertarian,"Johnson, Gary",5,000060
+ANDERSON,Greeley,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+ANDERSON,Greeley,President / Vice President,,Republican,"Romney, Mitt",61,000060
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,Democratic,"Obama, Barack",11,000080
+ANDERSON,Indian Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,Republican,"Romney, Mitt",56,000080
+ANDERSON,Kincaid,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Barnett, Andre",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Bush, Kent W",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Christensen, Will",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Goode, Virgil",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Stein, Jill E",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+ANDERSON,Kincaid,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+ANDERSON,Kincaid,President / Vice President,,Democratic,"Obama, Barack",20,000100
+ANDERSON,Kincaid,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+ANDERSON,Kincaid,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+ANDERSON,Kincaid,President / Vice President,,Republican,"Romney, Mitt",16,000100
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",24,000110
+ANDERSON,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+ANDERSON,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+ANDERSON,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",70,000110
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Barnett, Andre",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Bush, Kent W",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Christensen, Will",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Goode, Virgil",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Stein, Jill E",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,Democratic,"Obama, Barack",3,000120
+ANDERSON,Lone Elm City,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+ANDERSON,Lone Elm City,President / Vice President,,Republican,"Romney, Mitt",4,000120
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,Democratic,"Obama, Barack",18,000130
+ANDERSON,Lone Elm Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000130
+ANDERSON,Lone Elm Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+ANDERSON,Lone Elm Township,President / Vice President,,Republican,"Romney, Mitt",53,000130
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Ayers, Avery L",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Barnett, Andre",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Bush, Kent W",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Christensen, Will",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Duncan, Richard A",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Goode, Virgil",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Hoefling, Tom",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Knill, Dennis J",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Reed, Jill A.",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Rogers, Rick L",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Stein, Jill E",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,Democratic,"Obama, Barack",36,00014A
+ANDERSON,Monroe Township,President / Vice President,,Libertarian,"Johnson, Gary",4,00014A
+ANDERSON,Monroe Township,President / Vice President,,Reform,"Baldwin, Chuck",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,Republican,"Romney, Mitt",125,00014A
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+ANDERSON,North Rich Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+ANDERSON,North Rich Township,President / Vice President,,Democratic,"Obama, Barack",7,000150
+ANDERSON,North Rich Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+ANDERSON,North Rich Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+ANDERSON,North Rich Township,President / Vice President,,Republican,"Romney, Mitt",20,000150
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+ANDERSON,Ozark Township,President / Vice President,,Democratic,"Obama, Barack",12,000160
+ANDERSON,Ozark Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+ANDERSON,Ozark Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000160
+ANDERSON,Ozark Township,President / Vice President,,Republican,"Romney, Mitt",64,000160
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Stein, Jill E",1,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+ANDERSON,Putnam Township,President / Vice President,,Democratic,"Obama, Barack",53,000170
+ANDERSON,Putnam Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000170
+ANDERSON,Putnam Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+ANDERSON,Putnam Township,President / Vice President,,Republican,"Romney, Mitt",103,000170
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+ANDERSON,Reeder Township,President / Vice President,,Democratic,"Obama, Barack",24,000180
+ANDERSON,Reeder Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000180
+ANDERSON,Reeder Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000180
+ANDERSON,Reeder Township,President / Vice President,,Republican,"Romney, Mitt",73,000180
+ANDERSON,Rich Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+ANDERSON,Rich Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+ANDERSON,Rich Township,President / Vice President,,Democratic,"Obama, Barack",12,000190
+ANDERSON,Rich Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000190
+ANDERSON,Rich Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+ANDERSON,Rich Township,President / Vice President,,Republican,"Romney, Mitt",50,000190
+ANDERSON,Walker Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+ANDERSON,Walker Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+ANDERSON,Walker Township,President / Vice President,,Democratic,"Obama, Barack",51,000200
+ANDERSON,Walker Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000200
+ANDERSON,Walker Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000200
+ANDERSON,Walker Township,President / Vice President,,Republican,"Romney, Mitt",124,000200
+ANDERSON,Washington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+ANDERSON,Washington Township,President / Vice President,,Democratic,"Obama, Barack",47,000210
+ANDERSON,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000210
+ANDERSON,Washington Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+ANDERSON,Washington Township,President / Vice President,,Republican,"Romney, Mitt",83,000210
+ANDERSON,Welda Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+ANDERSON,Welda Township,President / Vice President,,Democratic,"Obama, Barack",37,000220
+ANDERSON,Welda Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000220
+ANDERSON,Welda Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+ANDERSON,Welda Township,President / Vice President,,Republican,"Romney, Mitt",89,000220
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Barnett, Andre",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Bush, Kent W",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Christensen, Will",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Goode, Virgil",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Stein, Jill E",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+ANDERSON,Westphalia City,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+ANDERSON,Westphalia City,President / Vice President,,Democratic,"Obama, Barack",15,000230
+ANDERSON,Westphalia City,President / Vice President,,Libertarian,"Johnson, Gary",3,000230
+ANDERSON,Westphalia City,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+ANDERSON,Westphalia City,President / Vice President,,Republican,"Romney, Mitt",32,000230
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,Democratic,"Obama, Barack",18,000240
+ANDERSON,Westphalia Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000240
+ANDERSON,Westphalia Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000240
+ANDERSON,Westphalia Township,President / Vice President,,Republican,"Romney, Mitt",76,000240
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Ayers, Avery L",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Barnett, Andre",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Barr, Roseanne C",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Bush, Kent W",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Christensen, Will",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Duncan, Richard A",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Goode, Virgil",2,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Hoefling, Tom",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Knill, Dennis J",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Reed, Jill A.",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Rogers, Rick L",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Stein, Jill E",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Thorne, Kevin M",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,write - in,"Warner, Gerald L.",0,200010
+ANDERSON,Jackson Township H5,President / Vice President,,Democratic,"Obama, Barack",43,200010
+ANDERSON,Jackson Township H5,President / Vice President,,Libertarian,"Johnson, Gary",2,200010
+ANDERSON,Jackson Township H5,President / Vice President,,Reform,"Baldwin, Chuck",4,200010
+ANDERSON,Jackson Township H5,President / Vice President,,Republican,"Romney, Mitt",149,200010
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Ayers, Avery L",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Barnett, Andre",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Barr, Roseanne C",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Bush, Kent W",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Christensen, Will",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Duncan, Richard A",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Goode, Virgil",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Hoefling, Tom",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Knill, Dennis J",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Reed, Jill A.",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Rogers, Rick L",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Stein, Jill E",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Thorne, Kevin M",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,write - in,"Warner, Gerald L.",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,Democratic,"Obama, Barack",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,Libertarian,"Johnson, Gary",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,Reform,"Baldwin, Chuck",0,200020
+ANDERSON,Jackson Township H9,President / Vice President,,Republican,"Romney, Mitt",0,200020
+ANDERSON,Colony,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",35,000010
+ANDERSON,Colony,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000010
+ANDERSON,Colony,United States House of Representatives,2,Republican,"Jenkins, Lynn",130,000010
+ANDERSON,Garnett Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",101,00002A
+ANDERSON,Garnett Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",27,00002A
+ANDERSON,Garnett Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",349,00002A
+ANDERSON,Garnett Precinct 1 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002B
+ANDERSON,Garnett Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",98,000030
+ANDERSON,Garnett Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",19,000030
+ANDERSON,Garnett Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",324,000030
+ANDERSON,Garnett Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",89,000040
+ANDERSON,Garnett Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000040
+ANDERSON,Garnett Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",235,000040
+ANDERSON,Garnett Precinct 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",18,000050
+ANDERSON,Garnett Precinct 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000050
+ANDERSON,Garnett Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",58,000050
+ANDERSON,Greeley,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",43,000060
+ANDERSON,Greeley,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000060
+ANDERSON,Greeley,United States House of Representatives,2,Republican,"Jenkins, Lynn",61,000060
+ANDERSON,Indian Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",9,000080
+ANDERSON,Indian Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000080
+ANDERSON,Indian Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,000080
+ANDERSON,Kincaid,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",10,000100
+ANDERSON,Kincaid,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000100
+ANDERSON,Kincaid,United States House of Representatives,2,Republican,"Jenkins, Lynn",21,000100
+ANDERSON,Lincoln Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",15,000110
+ANDERSON,Lincoln Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000110
+ANDERSON,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000110
+ANDERSON,Lone Elm City,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",2,000120
+ANDERSON,Lone Elm City,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000120
+ANDERSON,Lone Elm City,United States House of Representatives,2,Republican,"Jenkins, Lynn",3,000120
+ANDERSON,Lone Elm Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",13,000130
+ANDERSON,Lone Elm Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000130
+ANDERSON,Lone Elm Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",53,000130
+ANDERSON,Monroe Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",31,00014A
+ANDERSON,Monroe Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,00014A
+ANDERSON,Monroe Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",124,00014A
+ANDERSON,North Rich Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",6,000150
+ANDERSON,North Rich Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000150
+ANDERSON,North Rich Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",20,000150
+ANDERSON,Ozark Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",10,000160
+ANDERSON,Ozark Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000160
+ANDERSON,Ozark Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",64,000160
+ANDERSON,Putnam Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",50,000170
+ANDERSON,Putnam Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000170
+ANDERSON,Putnam Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,000170
+ANDERSON,Reeder Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",23,000180
+ANDERSON,Reeder Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000180
+ANDERSON,Reeder Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000180
+ANDERSON,Rich Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",6,000190
+ANDERSON,Rich Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000190
+ANDERSON,Rich Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",54,000190
+ANDERSON,Walker Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",36,000200
+ANDERSON,Walker Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,000200
+ANDERSON,Walker Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",126,000200
+ANDERSON,Washington Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",34,000210
+ANDERSON,Washington Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000210
+ANDERSON,Washington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",92,000210
+ANDERSON,Welda Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",29,000220
+ANDERSON,Welda Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000220
+ANDERSON,Welda Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",92,000220
+ANDERSON,Westphalia City,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",12,000230
+ANDERSON,Westphalia City,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000230
+ANDERSON,Westphalia City,United States House of Representatives,2,Republican,"Jenkins, Lynn",31,000230
+ANDERSON,Westphalia Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",22,000240
+ANDERSON,Westphalia Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000240
+ANDERSON,Westphalia Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",64,000240
+ANDERSON,Jackson Township H5,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",45,200010
+ANDERSON,Jackson Township H5,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,200010
+ANDERSON,Jackson Township H5,United States House of Representatives,2,Republican,"Jenkins, Lynn",147,200010
+ANDERSON,Jackson Township H9,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,200020
+ANDERSON,Jackson Township H9,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,200020
+ANDERSON,Jackson Township H9,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,200020

--- a/2012/20121106__ks__general__atchison__precinct.csv
+++ b/2012/20121106__ks__general__atchison__precinct.csv
@@ -1,0 +1,703 @@
+county,precinct,office,district,party,candidate,votes,vtd
+ATCHISON,Atchison Precinct 1,Kansas House of Representatives,63,Democratic,"Henry, Jerry",169,000010
+ATCHISON,Atchison Precinct 1,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",87,000010
+ATCHISON,Atchison Precinct 2 East,Kansas House of Representatives,63,Democratic,"Henry, Jerry",165,000020
+ATCHISON,Atchison Precinct 2 East,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",106,000020
+ATCHISON,Atchison Precinct 2 West,Kansas House of Representatives,63,Democratic,"Henry, Jerry",201,000030
+ATCHISON,Atchison Precinct 2 West,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",131,000030
+ATCHISON,Atchison Precinct 3 East,Kansas House of Representatives,63,Democratic,"Henry, Jerry",366,000040
+ATCHISON,Atchison Precinct 3 East,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",174,000040
+ATCHISON,Atchison Precinct 3 West,Kansas House of Representatives,63,Democratic,"Henry, Jerry",573,00005A
+ATCHISON,Atchison Precinct 3 West,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",283,00005A
+ATCHISON,Atchison Precinct 4,Kansas House of Representatives,63,Democratic,"Henry, Jerry",344,00006A
+ATCHISON,Atchison Precinct 4,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",132,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",0,00006C
+ATCHISON,Atchison Precinct 5 North,Kansas House of Representatives,63,Democratic,"Henry, Jerry",395,00007A
+ATCHISON,Atchison Precinct 5 North,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",230,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",0,00007C
+ATCHISON,Atchison Precinct 5 South,Kansas House of Representatives,63,Democratic,"Henry, Jerry",227,00008A
+ATCHISON,Atchison Precinct 5 South,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",130,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",0,00008D
+ATCHISON,Center Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",180,000100
+ATCHISON,Center Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",136,000100
+ATCHISON,Grasshopper Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",76,000110
+ATCHISON,Grasshopper Township,Kansas House of Representatives,62,Republican,"Garber, Randy",206,000110
+ATCHISON,Huron Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",60,000120
+ATCHISON,Huron Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",36,000120
+ATCHISON,Kapioma Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",37,000130
+ATCHISON,Kapioma Township,Kansas House of Representatives,62,Republican,"Garber, Randy",88,000130
+ATCHISON,Lancaster Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",195,000140
+ATCHISON,Lancaster Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",105,000140
+ATCHISON,Shannon Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",434,00016A
+ATCHISON,Shannon Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",216,00016A
+ATCHISON,Walnut Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",158,00017A
+ATCHISON,Walnut Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",74,00017A
+ATCHISON,Walnut Township Enclave,Kansas House of Representatives,63,Democratic,"Henry, Jerry",0,00017B
+ATCHISON,Walnut Township Enclave,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",0,00017B
+ATCHISON,Mount Pleasant Voting District Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",312,100050
+ATCHISON,Mount Pleasant Voting District Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",139,100050
+ATCHISON,Benton Township H62,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",152,120020
+ATCHISON,Benton Township H62,Kansas House of Representatives,62,Republican,"Garber, Randy",182,120020
+ATCHISON,Benton Township H63,Kansas House of Representatives,63,Democratic,"Henry, Jerry",66,120030
+ATCHISON,Benton Township H63,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",40,120030
+ATCHISON,Atchison Precinct 1,Kansas Senate,1,Democratic,"Lukert, Steve",107,000010
+ATCHISON,Atchison Precinct 1,Kansas Senate,1,Republican,"Pyle, Dennis D.",145,000010
+ATCHISON,Atchison Precinct 2 East,Kansas Senate,1,Democratic,"Lukert, Steve",133,000020
+ATCHISON,Atchison Precinct 2 East,Kansas Senate,1,Republican,"Pyle, Dennis D.",136,000020
+ATCHISON,Atchison Precinct 2 West,Kansas Senate,1,Democratic,"Lukert, Steve",154,000030
+ATCHISON,Atchison Precinct 2 West,Kansas Senate,1,Republican,"Pyle, Dennis D.",176,000030
+ATCHISON,Atchison Precinct 3 East,Kansas Senate,1,Democratic,"Lukert, Steve",256,000040
+ATCHISON,Atchison Precinct 3 East,Kansas Senate,1,Republican,"Pyle, Dennis D.",271,000040
+ATCHISON,Atchison Precinct 3 West,Kansas Senate,1,Democratic,"Lukert, Steve",439,00005A
+ATCHISON,Atchison Precinct 3 West,Kansas Senate,1,Republican,"Pyle, Dennis D.",413,00005A
+ATCHISON,Atchison Precinct 4,Kansas Senate,1,Democratic,"Lukert, Steve",256,00006A
+ATCHISON,Atchison Precinct 4,Kansas Senate,1,Republican,"Pyle, Dennis D.",202,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,Kansas Senate,1,Democratic,"Lukert, Steve",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,Kansas Senate,1,Democratic,"Lukert, Steve",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00006C
+ATCHISON,Atchison Precinct 5 North,Kansas Senate,1,Democratic,"Lukert, Steve",301,00007A
+ATCHISON,Atchison Precinct 5 North,Kansas Senate,1,Republican,"Pyle, Dennis D.",314,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,Kansas Senate,1,Democratic,"Lukert, Steve",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,Kansas Senate,1,Democratic,"Lukert, Steve",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00007C
+ATCHISON,Atchison Precinct 5 South,Kansas Senate,1,Democratic,"Lukert, Steve",183,00008A
+ATCHISON,Atchison Precinct 5 South,Kansas Senate,1,Republican,"Pyle, Dennis D.",168,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,Kansas Senate,1,Democratic,"Lukert, Steve",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,Kansas Senate,1,Democratic,"Lukert, Steve",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,Kansas Senate,1,Democratic,"Lukert, Steve",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00008D
+ATCHISON,Center Township,Kansas Senate,1,Democratic,"Lukert, Steve",104,000100
+ATCHISON,Center Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",209,000100
+ATCHISON,Grasshopper Township,Kansas Senate,1,Democratic,"Lukert, Steve",125,000110
+ATCHISON,Grasshopper Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",160,000110
+ATCHISON,Huron Township,Kansas Senate,1,Democratic,"Lukert, Steve",48,000120
+ATCHISON,Huron Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",47,000120
+ATCHISON,Kapioma Township,Kansas Senate,1,Democratic,"Lukert, Steve",47,000130
+ATCHISON,Kapioma Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",82,000130
+ATCHISON,Lancaster Township,Kansas Senate,1,Democratic,"Lukert, Steve",145,000140
+ATCHISON,Lancaster Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",155,000140
+ATCHISON,Shannon Township,Kansas Senate,1,Democratic,"Lukert, Steve",282,00016A
+ATCHISON,Shannon Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",356,00016A
+ATCHISON,Walnut Township,Kansas Senate,1,Democratic,"Lukert, Steve",116,00017A
+ATCHISON,Walnut Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",110,00017A
+ATCHISON,Walnut Township Enclave,Kansas Senate,1,Democratic,"Lukert, Steve",0,00017B
+ATCHISON,Walnut Township Enclave,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00017B
+ATCHISON,Mount Pleasant Voting District Township,Kansas Senate,1,Democratic,"Lukert, Steve",177,100050
+ATCHISON,Mount Pleasant Voting District Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",262,100050
+ATCHISON,Benton Township H62,Kansas Senate,1,Democratic,"Lukert, Steve",191,120020
+ATCHISON,Benton Township H62,Kansas Senate,1,Republican,"Pyle, Dennis D.",167,120020
+ATCHISON,Benton Township H63,Kansas Senate,1,Democratic,"Lukert, Steve",55,120030
+ATCHISON,Benton Township H63,Kansas Senate,1,Republican,"Pyle, Dennis D.",51,120030
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,Democratic,"Obama, Barack",113,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,Republican,"Romney, Mitt",136,000010
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Barnett, Andre",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Bush, Kent W",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Christensen, Will",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Goode, Virgil",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Stein, Jill E",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,Democratic,"Obama, Barack",105,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,Libertarian,"Johnson, Gary",6,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,Republican,"Romney, Mitt",163,000020
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Barnett, Andre",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Bush, Kent W",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Christensen, Will",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Goode, Virgil",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Stein, Jill E",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,Democratic,"Obama, Barack",143,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,Libertarian,"Johnson, Gary",11,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,Republican,"Romney, Mitt",177,000030
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",2,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Barnett, Andre",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Bush, Kent W",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Christensen, Will",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Goode, Virgil",1,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Stein, Jill E",2,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,Democratic,"Obama, Barack",243,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,Libertarian,"Johnson, Gary",14,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,Reform,"Baldwin, Chuck",5,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,Republican,"Romney, Mitt",277,000040
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Ayers, Avery L",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Barnett, Andre",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Barr, Roseanne C",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Bush, Kent W",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Christensen, Will",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Duncan, Richard A",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Goode, Virgil",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Hoefling, Tom",1,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Knill, Dennis J",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Reed, Jill A.",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Rogers, Rick L",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Stein, Jill E",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Thorne, Kevin M",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Warner, Gerald L.",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,Democratic,"Obama, Barack",382,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,Libertarian,"Johnson, Gary",13,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,Reform,"Baldwin, Chuck",2,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,Republican,"Romney, Mitt",464,00005A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Goode, Virgil",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Stein, Jill E",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,Democratic,"Obama, Barack",256,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",5,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",1,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,Republican,"Romney, Mitt",217,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Christensen, Will",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,00006C
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Ayers, Avery L",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Barnett, Andre",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Barr, Roseanne C",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Bush, Kent W",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Christensen, Will",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Duncan, Richard A",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Goode, Virgil",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Hoefling, Tom",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Knill, Dennis J",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Reed, Jill A.",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Rogers, Rick L",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Stein, Jill E",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Thorne, Kevin M",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Warner, Gerald L.",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,Democratic,"Obama, Barack",266,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,Libertarian,"Johnson, Gary",12,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,Reform,"Baldwin, Chuck",4,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,Republican,"Romney, Mitt",348,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Christensen, Will",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,00007C
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Ayers, Avery L",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Barnett, Andre",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Barr, Roseanne C",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Bush, Kent W",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Christensen, Will",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Duncan, Richard A",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Goode, Virgil",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Hoefling, Tom",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Knill, Dennis J",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Reed, Jill A.",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Rogers, Rick L",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Stein, Jill E",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Thorne, Kevin M",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Warner, Gerald L.",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,Democratic,"Obama, Barack",158,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,Libertarian,"Johnson, Gary",7,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,Reform,"Baldwin, Chuck",3,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,Republican,"Romney, Mitt",199,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Christensen, Will",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Ayers, Avery L",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Barnett, Andre",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Barr, Roseanne C",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Bush, Kent W",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Christensen, Will",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Duncan, Richard A",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Goode, Virgil",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Knill, Dennis J",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Reed, Jill A.",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Rogers, Rick L",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Stein, Jill E",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Thorne, Kevin M",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Warner, Gerald L.",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,Democratic,"Obama, Barack",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,Reform,"Baldwin, Chuck",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,Republican,"Romney, Mitt",0,00008D
+ATCHISON,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+ATCHISON,Center Township,President / Vice President,,Democratic,"Obama, Barack",82,000100
+ATCHISON,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000100
+ATCHISON,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+ATCHISON,Center Township,President / Vice President,,Republican,"Romney, Mitt",223,000100
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,Democratic,"Obama, Barack",57,000110
+ATCHISON,Grasshopper Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000110
+ATCHISON,Grasshopper Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+ATCHISON,Grasshopper Township,President / Vice President,,Republican,"Romney, Mitt",221,000110
+ATCHISON,Huron Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+ATCHISON,Huron Township,President / Vice President,,Democratic,"Obama, Barack",37,000120
+ATCHISON,Huron Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000120
+ATCHISON,Huron Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+ATCHISON,Huron Township,President / Vice President,,Republican,"Romney, Mitt",60,000120
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,Democratic,"Obama, Barack",32,000130
+ATCHISON,Kapioma Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+ATCHISON,Kapioma Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000130
+ATCHISON,Kapioma Township,President / Vice President,,Republican,"Romney, Mitt",95,000130
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,Democratic,"Obama, Barack",105,000140
+ATCHISON,Lancaster Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000140
+ATCHISON,Lancaster Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000140
+ATCHISON,Lancaster Township,President / Vice President,,Republican,"Romney, Mitt",172,000140
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Ayers, Avery L",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Barnett, Andre",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Bush, Kent W",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Christensen, Will",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Duncan, Richard A",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Goode, Virgil",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Knill, Dennis J",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Reed, Jill A.",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Rogers, Rick L",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Stein, Jill E",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,Democratic,"Obama, Barack",214,00016A
+ATCHISON,Shannon Township,President / Vice President,,Libertarian,"Johnson, Gary",18,00016A
+ATCHISON,Shannon Township,President / Vice President,,Reform,"Baldwin, Chuck",3,00016A
+ATCHISON,Shannon Township,President / Vice President,,Republican,"Romney, Mitt",419,00016A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Ayers, Avery L",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Barnett, Andre",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Bush, Kent W",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Christensen, Will",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Duncan, Richard A",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Goode, Virgil",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Knill, Dennis J",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Reed, Jill A.",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Rogers, Rick L",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Stein, Jill E",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,Democratic,"Obama, Barack",100,00017A
+ATCHISON,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",5,00017A
+ATCHISON,Walnut Township,President / Vice President,,Reform,"Baldwin, Chuck",2,00017A
+ATCHISON,Walnut Township,President / Vice President,,Republican,"Romney, Mitt",126,00017A
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Christensen, Will",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00017B
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Ayers, Avery L",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Barnett, Andre",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Barr, Roseanne C",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Bush, Kent W",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Christensen, Will",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Duncan, Richard A",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Goode, Virgil",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Hoefling, Tom",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Knill, Dennis J",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Reed, Jill A.",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Rogers, Rick L",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Stein, Jill E",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Thorne, Kevin M",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,write - in,"Warner, Gerald L.",0,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,Democratic,"Obama, Barack",121,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,Libertarian,"Johnson, Gary",10,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,Reform,"Baldwin, Chuck",2,100050
+ATCHISON,Mount Pleasant Voting District Township,President / Vice President,,Republican,"Romney, Mitt",317,100050
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Barnett, Andre",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Bush, Kent W",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Christensen, Will",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Goode, Virgil",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Stein, Jill E",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,Democratic,"Obama, Barack",120,120020
+ATCHISON,Benton Township H62,President / Vice President,,Libertarian,"Johnson, Gary",6,120020
+ATCHISON,Benton Township H62,President / Vice President,,Reform,"Baldwin, Chuck",3,120020
+ATCHISON,Benton Township H62,President / Vice President,,Republican,"Romney, Mitt",232,120020
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Barnett, Andre",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Bush, Kent W",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Christensen, Will",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Goode, Virgil",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Stein, Jill E",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,Democratic,"Obama, Barack",33,120030
+ATCHISON,Benton Township H63,President / Vice President,,Libertarian,"Johnson, Gary",3,120030
+ATCHISON,Benton Township H63,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,Republican,"Romney, Mitt",71,120030
+ATCHISON,Atchison Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",76,000010
+ATCHISON,Atchison Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000010
+ATCHISON,Atchison Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",166,000010
+ATCHISON,Atchison Precinct 2 East,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",89,000020
+ATCHISON,Atchison Precinct 2 East,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000020
+ATCHISON,Atchison Precinct 2 East,United States House of Representatives,2,Republican,"Jenkins, Lynn",175,000020
+ATCHISON,Atchison Precinct 2 West,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",110,000030
+ATCHISON,Atchison Precinct 2 West,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000030
+ATCHISON,Atchison Precinct 2 West,United States House of Representatives,2,Republican,"Jenkins, Lynn",198,000030
+ATCHISON,Atchison Precinct 3 East,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",194,000040
+ATCHISON,Atchison Precinct 3 East,United States House of Representatives,2,Libertarian,"Hawver, Dennis",27,000040
+ATCHISON,Atchison Precinct 3 East,United States House of Representatives,2,Republican,"Jenkins, Lynn",304,000040
+ATCHISON,Atchison Precinct 3 West,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",283,00005A
+ATCHISON,Atchison Precinct 3 West,United States House of Representatives,2,Libertarian,"Hawver, Dennis",37,00005A
+ATCHISON,Atchison Precinct 3 West,United States House of Representatives,2,Republican,"Jenkins, Lynn",522,00005A
+ATCHISON,Atchison Precinct 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",188,00006A
+ATCHISON,Atchison Precinct 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,00006A
+ATCHISON,Atchison Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",257,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00006C
+ATCHISON,Atchison Precinct 5 North,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",213,00007A
+ATCHISON,Atchison Precinct 5 North,United States House of Representatives,2,Libertarian,"Hawver, Dennis",24,00007A
+ATCHISON,Atchison Precinct 5 North,United States House of Representatives,2,Republican,"Jenkins, Lynn",378,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00007C
+ATCHISON,Atchison Precinct 5 South,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",107,00008A
+ATCHISON,Atchison Precinct 5 South,United States House of Representatives,2,Libertarian,"Hawver, Dennis",22,00008A
+ATCHISON,Atchison Precinct 5 South,United States House of Representatives,2,Republican,"Jenkins, Lynn",227,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00008D
+ATCHISON,Center Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",71,000100
+ATCHISON,Center Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000100
+ATCHISON,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",230,000100
+ATCHISON,Grasshopper Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",52,000110
+ATCHISON,Grasshopper Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,000110
+ATCHISON,Grasshopper Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",214,000110
+ATCHISON,Huron Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",28,000120
+ATCHISON,Huron Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000120
+ATCHISON,Huron Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",64,000120
+ATCHISON,Kapioma Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",35,000130
+ATCHISON,Kapioma Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000130
+ATCHISON,Kapioma Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",86,000130
+ATCHISON,Lancaster Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",69,000140
+ATCHISON,Lancaster Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",17,000140
+ATCHISON,Lancaster Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",210,000140
+ATCHISON,Shannon Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",164,00016A
+ATCHISON,Shannon Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",40,00016A
+ATCHISON,Shannon Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",437,00016A
+ATCHISON,Walnut Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",83,00017A
+ATCHISON,Walnut Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,00017A
+ATCHISON,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",132,00017A
+ATCHISON,Walnut Township Enclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00017B
+ATCHISON,Walnut Township Enclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00017B
+ATCHISON,Walnut Township Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00017B
+ATCHISON,Mount Pleasant Voting District Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",107,100050
+ATCHISON,Mount Pleasant Voting District Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",22,100050
+ATCHISON,Mount Pleasant Voting District Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",314,100050
+ATCHISON,Benton Township H62,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",96,120020
+ATCHISON,Benton Township H62,United States House of Representatives,2,Libertarian,"Hawver, Dennis",20,120020
+ATCHISON,Benton Township H62,United States House of Representatives,2,Republican,"Jenkins, Lynn",237,120020
+ATCHISON,Benton Township H63,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",24,120030
+ATCHISON,Benton Township H63,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,120030
+ATCHISON,Benton Township H63,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,120030

--- a/2012/20121106__ks__general__barber__precinct.csv
+++ b/2012/20121106__ks__general__barber__precinct.csv
@@ -1,0 +1,625 @@
+county,precinct,office,district,party,candidate,votes,vtd
+BARBER,Aetna Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",1,000010
+BARBER,Aetna Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",4,000010
+BARBER,Deerhead Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",0,000020
+BARBER,Deerhead Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",10,000020
+BARBER,Eagle Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",0,000030
+BARBER,Eagle Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",19,000030
+BARBER,Elm Mills Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",16,000040
+BARBER,Elm Mills Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",63,000040
+BARBER,Elwood Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",28,000050
+BARBER,Elwood Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",72,000050
+BARBER,Hazelton Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",33,000060
+BARBER,Hazelton Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",53,000060
+BARBER,Kiowa East Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",90,000070
+BARBER,Kiowa East Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",261,000070
+BARBER,Kiowa West Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",72,000080
+BARBER,Kiowa West Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",147,000080
+BARBER,Lake City Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",5,000090
+BARBER,Lake City Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",27,000090
+BARBER,McAdoo Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",1,000100
+BARBER,McAdoo Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",13,000100
+BARBER,Medicine Lodge Precinct 1,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",94,000110
+BARBER,Medicine Lodge Precinct 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",253,000110
+BARBER,Medicine Lodge Precinct 2,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",70,00012A
+BARBER,Medicine Lodge Precinct 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",207,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,00012B
+BARBER,Medicine Lodge Precinct 3,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",40,000130
+BARBER,Medicine Lodge Precinct 3,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",165,000130
+BARBER,Medicine Lodge Precinct 4,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",30,000140
+BARBER,Medicine Lodge Precinct 4,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",111,000140
+BARBER,Medicine Lodge Precinct 5,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",3,000150
+BARBER,Medicine Lodge Precinct 5,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",29,000150
+BARBER,Mingona Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",8,000160
+BARBER,Mingona Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",39,000160
+BARBER,Moore Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",6,000170
+BARBER,Moore Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",12,000170
+BARBER,Nippawalla Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",3,000180
+BARBER,Nippawalla Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",11,000180
+BARBER,Ridge Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",0,000190
+BARBER,Ridge Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,000190
+BARBER,Sharon Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",38,000200
+BARBER,Sharon Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",145,000200
+BARBER,Sun City Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",3,000210
+BARBER,Sun City Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",22,000210
+BARBER,Turkey Creek Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",1,000220
+BARBER,Turkey Creek Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",6,000220
+BARBER,Valley Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",9,000230
+BARBER,Valley Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",57,000230
+BARBER,Aetna Township,Kansas Senate,32,Republican,"Abrams, Steve E",5,000010
+BARBER,Deerhead Township,Kansas Senate,32,Republican,"Abrams, Steve E",9,000020
+BARBER,Eagle Township,Kansas Senate,32,Republican,"Abrams, Steve E",16,000030
+BARBER,Elm Mills Township,Kansas Senate,32,Republican,"Abrams, Steve E",60,000040
+BARBER,Elwood Township,Kansas Senate,32,Republican,"Abrams, Steve E",87,000050
+BARBER,Hazelton Township,Kansas Senate,32,Republican,"Abrams, Steve E",72,000060
+BARBER,Kiowa East Township,Kansas Senate,32,Republican,"Abrams, Steve E",296,000070
+BARBER,Kiowa West Township,Kansas Senate,32,Republican,"Abrams, Steve E",177,000080
+BARBER,Lake City Township,Kansas Senate,32,Republican,"Abrams, Steve E",24,000090
+BARBER,McAdoo Township,Kansas Senate,32,Republican,"Abrams, Steve E",12,000100
+BARBER,Medicine Lodge Precinct 1,Kansas Senate,32,Republican,"Abrams, Steve E",292,000110
+BARBER,Medicine Lodge Precinct 2,Kansas Senate,32,Republican,"Abrams, Steve E",234,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,Kansas Senate,32,Republican,"Abrams, Steve E",0,00012B
+BARBER,Medicine Lodge Precinct 3,Kansas Senate,32,Republican,"Abrams, Steve E",171,000130
+BARBER,Medicine Lodge Precinct 4,Kansas Senate,32,Republican,"Abrams, Steve E",116,000140
+BARBER,Medicine Lodge Precinct 5,Kansas Senate,32,Republican,"Abrams, Steve E",30,000150
+BARBER,Mingona Township,Kansas Senate,32,Republican,"Abrams, Steve E",38,000160
+BARBER,Moore Township,Kansas Senate,32,Republican,"Abrams, Steve E",16,000170
+BARBER,Nippawalla Township,Kansas Senate,32,Republican,"Abrams, Steve E",13,000180
+BARBER,Ridge Township,Kansas Senate,32,Republican,"Abrams, Steve E",0,000190
+BARBER,Sharon Township,Kansas Senate,32,Republican,"Abrams, Steve E",166,000200
+BARBER,Sun City Township,Kansas Senate,32,Republican,"Abrams, Steve E",23,000210
+BARBER,Turkey Creek Township,Kansas Senate,32,Republican,"Abrams, Steve E",7,000220
+BARBER,Valley Township,Kansas Senate,32,Republican,"Abrams, Steve E",50,000230
+BARBER,Aetna Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+BARBER,Aetna Township,President / Vice President,,Democratic,"Obama, Barack",0,000010
+BARBER,Aetna Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+BARBER,Aetna Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+BARBER,Aetna Township,President / Vice President,,Republican,"Romney, Mitt",5,000010
+BARBER,Deerhead Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+BARBER,Deerhead Township,President / Vice President,,Democratic,"Obama, Barack",0,000020
+BARBER,Deerhead Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+BARBER,Deerhead Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+BARBER,Deerhead Township,President / Vice President,,Republican,"Romney, Mitt",9,000020
+BARBER,Eagle Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+BARBER,Eagle Township,President / Vice President,,Democratic,"Obama, Barack",0,000030
+BARBER,Eagle Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+BARBER,Eagle Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+BARBER,Eagle Township,President / Vice President,,Republican,"Romney, Mitt",19,000030
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Stein, Jill E",1,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+BARBER,Elm Mills Township,President / Vice President,,Democratic,"Obama, Barack",10,000040
+BARBER,Elm Mills Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+BARBER,Elm Mills Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+BARBER,Elm Mills Township,President / Vice President,,Republican,"Romney, Mitt",62,000040
+BARBER,Elwood Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+BARBER,Elwood Township,President / Vice President,,Democratic,"Obama, Barack",23,000050
+BARBER,Elwood Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+BARBER,Elwood Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+BARBER,Elwood Township,President / Vice President,,Republican,"Romney, Mitt",78,000050
+BARBER,Hazelton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+BARBER,Hazelton Township,President / Vice President,,Democratic,"Obama, Barack",27,000060
+BARBER,Hazelton Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+BARBER,Hazelton Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000060
+BARBER,Hazelton Township,President / Vice President,,Republican,"Romney, Mitt",56,000060
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Stein, Jill E",1,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+BARBER,Kiowa East Township,President / Vice President,,Democratic,"Obama, Barack",63,000070
+BARBER,Kiowa East Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000070
+BARBER,Kiowa East Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000070
+BARBER,Kiowa East Township,President / Vice President,,Republican,"Romney, Mitt",283,000070
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+BARBER,Kiowa West Township,President / Vice President,,Democratic,"Obama, Barack",53,000080
+BARBER,Kiowa West Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000080
+BARBER,Kiowa West Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+BARBER,Kiowa West Township,President / Vice President,,Republican,"Romney, Mitt",162,000080
+BARBER,Lake City Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+BARBER,Lake City Township,President / Vice President,,Democratic,"Obama, Barack",10,000090
+BARBER,Lake City Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+BARBER,Lake City Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+BARBER,Lake City Township,President / Vice President,,Republican,"Romney, Mitt",21,000090
+BARBER,McAdoo Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+BARBER,McAdoo Township,President / Vice President,,Democratic,"Obama, Barack",3,000100
+BARBER,McAdoo Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+BARBER,McAdoo Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+BARBER,McAdoo Township,President / Vice President,,Republican,"Romney, Mitt",11,000100
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,Democratic,"Obama, Barack",97,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",3,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,Republican,"Romney, Mitt",246,000110
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,Democratic,"Obama, Barack",61,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",9,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,Republican,"Romney, Mitt",213,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00012B
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,Democratic,"Obama, Barack",49,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",2,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,Republican,"Romney, Mitt",155,000130
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Goode, Virgil",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Stein, Jill E",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,Democratic,"Obama, Barack",24,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",3,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",3,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,Republican,"Romney, Mitt",115,000140
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Barnett, Andre",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Bush, Kent W",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Christensen, Will",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Goode, Virgil",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Stein, Jill E",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,Democratic,"Obama, Barack",5,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",1,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,Republican,"Romney, Mitt",26,000150
+BARBER,Mingona Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+BARBER,Mingona Township,President / Vice President,,Democratic,"Obama, Barack",7,000160
+BARBER,Mingona Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000160
+BARBER,Mingona Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+BARBER,Mingona Township,President / Vice President,,Republican,"Romney, Mitt",39,000160
+BARBER,Moore Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+BARBER,Moore Township,President / Vice President,,Democratic,"Obama, Barack",5,000170
+BARBER,Moore Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+BARBER,Moore Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+BARBER,Moore Township,President / Vice President,,Republican,"Romney, Mitt",14,000170
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+BARBER,Nippawalla Township,President / Vice President,,Democratic,"Obama, Barack",2,000180
+BARBER,Nippawalla Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+BARBER,Nippawalla Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000180
+BARBER,Nippawalla Township,President / Vice President,,Republican,"Romney, Mitt",14,000180
+BARBER,Ridge Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+BARBER,Ridge Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+BARBER,Ridge Township,President / Vice President,,Democratic,"Obama, Barack",0,000190
+BARBER,Ridge Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+BARBER,Ridge Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+BARBER,Ridge Township,President / Vice President,,Republican,"Romney, Mitt",0,000190
+BARBER,Sharon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+BARBER,Sharon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+BARBER,Sharon Township,President / Vice President,,Democratic,"Obama, Barack",30,000200
+BARBER,Sharon Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000200
+BARBER,Sharon Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000200
+BARBER,Sharon Township,President / Vice President,,Republican,"Romney, Mitt",154,000200
+BARBER,Sun City Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+BARBER,Sun City Township,President / Vice President,,Democratic,"Obama, Barack",2,000210
+BARBER,Sun City Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+BARBER,Sun City Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+BARBER,Sun City Township,President / Vice President,,Republican,"Romney, Mitt",23,000210
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,Democratic,"Obama, Barack",1,000220
+BARBER,Turkey Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,Republican,"Romney, Mitt",8,000220
+BARBER,Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+BARBER,Valley Township,President / Vice President,,Democratic,"Obama, Barack",10,000230
+BARBER,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+BARBER,Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000230
+BARBER,Valley Township,President / Vice President,,Republican,"Romney, Mitt",59,000230
+BARBER,Aetna Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000010
+BARBER,Aetna Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000010
+BARBER,Aetna Township,United States House of Representatives,4,Republican,"Pompeo, Mike",3,000010
+BARBER,Deerhead Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",1,000020
+BARBER,Deerhead Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000020
+BARBER,Deerhead Township,United States House of Representatives,4,Republican,"Pompeo, Mike",7,000020
+BARBER,Eagle Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",1,000030
+BARBER,Eagle Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000030
+BARBER,Eagle Township,United States House of Representatives,4,Republican,"Pompeo, Mike",15,000030
+BARBER,Elm Mills Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",10,000040
+BARBER,Elm Mills Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000040
+BARBER,Elm Mills Township,United States House of Representatives,4,Republican,"Pompeo, Mike",61,000040
+BARBER,Elwood Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",24,000050
+BARBER,Elwood Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",9,000050
+BARBER,Elwood Township,United States House of Representatives,4,Republican,"Pompeo, Mike",64,000050
+BARBER,Hazelton Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",21,000060
+BARBER,Hazelton Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",13,000060
+BARBER,Hazelton Township,United States House of Representatives,4,Republican,"Pompeo, Mike",49,000060
+BARBER,Kiowa East Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",51,000070
+BARBER,Kiowa East Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",17,000070
+BARBER,Kiowa East Township,United States House of Representatives,4,Republican,"Pompeo, Mike",277,000070
+BARBER,Kiowa West Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",49,000080
+BARBER,Kiowa West Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",17,000080
+BARBER,Kiowa West Township,United States House of Representatives,4,Republican,"Pompeo, Mike",151,000080
+BARBER,Lake City Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",8,000090
+BARBER,Lake City Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000090
+BARBER,Lake City Township,United States House of Representatives,4,Republican,"Pompeo, Mike",20,000090
+BARBER,McAdoo Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000100
+BARBER,McAdoo Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000100
+BARBER,McAdoo Township,United States House of Representatives,4,Republican,"Pompeo, Mike",11,000100
+BARBER,Medicine Lodge Precinct 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",82,000110
+BARBER,Medicine Lodge Precinct 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",23,000110
+BARBER,Medicine Lodge Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",239,000110
+BARBER,Medicine Lodge Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",42,00012A
+BARBER,Medicine Lodge Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",16,00012A
+BARBER,Medicine Lodge Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",205,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00012B
+BARBER,Medicine Lodge Precinct 3,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",30,000130
+BARBER,Medicine Lodge Precinct 3,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000130
+BARBER,Medicine Lodge Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Mike",165,000130
+BARBER,Medicine Lodge Precinct 4,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",16,000140
+BARBER,Medicine Lodge Precinct 4,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",7,000140
+BARBER,Medicine Lodge Precinct 4,United States House of Representatives,4,Republican,"Pompeo, Mike",115,000140
+BARBER,Medicine Lodge Precinct 5,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000150
+BARBER,Medicine Lodge Precinct 5,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000150
+BARBER,Medicine Lodge Precinct 5,United States House of Representatives,4,Republican,"Pompeo, Mike",29,000150
+BARBER,Mingona Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",6,000160
+BARBER,Mingona Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000160
+BARBER,Mingona Township,United States House of Representatives,4,Republican,"Pompeo, Mike",37,000160
+BARBER,Moore Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",5,000170
+BARBER,Moore Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000170
+BARBER,Moore Township,United States House of Representatives,4,Republican,"Pompeo, Mike",12,000170
+BARBER,Nippawalla Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",1,000180
+BARBER,Nippawalla Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000180
+BARBER,Nippawalla Township,United States House of Representatives,4,Republican,"Pompeo, Mike",11,000180
+BARBER,Ridge Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,000190
+BARBER,Ridge Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000190
+BARBER,Ridge Township,United States House of Representatives,4,Republican,"Pompeo, Mike",0,000190
+BARBER,Sharon Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",24,000200
+BARBER,Sharon Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000200
+BARBER,Sharon Township,United States House of Representatives,4,Republican,"Pompeo, Mike",152,000200
+BARBER,Sun City Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000210
+BARBER,Sun City Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000210
+BARBER,Sun City Township,United States House of Representatives,4,Republican,"Pompeo, Mike",21,000210
+BARBER,Turkey Creek Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",1,000220
+BARBER,Turkey Creek Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000220
+BARBER,Turkey Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",6,000220
+BARBER,Valley Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",9,000230
+BARBER,Valley Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000230
+BARBER,Valley Township,United States House of Representatives,4,Republican,"Pompeo, Mike",52,000230

--- a/2012/20121106__ks__general__barton__precinct.csv
+++ b/2012/20121106__ks__general__barton__precinct.csv
@@ -1,0 +1,986 @@
+county,precinct,office,district,party,candidate,votes,vtd
+BARTON,Albion Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",2,000010
+BARTON,Albion Township,Kansas House of Representatives,112,Republican,"Edmonds, John",30,000010
+BARTON,Beaver Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",43,000020
+BARTON,Buffalo Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",60,000030
+BARTON,Buffalo Township,Kansas House of Representatives,112,Republican,"Edmonds, John",145,000030
+BARTON,Cheyenne Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",94,000040
+BARTON,Clarence Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",52,000050
+BARTON,Cleveland Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",16,000060
+BARTON,Comanche Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",156,000070
+BARTON,Eureka Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",13,000080
+BARTON,Eureka Township,Kansas House of Representatives,112,Republican,"Edmonds, John",38,000080
+BARTON,Fairview Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",47,000090
+BARTON,Grant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",24,000100
+BARTON,Great Bend City Ward 1 Precinct 1,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",116,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,Kansas House of Representatives,112,Republican,"Edmonds, John",200,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",127,000120
+BARTON,Great Bend City Ward 1 Precinct 2,Kansas House of Representatives,112,Republican,"Edmonds, John",343,000120
+BARTON,Great Bend City Ward 1 Precinct 3,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",93,000130
+BARTON,Great Bend City Ward 1 Precinct 3,Kansas House of Representatives,112,Republican,"Edmonds, John",288,000130
+BARTON,Great Bend City Ward 2 Precinct 1,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",192,000140
+BARTON,Great Bend City Ward 2 Precinct 1,Kansas House of Representatives,112,Republican,"Edmonds, John",426,000140
+BARTON,Great Bend City Ward 2 Precinct 2,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",160,000150
+BARTON,Great Bend City Ward 2 Precinct 2,Kansas House of Representatives,112,Republican,"Edmonds, John",451,000150
+BARTON,Great Bend City Ward 2 Precinct 3,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",169,000160
+BARTON,Great Bend City Ward 2 Precinct 3,Kansas House of Representatives,112,Republican,"Edmonds, John",513,000160
+BARTON,Great Bend City Ward 3 Precinct 1,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",98,000170
+BARTON,Great Bend City Ward 3 Precinct 1,Kansas House of Representatives,112,Republican,"Edmonds, John",303,000170
+BARTON,Great Bend City Ward 3 Precinct 2,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",118,000180
+BARTON,Great Bend City Ward 3 Precinct 2,Kansas House of Representatives,112,Republican,"Edmonds, John",360,000180
+BARTON,Great Bend City Ward 3 Precinct 3,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",133,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,Kansas House of Representatives,112,Republican,"Edmonds, John",375,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",97,000200
+BARTON,Great Bend City Ward 4 Precinct 1,Kansas House of Representatives,112,Republican,"Edmonds, John",178,000200
+BARTON,Great Bend City Ward 4 Precinct 2,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",79,000210
+BARTON,Great Bend City Ward 4 Precinct 2,Kansas House of Representatives,112,Republican,"Edmonds, John",147,000210
+BARTON,Great Bend City Ward 4 Precinct 3,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",34,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,Kansas House of Representatives,112,Republican,"Edmonds, John",52,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00022F
+BARTON,Great Bend Township Part A,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",142,00023A
+BARTON,Great Bend Township Part A,Kansas House of Representatives,112,Republican,"Edmonds, John",415,00023A
+BARTON,Great Bend Township Part B,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",23,00023B
+BARTON,Great Bend Township Part B,Kansas House of Representatives,112,Republican,"Edmonds, John",87,00023B
+BARTON,Great Bend Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00023C
+BARTON,Great Bend Township,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00023C
+BARTON,Hoisington Ward 1,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",61,000240
+BARTON,Hoisington Ward 1,Kansas House of Representatives,112,Republican,"Edmonds, John",176,000240
+BARTON,Hoisington Ward 2,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",63,000250
+BARTON,Hoisington Ward 2,Kansas House of Representatives,112,Republican,"Edmonds, John",192,000250
+BARTON,Hoisington Ward 3,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",60,000260
+BARTON,Hoisington Ward 3,Kansas House of Representatives,112,Republican,"Edmonds, John",215,000260
+BARTON,Hoisington Ward 4,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",64,00027A
+BARTON,Hoisington Ward 4,Kansas House of Representatives,112,Republican,"Edmonds, John",181,00027A
+BARTON,Hoisington Ward 4 Exclave,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,00027B
+BARTON,Hoisington Ward 4 Exclave,Kansas House of Representatives,112,Republican,"Edmonds, John",0,00027B
+BARTON,Independent Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",307,000280
+BARTON,Lakin Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",804,000290
+BARTON,Liberty Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",26,000300
+BARTON,Liberty Township,Kansas House of Representatives,112,Republican,"Edmonds, John",83,000300
+BARTON,Logan Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",61,000310
+BARTON,North Homestead Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",17,000320
+BARTON,North Homestead Township,Kansas House of Representatives,112,Republican,"Edmonds, John",45,000320
+BARTON,Pawnee Rock Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",130,000330
+BARTON,South Bend Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",76,000340
+BARTON,South Bend Township,Kansas House of Representatives,112,Republican,"Edmonds, John",204,000340
+BARTON,South Homestead Township,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",33,000350
+BARTON,South Homestead Township,Kansas House of Representatives,112,Republican,"Edmonds, John",132,000350
+BARTON,Union Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",52,000360
+BARTON,Walnut Township Albert,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",93,000370
+BARTON,Walnut Township Olmitz,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",60,000380
+BARTON,Wheatland Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",28,000390
+BARTON,Hoisington Landfill,Kansas House of Representatives,112,Democratic,"Muehleisen, Steve",0,900010
+BARTON,Hoisington Landfill,Kansas House of Representatives,112,Republican,"Edmonds, John",0,900010
+BARTON,Albion Township,Kansas Senate,33,Republican,"Holmes, Mitch",32,000010
+BARTON,Beaver Township,Kansas Senate,33,Republican,"Holmes, Mitch",40,000020
+BARTON,Buffalo Township,Kansas Senate,33,Republican,"Holmes, Mitch",188,000030
+BARTON,Cheyenne Township,Kansas Senate,33,Republican,"Holmes, Mitch",96,000040
+BARTON,Clarence Township,Kansas Senate,33,Republican,"Holmes, Mitch",52,000050
+BARTON,Cleveland Township,Kansas Senate,33,Republican,"Holmes, Mitch",17,000060
+BARTON,Comanche Township,Kansas Senate,33,Republican,"Holmes, Mitch",166,000070
+BARTON,Eureka Township,Kansas Senate,33,Republican,"Holmes, Mitch",45,000080
+BARTON,Fairview Township,Kansas Senate,33,Republican,"Holmes, Mitch",47,000090
+BARTON,Grant Township,Kansas Senate,33,Republican,"Holmes, Mitch",25,000100
+BARTON,Great Bend City Ward 1 Precinct 1,Kansas Senate,33,Republican,"Holmes, Mitch",272,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Kansas Senate,33,Republican,"Holmes, Mitch",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,Kansas Senate,33,Republican,"Holmes, Mitch",418,000120
+BARTON,Great Bend City Ward 1 Precinct 3,Kansas Senate,33,Republican,"Holmes, Mitch",339,000130
+BARTON,Great Bend City Ward 2 Precinct 1,Kansas Senate,33,Republican,"Holmes, Mitch",535,000140
+BARTON,Great Bend City Ward 2 Precinct 2,Kansas Senate,33,Republican,"Holmes, Mitch",544,000150
+BARTON,Great Bend City Ward 2 Precinct 3,Kansas Senate,33,Republican,"Holmes, Mitch",600,000160
+BARTON,Great Bend City Ward 3 Precinct 1,Kansas Senate,33,Republican,"Holmes, Mitch",348,000170
+BARTON,Great Bend City Ward 3 Precinct 2,Kansas Senate,33,Republican,"Holmes, Mitch",418,000180
+BARTON,Great Bend City Ward 3 Precinct 3,Kansas Senate,33,Republican,"Holmes, Mitch",451,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Kansas Senate,33,Republican,"Holmes, Mitch",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,Kansas Senate,33,Republican,"Holmes, Mitch",234,000200
+BARTON,Great Bend City Ward 4 Precinct 2,Kansas Senate,33,Republican,"Holmes, Mitch",187,000210
+BARTON,Great Bend City Ward 4 Precinct 3,Kansas Senate,33,Republican,"Holmes, Mitch",67,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Kansas Senate,33,Republican,"Holmes, Mitch",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Kansas Senate,33,Republican,"Holmes, Mitch",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Kansas Senate,33,Republican,"Holmes, Mitch",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Kansas Senate,33,Republican,"Holmes, Mitch",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Kansas Senate,33,Republican,"Holmes, Mitch",0,00022F
+BARTON,Great Bend Township Part A,Kansas Senate,33,Republican,"Holmes, Mitch",512,00023A
+BARTON,Great Bend Township Part B,Kansas Senate,33,Republican,"Holmes, Mitch",98,00023B
+BARTON,Great Bend Township,Kansas Senate,33,Republican,"Holmes, Mitch",0,00023C
+BARTON,Hoisington Ward 1,Kansas Senate,33,Republican,"Holmes, Mitch",193,000240
+BARTON,Hoisington Ward 2,Kansas Senate,33,Republican,"Holmes, Mitch",216,000250
+BARTON,Hoisington Ward 3,Kansas Senate,33,Republican,"Holmes, Mitch",257,000260
+BARTON,Hoisington Ward 4,Kansas Senate,33,Republican,"Holmes, Mitch",217,00027A
+BARTON,Hoisington Ward 4 Exclave,Kansas Senate,33,Republican,"Holmes, Mitch",0,00027B
+BARTON,Independent Township,Kansas Senate,33,Republican,"Holmes, Mitch",317,000280
+BARTON,Lakin Township,Kansas Senate,33,Republican,"Holmes, Mitch",843,000290
+BARTON,Liberty Township,Kansas Senate,33,Republican,"Holmes, Mitch",105,000300
+BARTON,Logan Township,Kansas Senate,33,Republican,"Holmes, Mitch",68,000310
+BARTON,North Homestead Township,Kansas Senate,33,Republican,"Holmes, Mitch",55,000320
+BARTON,Pawnee Rock Township,Kansas Senate,33,Republican,"Holmes, Mitch",132,000330
+BARTON,South Bend Township,Kansas Senate,33,Republican,"Holmes, Mitch",262,000340
+BARTON,South Homestead Township,Kansas Senate,33,Republican,"Holmes, Mitch",161,000350
+BARTON,Union Township,Kansas Senate,33,Republican,"Holmes, Mitch",51,000360
+BARTON,Walnut Township Albert,Kansas Senate,33,Republican,"Holmes, Mitch",98,000370
+BARTON,Walnut Township Olmitz,Kansas Senate,33,Republican,"Holmes, Mitch",64,000380
+BARTON,Wheatland Township,Kansas Senate,33,Republican,"Holmes, Mitch",28,000390
+BARTON,Hoisington Landfill,Kansas Senate,33,Republican,"Holmes, Mitch",0,900010
+BARTON,Albion Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Stein, Jill E",1,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+BARTON,Albion Township,President / Vice President,,Democratic,"Obama, Barack",2,000010
+BARTON,Albion Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+BARTON,Albion Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+BARTON,Albion Township,President / Vice President,,Republican,"Romney, Mitt",31,000010
+BARTON,Beaver Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+BARTON,Beaver Township,President / Vice President,,Democratic,"Obama, Barack",11,000020
+BARTON,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+BARTON,Beaver Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+BARTON,Beaver Township,President / Vice President,,Republican,"Romney, Mitt",32,000020
+BARTON,Buffalo Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+BARTON,Buffalo Township,President / Vice President,,Democratic,"Obama, Barack",45,000030
+BARTON,Buffalo Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000030
+BARTON,Buffalo Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+BARTON,Buffalo Township,President / Vice President,,Republican,"Romney, Mitt",167,000030
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+BARTON,Cheyenne Township,President / Vice President,,Democratic,"Obama, Barack",11,000040
+BARTON,Cheyenne Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+BARTON,Cheyenne Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000040
+BARTON,Cheyenne Township,President / Vice President,,Republican,"Romney, Mitt",94,000040
+BARTON,Clarence Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+BARTON,Clarence Township,President / Vice President,,Democratic,"Obama, Barack",13,000050
+BARTON,Clarence Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+BARTON,Clarence Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000050
+BARTON,Clarence Township,President / Vice President,,Republican,"Romney, Mitt",46,000050
+BARTON,Cleveland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+BARTON,Cleveland Township,President / Vice President,,Democratic,"Obama, Barack",3,000060
+BARTON,Cleveland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+BARTON,Cleveland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+BARTON,Cleveland Township,President / Vice President,,Republican,"Romney, Mitt",17,000060
+BARTON,Comanche Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+BARTON,Comanche Township,President / Vice President,,Democratic,"Obama, Barack",37,000070
+BARTON,Comanche Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+BARTON,Comanche Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+BARTON,Comanche Township,President / Vice President,,Republican,"Romney, Mitt",155,000070
+BARTON,Eureka Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+BARTON,Eureka Township,President / Vice President,,Democratic,"Obama, Barack",6,000080
+BARTON,Eureka Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+BARTON,Eureka Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+BARTON,Eureka Township,President / Vice President,,Republican,"Romney, Mitt",42,000080
+BARTON,Fairview Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+BARTON,Fairview Township,President / Vice President,,Democratic,"Obama, Barack",15,000090
+BARTON,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+BARTON,Fairview Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+BARTON,Fairview Township,President / Vice President,,Republican,"Romney, Mitt",38,000090
+BARTON,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+BARTON,Grant Township,President / Vice President,,Democratic,"Obama, Barack",7,000100
+BARTON,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+BARTON,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+BARTON,Grant Township,President / Vice President,,Republican,"Romney, Mitt",21,000100
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",125,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",5,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",204,00011A
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",118,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",10,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",5,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",358,000120
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",84,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",6,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",312,000130
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",156,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",4,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",484,000140
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",133,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",502,000150
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",145,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",7,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",557,000160
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",93,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",317,000170
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",129,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",5,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",4,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",355,000180
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",117,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",6,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",6,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",405,00019A
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",100,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",186,000200
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",82,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",4,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",149,000210
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",45,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",1,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",43,00022A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Barnett, Andre",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Bush, Kent W",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Christensen, Will",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Goode, Virgil",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Stein, Jill E",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,Democratic,"Obama, Barack",104,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,Libertarian,"Johnson, Gary",3,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,Reform,"Baldwin, Chuck",1,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,Republican,"Romney, Mitt",466,00023A
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Ayers, Avery L",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Barnett, Andre",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Bush, Kent W",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Christensen, Will",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Duncan, Richard A",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Goode, Virgil",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Knill, Dennis J",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Reed, Jill A.",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Rogers, Rick L",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Stein, Jill E",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,Democratic,"Obama, Barack",18,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,Libertarian,"Johnson, Gary",2,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,Republican,"Romney, Mitt",93,00023B
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,Democratic,"Obama, Barack",51,000240
+BARTON,Hoisington Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000240
+BARTON,Hoisington Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000240
+BARTON,Hoisington Ward 1,President / Vice President,,Republican,"Romney, Mitt",182,000240
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,Democratic,"Obama, Barack",61,000250
+BARTON,Hoisington Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",2,000250
+BARTON,Hoisington Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,Republican,"Romney, Mitt",209,000250
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,Democratic,"Obama, Barack",50,000260
+BARTON,Hoisington Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",6,000260
+BARTON,Hoisington Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",2,000260
+BARTON,Hoisington Ward 3,President / Vice President,,Republican,"Romney, Mitt",229,000260
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Christensen, Will",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,Democratic,"Obama, Barack",53,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",3,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",1,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,Republican,"Romney, Mitt",189,00027A
+BARTON,Independent Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Barnett, Andre",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Bush, Kent W",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Christensen, Will",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Goode, Virgil",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Stein, Jill E",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+BARTON,Independent Township,President / Vice President,,Democratic,"Obama, Barack",54,000280
+BARTON,Independent Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000280
+BARTON,Independent Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000280
+BARTON,Independent Township,President / Vice President,,Republican,"Romney, Mitt",293,000280
+BARTON,Lakin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Barnett, Andre",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Bush, Kent W",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Christensen, Will",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Goode, Virgil",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Stein, Jill E",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+BARTON,Lakin Township,President / Vice President,,Democratic,"Obama, Barack",195,000290
+BARTON,Lakin Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000290
+BARTON,Lakin Township,President / Vice President,,Reform,"Baldwin, Chuck",6,000290
+BARTON,Lakin Township,President / Vice President,,Republican,"Romney, Mitt",793,000290
+BARTON,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+BARTON,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",20,000300
+BARTON,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000300
+BARTON,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000300
+BARTON,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",98,000300
+BARTON,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+BARTON,Logan Township,President / Vice President,,Democratic,"Obama, Barack",8,000310
+BARTON,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000310
+BARTON,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000310
+BARTON,Logan Township,President / Vice President,,Republican,"Romney, Mitt",70,000310
+BARTON,North Homestead Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Barnett, Andre",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Bush, Kent W",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Christensen, Will",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Goode, Virgil",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Stein, Jill E",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+BARTON,North Homestead Township,President / Vice President,,Democratic,"Obama, Barack",13,000320
+BARTON,North Homestead Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000320
+BARTON,North Homestead Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000320
+BARTON,North Homestead Township,President / Vice President,,Republican,"Romney, Mitt",51,000320
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Ayers, Avery L",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Barnett, Andre",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Bush, Kent W",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Christensen, Will",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Duncan, Richard A",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Goode, Virgil",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Knill, Dennis J",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Reed, Jill A.",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Rogers, Rick L",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Stein, Jill E",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,Democratic,"Obama, Barack",42,000330
+BARTON,Pawnee Rock Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000330
+BARTON,Pawnee Rock Township,President / Vice President,,Republican,"Romney, Mitt",113,000330
+BARTON,South Bend Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Ayers, Avery L",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Barnett, Andre",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Bush, Kent W",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Christensen, Will",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Duncan, Richard A",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Goode, Virgil",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Knill, Dennis J",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Reed, Jill A.",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Rogers, Rick L",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Stein, Jill E",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000340
+BARTON,South Bend Township,President / Vice President,,Democratic,"Obama, Barack",69,000340
+BARTON,South Bend Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000340
+BARTON,South Bend Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000340
+BARTON,South Bend Township,President / Vice President,,Republican,"Romney, Mitt",221,000340
+BARTON,South Homestead Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Ayers, Avery L",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Barnett, Andre",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Bush, Kent W",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Christensen, Will",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Duncan, Richard A",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Goode, Virgil",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Knill, Dennis J",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Reed, Jill A.",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Rogers, Rick L",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Stein, Jill E",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000350
+BARTON,South Homestead Township,President / Vice President,,Democratic,"Obama, Barack",20,000350
+BARTON,South Homestead Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000350
+BARTON,South Homestead Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000350
+BARTON,South Homestead Township,President / Vice President,,Republican,"Romney, Mitt",147,000350
+BARTON,Union Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Ayers, Avery L",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Barnett, Andre",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Bush, Kent W",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Christensen, Will",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Duncan, Richard A",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Goode, Virgil",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Knill, Dennis J",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Reed, Jill A.",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Rogers, Rick L",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Stein, Jill E",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000360
+BARTON,Union Township,President / Vice President,,Democratic,"Obama, Barack",12,000360
+BARTON,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000360
+BARTON,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000360
+BARTON,Union Township,President / Vice President,,Republican,"Romney, Mitt",41,000360
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Ayers, Avery L",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Barnett, Andre",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Barr, Roseanne C",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Bush, Kent W",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Christensen, Will",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Duncan, Richard A",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Goode, Virgil",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Knill, Dennis J",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Reed, Jill A.",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Rogers, Rick L",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Stein, Jill E",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Thorne, Kevin M",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Warner, Gerald L.",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,Democratic,"Obama, Barack",23,000370
+BARTON,Walnut Township Albert,President / Vice President,,Libertarian,"Johnson, Gary",2,000370
+BARTON,Walnut Township Albert,President / Vice President,,Reform,"Baldwin, Chuck",1,000370
+BARTON,Walnut Township Albert,President / Vice President,,Republican,"Romney, Mitt",80,000370
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Ayers, Avery L",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Barnett, Andre",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Barr, Roseanne C",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Bush, Kent W",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Christensen, Will",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Duncan, Richard A",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Goode, Virgil",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Knill, Dennis J",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Reed, Jill A.",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Rogers, Rick L",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Stein, Jill E",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Thorne, Kevin M",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Warner, Gerald L.",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,Democratic,"Obama, Barack",22,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,Libertarian,"Johnson, Gary",2,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,Reform,"Baldwin, Chuck",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,Republican,"Romney, Mitt",57,000380
+BARTON,Wheatland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Barnett, Andre",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Bush, Kent W",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Christensen, Will",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Goode, Virgil",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Stein, Jill E",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000390
+BARTON,Wheatland Township,President / Vice President,,Democratic,"Obama, Barack",5,000390
+BARTON,Wheatland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000390
+BARTON,Wheatland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000390
+BARTON,Wheatland Township,President / Vice President,,Republican,"Romney, Mitt",27,000390
+BARTON,Albion Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000010
+BARTON,Beaver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",42,000020
+BARTON,Buffalo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",189,000030
+BARTON,Cheyenne Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",100,000040
+BARTON,Clarence Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000050
+BARTON,Cleveland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000060
+BARTON,Comanche Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",172,000070
+BARTON,Eureka Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,000080
+BARTON,Fairview Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",50,000090
+BARTON,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000100
+BARTON,Great Bend City Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",275,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",419,000120
+BARTON,Great Bend City Ward 1 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",342,000130
+BARTON,Great Bend City Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",544,000140
+BARTON,Great Bend City Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",551,000150
+BARTON,Great Bend City Ward 2 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",616,000160
+BARTON,Great Bend City Ward 3 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",361,000170
+BARTON,Great Bend City Ward 3 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",425,000180
+BARTON,Great Bend City Ward 3 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",468,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",236,000200
+BARTON,Great Bend City Ward 4 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",187,000210
+BARTON,Great Bend City Ward 4 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",71,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022F
+BARTON,Great Bend Township Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",517,00023A
+BARTON,Great Bend Township Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",102,00023B
+BARTON,Great Bend Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00023C
+BARTON,Hoisington Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",199,000240
+BARTON,Hoisington Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",229,000250
+BARTON,Hoisington Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",259,000260
+BARTON,Hoisington Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",221,00027A
+BARTON,Hoisington Ward 4 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00027B
+BARTON,Independent Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",324,000280
+BARTON,Lakin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",868,000290
+BARTON,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",105,000300
+BARTON,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,000310
+BARTON,North Homestead Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",54,000320
+BARTON,Pawnee Rock Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",133,000330
+BARTON,South Bend Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",267,000340
+BARTON,South Homestead Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",157,000350
+BARTON,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,000360
+BARTON,Walnut Township Albert,United States House of Representatives,1,Republican,"Huelskamp, Tim",101,000370
+BARTON,Walnut Township Olmitz,United States House of Representatives,1,Republican,"Huelskamp, Tim",68,000380
+BARTON,Wheatland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000390
+BARTON,Hoisington Landfill,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010

--- a/2012/20121106__ks__general__bourbon__precinct.csv
+++ b/2012/20121106__ks__general__bourbon__precinct.csv
@@ -1,0 +1,813 @@
+county,precinct,office,district,party,candidate,votes,vtd
+BOURBON,Drywood Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",60,000010
+BOURBON,Drywood Township,Kansas House of Representatives,4,Republican,"Read, Marty",130,000010
+BOURBON,Fort Scott Ward 1,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",220,00002A
+BOURBON,Fort Scott Ward 1,Kansas House of Representatives,4,Republican,"Read, Marty",184,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Kansas House of Representatives,4,Republican,"Read, Marty",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,Kansas House of Representatives,4,Republican,"Read, Marty",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Kansas House of Representatives,4,Republican,"Read, Marty",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Kansas House of Representatives,4,Republican,"Read, Marty",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Kansas House of Representatives,4,Republican,"Read, Marty",0,00002F
+BOURBON,Fort Scott Ward 2,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",229,00003A
+BOURBON,Fort Scott Ward 2,Kansas House of Representatives,4,Republican,"Read, Marty",172,00003A
+BOURBON,Fort Scott Ward 3,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",91,000040
+BOURBON,Fort Scott Ward 3,Kansas House of Representatives,4,Republican,"Read, Marty",69,000040
+BOURBON,Fort Scott Ward 4,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",211,00005A
+BOURBON,Fort Scott Ward 4,Kansas House of Representatives,4,Republican,"Read, Marty",200,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,Kansas House of Representatives,4,Republican,"Read, Marty",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,Kansas House of Representatives,4,Republican,"Read, Marty",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas House of Representatives,4,Republican,"Read, Marty",0,00005D
+BOURBON,Fort Scott Ward 5,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",222,000060
+BOURBON,Fort Scott Ward 5,Kansas House of Representatives,4,Republican,"Read, Marty",238,000060
+BOURBON,Fort Scott Ward 6,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",311,000070
+BOURBON,Fort Scott Ward 6,Kansas House of Representatives,4,Republican,"Read, Marty",339,000070
+BOURBON,Fort Scott Ward 7,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",279,000080
+BOURBON,Fort Scott Ward 7,Kansas House of Representatives,4,Republican,"Read, Marty",263,000080
+BOURBON,Franklin Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",43,000090
+BOURBON,Franklin Township,Kansas House of Representatives,4,Republican,"Read, Marty",98,000090
+BOURBON,Freedom Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",57,000100
+BOURBON,Freedom Township,Kansas House of Representatives,4,Republican,"Read, Marty",147,000100
+BOURBON,Marion Township,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",171,000110
+BOURBON,Marion Township,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",13,000110
+BOURBON,Marion Township,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",316,000110
+BOURBON,Marmaton Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",137,000120
+BOURBON,Marmaton Township,Kansas House of Representatives,4,Republican,"Read, Marty",217,000120
+BOURBON,Mill Creek Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",79,000130
+BOURBON,Mill Creek Township,Kansas House of Representatives,4,Republican,"Read, Marty",155,000130
+BOURBON,North Scott Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",144,000140
+BOURBON,North Scott Township,Kansas House of Representatives,4,Republican,"Read, Marty",227,000140
+BOURBON,Osage Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",56,000150
+BOURBON,Osage Township,Kansas House of Representatives,4,Republican,"Read, Marty",110,000150
+BOURBON,Pawnee Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",66,000160
+BOURBON,Pawnee Township,Kansas House of Representatives,4,Republican,"Read, Marty",70,000160
+BOURBON,South Scott Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",316,000170
+BOURBON,South Scott Township,Kansas House of Representatives,4,Republican,"Read, Marty",474,000170
+BOURBON,Timberhill Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",27,000180
+BOURBON,Timberhill Township,Kansas House of Representatives,4,Republican,"Read, Marty",73,000180
+BOURBON,Walnut Township,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",14,000190
+BOURBON,Walnut Township,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",1,000190
+BOURBON,Walnut Township,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",31,000190
+BOURBON,Fort Scott Ward 6 Exclave A,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,Kansas House of Representatives,4,Republican,"Read, Marty",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas House of Representatives,4,Republican,"Read, Marty",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,Kansas House of Representatives,4,Republican,"Read, Marty",0,900030
+BOURBON,Drywood Township,Kansas Senate,13,Democratic,"Garman, Gene",50,000010
+BOURBON,Drywood Township,Kansas Senate,13,Republican,"LaTurner, Jacob",138,000010
+BOURBON,Fort Scott Ward 1,Kansas Senate,13,Democratic,"Garman, Gene",174,00002A
+BOURBON,Fort Scott Ward 1,Kansas Senate,13,Republican,"LaTurner, Jacob",202,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Kansas Senate,12,Democratic,"Cassells, Denise",7,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Kansas Senate,12,Republican,"Tyson, Caryn",8,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,Kansas Senate,12,Democratic,"Cassells, Denise",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,Kansas Senate,12,Republican,"Tyson, Caryn",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Kansas Senate,12,Democratic,"Cassells, Denise",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Kansas Senate,12,Republican,"Tyson, Caryn",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Kansas Senate,12,Democratic,"Cassells, Denise",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Kansas Senate,12,Republican,"Tyson, Caryn",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Kansas Senate,12,Democratic,"Cassells, Denise",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Kansas Senate,12,Republican,"Tyson, Caryn",0,00002F
+BOURBON,Fort Scott Ward 2,Kansas Senate,13,Democratic,"Garman, Gene",162,00003A
+BOURBON,Fort Scott Ward 2,Kansas Senate,13,Republican,"LaTurner, Jacob",225,00003A
+BOURBON,Fort Scott Ward 3,Kansas Senate,13,Democratic,"Garman, Gene",61,000040
+BOURBON,Fort Scott Ward 3,Kansas Senate,13,Republican,"LaTurner, Jacob",92,000040
+BOURBON,Fort Scott Ward 4,Kansas Senate,13,Democratic,"Garman, Gene",152,00005A
+BOURBON,Fort Scott Ward 4,Kansas Senate,13,Republican,"LaTurner, Jacob",236,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,Kansas Senate,13,Democratic,"Garman, Gene",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,Kansas Senate,13,Democratic,"Garman, Gene",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas Senate,13,Democratic,"Garman, Gene",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00005D
+BOURBON,Fort Scott Ward 5,Kansas Senate,13,Democratic,"Garman, Gene",172,000060
+BOURBON,Fort Scott Ward 5,Kansas Senate,13,Republican,"LaTurner, Jacob",262,000060
+BOURBON,Fort Scott Ward 6,Kansas Senate,13,Democratic,"Garman, Gene",246,000070
+BOURBON,Fort Scott Ward 6,Kansas Senate,13,Republican,"LaTurner, Jacob",369,000070
+BOURBON,Fort Scott Ward 7,Kansas Senate,13,Democratic,"Garman, Gene",193,000080
+BOURBON,Fort Scott Ward 7,Kansas Senate,13,Republican,"LaTurner, Jacob",334,000080
+BOURBON,Franklin Township,Kansas Senate,12,Democratic,"Cassells, Denise",49,000090
+BOURBON,Franklin Township,Kansas Senate,12,Republican,"Tyson, Caryn",91,000090
+BOURBON,Freedom Township,Kansas Senate,12,Democratic,"Cassells, Denise",62,000100
+BOURBON,Freedom Township,Kansas Senate,12,Republican,"Tyson, Caryn",141,000100
+BOURBON,Marion Township,Kansas Senate,12,Democratic,"Cassells, Denise",143,000110
+BOURBON,Marion Township,Kansas Senate,12,Republican,"Tyson, Caryn",359,000110
+BOURBON,Marmaton Township,Kansas Senate,12,Democratic,"Cassells, Denise",113,000120
+BOURBON,Marmaton Township,Kansas Senate,12,Republican,"Tyson, Caryn",234,000120
+BOURBON,Mill Creek Township,Kansas Senate,12,Democratic,"Cassells, Denise",71,000130
+BOURBON,Mill Creek Township,Kansas Senate,12,Republican,"Tyson, Caryn",159,000130
+BOURBON,North Scott Township,Kansas Senate,12,Democratic,"Cassells, Denise",117,000140
+BOURBON,North Scott Township,Kansas Senate,12,Republican,"Tyson, Caryn",249,000140
+BOURBON,Osage Township,Kansas Senate,12,Democratic,"Cassells, Denise",59,000150
+BOURBON,Osage Township,Kansas Senate,12,Republican,"Tyson, Caryn",105,000150
+BOURBON,Pawnee Township,Kansas Senate,13,Democratic,"Garman, Gene",39,000160
+BOURBON,Pawnee Township,Kansas Senate,13,Republican,"LaTurner, Jacob",88,000160
+BOURBON,South Scott Township,Kansas Senate,13,Democratic,"Garman, Gene",223,000170
+BOURBON,South Scott Township,Kansas Senate,13,Republican,"LaTurner, Jacob",543,000170
+BOURBON,Timberhill Township,Kansas Senate,12,Democratic,"Cassells, Denise",26,000180
+BOURBON,Timberhill Township,Kansas Senate,12,Republican,"Tyson, Caryn",73,000180
+BOURBON,Walnut Township,Kansas Senate,13,Democratic,"Garman, Gene",6,000190
+BOURBON,Walnut Township,Kansas Senate,13,Republican,"LaTurner, Jacob",39,000190
+BOURBON,Fort Scott Ward 6 Exclave A,Kansas Senate,13,Democratic,"Garman, Gene",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,Kansas Senate,13,Republican,"LaTurner, Jacob",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas Senate,13,Democratic,"Garman, Gene",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas Senate,13,Republican,"LaTurner, Jacob",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,Kansas Senate,13,Democratic,"Garman, Gene",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,Kansas Senate,13,Republican,"LaTurner, Jacob",0,900030
+BOURBON,Drywood Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+BOURBON,Drywood Township,President / Vice President,,Democratic,"Obama, Barack",53,000010
+BOURBON,Drywood Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+BOURBON,Drywood Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000010
+BOURBON,Drywood Township,President / Vice President,,Republican,"Romney, Mitt",134,000010
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Christensen, Will",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,Democratic,"Obama, Barack",166,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",6,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,Republican,"Romney, Mitt",223,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Ayers, Avery L",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Barnett, Andre",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Barr, Roseanne C",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Bush, Kent W",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Christensen, Will",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Duncan, Richard A",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Goode, Virgil",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Hoefling, Tom",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Knill, Dennis J",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Reed, Jill A.",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Rogers, Rick L",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Stein, Jill E",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Thorne, Kevin M",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Warner, Gerald L.",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,Democratic,"Obama, Barack",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,Libertarian,"Johnson, Gary",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,Reform,"Baldwin, Chuck",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,Republican,"Romney, Mitt",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Ayers, Avery L",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Barnett, Andre",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Barr, Roseanne C",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Bush, Kent W",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Christensen, Will",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Duncan, Richard A",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Goode, Virgil",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Hoefling, Tom",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Knill, Dennis J",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Reed, Jill A.",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Rogers, Rick L",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Stein, Jill E",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Thorne, Kevin M",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Warner, Gerald L.",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,Democratic,"Obama, Barack",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,Libertarian,"Johnson, Gary",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,Reform,"Baldwin, Chuck",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,Republican,"Romney, Mitt",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Ayers, Avery L",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Barnett, Andre",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Barr, Roseanne C",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Bush, Kent W",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Christensen, Will",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Duncan, Richard A",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Goode, Virgil",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Hoefling, Tom",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Knill, Dennis J",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Reed, Jill A.",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Rogers, Rick L",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Stein, Jill E",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Thorne, Kevin M",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Warner, Gerald L.",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,Democratic,"Obama, Barack",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,Libertarian,"Johnson, Gary",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,Reform,"Baldwin, Chuck",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,Republican,"Romney, Mitt",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Ayers, Avery L",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Barnett, Andre",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Barr, Roseanne C",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Bush, Kent W",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Christensen, Will",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Duncan, Richard A",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Goode, Virgil",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Hoefling, Tom",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Knill, Dennis J",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Reed, Jill A.",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Rogers, Rick L",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Stein, Jill E",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Thorne, Kevin M",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Warner, Gerald L.",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,Democratic,"Obama, Barack",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,Libertarian,"Johnson, Gary",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,Reform,"Baldwin, Chuck",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,Republican,"Romney, Mitt",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Ayers, Avery L",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Barnett, Andre",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Barr, Roseanne C",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Bush, Kent W",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Christensen, Will",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Duncan, Richard A",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Goode, Virgil",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Hoefling, Tom",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Knill, Dennis J",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Reed, Jill A.",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Rogers, Rick L",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Stein, Jill E",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Thorne, Kevin M",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Warner, Gerald L.",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,Democratic,"Obama, Barack",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,Libertarian,"Johnson, Gary",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,Reform,"Baldwin, Chuck",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,Republican,"Romney, Mitt",0,00002F
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,Democratic,"Obama, Barack",184,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",4,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",3,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,Republican,"Romney, Mitt",210,00003A
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,Democratic,"Obama, Barack",76,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",3,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,Republican,"Romney, Mitt",82,000040
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Christensen, Will",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,Democratic,"Obama, Barack",143,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",8,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,Republican,"Romney, Mitt",262,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Christensen, Will",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Ayers, Avery L",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Barnett, Andre",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Barr, Roseanne C",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Bush, Kent W",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Christensen, Will",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Duncan, Richard A",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Goode, Virgil",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Knill, Dennis J",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Reed, Jill A.",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Rogers, Rick L",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Stein, Jill E",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Thorne, Kevin M",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Warner, Gerald L.",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,Democratic,"Obama, Barack",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,Reform,"Baldwin, Chuck",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,Republican,"Romney, Mitt",0,00005D
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Barnett, Andre",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Bush, Kent W",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Christensen, Will",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Goode, Virgil",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Stein, Jill E",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,Democratic,"Obama, Barack",149,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",12,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,Reform,"Baldwin, Chuck",2,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,Republican,"Romney, Mitt",289,000060
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Barnett, Andre",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Bush, Kent W",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Christensen, Will",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Goode, Virgil",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Stein, Jill E",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,Democratic,"Obama, Barack",218,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,Libertarian,"Johnson, Gary",6,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,Reform,"Baldwin, Chuck",4,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,Republican,"Romney, Mitt",425,000070
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Barnett, Andre",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Bush, Kent W",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Christensen, Will",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Goode, Virgil",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Stein, Jill E",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,Democratic,"Obama, Barack",209,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,Libertarian,"Johnson, Gary",14,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,Reform,"Baldwin, Chuck",4,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,Republican,"Romney, Mitt",316,000080
+BOURBON,Franklin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+BOURBON,Franklin Township,President / Vice President,,Democratic,"Obama, Barack",38,000090
+BOURBON,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+BOURBON,Franklin Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+BOURBON,Franklin Township,President / Vice President,,Republican,"Romney, Mitt",104,000090
+BOURBON,Freedom Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+BOURBON,Freedom Township,President / Vice President,,Democratic,"Obama, Barack",50,000100
+BOURBON,Freedom Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000100
+BOURBON,Freedom Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+BOURBON,Freedom Township,President / Vice President,,Republican,"Romney, Mitt",143,000100
+BOURBON,Marion Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Goode, Virgil",4,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+BOURBON,Marion Township,President / Vice President,,Democratic,"Obama, Barack",120,000110
+BOURBON,Marion Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000110
+BOURBON,Marion Township,President / Vice President,,Reform,"Baldwin, Chuck",6,000110
+BOURBON,Marion Township,President / Vice President,,Republican,"Romney, Mitt",372,000110
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Goode, Virgil",1,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+BOURBON,Marmaton Township,President / Vice President,,Democratic,"Obama, Barack",108,000120
+BOURBON,Marmaton Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000120
+BOURBON,Marmaton Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+BOURBON,Marmaton Township,President / Vice President,,Republican,"Romney, Mitt",233,000120
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Goode, Virgil",1,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,Democratic,"Obama, Barack",50,000130
+BOURBON,Mill Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000130
+BOURBON,Mill Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",6,000130
+BOURBON,Mill Creek Township,President / Vice President,,Republican,"Romney, Mitt",161,000130
+BOURBON,North Scott Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+BOURBON,North Scott Township,President / Vice President,,Democratic,"Obama, Barack",113,000140
+BOURBON,North Scott Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000140
+BOURBON,North Scott Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+BOURBON,North Scott Township,President / Vice President,,Republican,"Romney, Mitt",248,000140
+BOURBON,Osage Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+BOURBON,Osage Township,President / Vice President,,Democratic,"Obama, Barack",45,000150
+BOURBON,Osage Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000150
+BOURBON,Osage Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+BOURBON,Osage Township,President / Vice President,,Republican,"Romney, Mitt",118,000150
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+BOURBON,Pawnee Township,President / Vice President,,Democratic,"Obama, Barack",39,000160
+BOURBON,Pawnee Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000160
+BOURBON,Pawnee Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+BOURBON,Pawnee Township,President / Vice President,,Republican,"Romney, Mitt",93,000160
+BOURBON,South Scott Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+BOURBON,South Scott Township,President / Vice President,,Democratic,"Obama, Barack",207,000170
+BOURBON,South Scott Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000170
+BOURBON,South Scott Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000170
+BOURBON,South Scott Township,President / Vice President,,Republican,"Romney, Mitt",571,000170
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+BOURBON,Timberhill Township,President / Vice President,,Democratic,"Obama, Barack",24,000180
+BOURBON,Timberhill Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+BOURBON,Timberhill Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000180
+BOURBON,Timberhill Township,President / Vice President,,Republican,"Romney, Mitt",76,000180
+BOURBON,Walnut Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+BOURBON,Walnut Township,President / Vice President,,Democratic,"Obama, Barack",4,000190
+BOURBON,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+BOURBON,Walnut Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+BOURBON,Walnut Township,President / Vice President,,Republican,"Romney, Mitt",42,000190
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Barnett, Andre",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Bush, Kent W",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Christensen, Will",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Goode, Virgil",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Stein, Jill E",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,Democratic,"Obama, Barack",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,Republican,"Romney, Mitt",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Barnett, Andre",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Bush, Kent W",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Christensen, Will",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Goode, Virgil",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Stein, Jill E",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,Democratic,"Obama, Barack",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,Republican,"Romney, Mitt",0,900030
+BOURBON,Drywood Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",46,000010
+BOURBON,Drywood Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000010
+BOURBON,Drywood Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",142,000010
+BOURBON,Fort Scott Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",136,00002A
+BOURBON,Fort Scott Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,00002A
+BOURBON,Fort Scott Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",242,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002F
+BOURBON,Fort Scott Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",127,00003A
+BOURBON,Fort Scott Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",21,00003A
+BOURBON,Fort Scott Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",250,00003A
+BOURBON,Fort Scott Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",45,000040
+BOURBON,Fort Scott Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000040
+BOURBON,Fort Scott Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",104,000040
+BOURBON,Fort Scott Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",117,00005A
+BOURBON,Fort Scott Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",21,00005A
+BOURBON,Fort Scott Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",263,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005D
+BOURBON,Fort Scott Ward 5,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",123,000060
+BOURBON,Fort Scott Ward 5,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,000060
+BOURBON,Fort Scott Ward 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",312,000060
+BOURBON,Fort Scott Ward 6,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",177,000070
+BOURBON,Fort Scott Ward 6,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000070
+BOURBON,Fort Scott Ward 6,United States House of Representatives,2,Republican,"Jenkins, Lynn",451,000070
+BOURBON,Fort Scott Ward 7,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",156,000080
+BOURBON,Fort Scott Ward 7,United States House of Representatives,2,Libertarian,"Hawver, Dennis",24,000080
+BOURBON,Fort Scott Ward 7,United States House of Representatives,2,Republican,"Jenkins, Lynn",352,000080
+BOURBON,Franklin Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",39,000090
+BOURBON,Franklin Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000090
+BOURBON,Franklin Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,000090
+BOURBON,Freedom Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",39,000100
+BOURBON,Freedom Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,000100
+BOURBON,Freedom Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",149,000100
+BOURBON,Marion Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",106,000110
+BOURBON,Marion Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",17,000110
+BOURBON,Marion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",380,000110
+BOURBON,Marmaton Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",84,000120
+BOURBON,Marmaton Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,000120
+BOURBON,Marmaton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",255,000120
+BOURBON,Mill Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",49,000130
+BOURBON,Mill Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000130
+BOURBON,Mill Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",176,000130
+BOURBON,North Scott Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",96,000140
+BOURBON,North Scott Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000140
+BOURBON,North Scott Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",266,000140
+BOURBON,Osage Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",37,000150
+BOURBON,Osage Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000150
+BOURBON,Osage Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",123,000150
+BOURBON,Pawnee Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",40,000160
+BOURBON,Pawnee Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000160
+BOURBON,Pawnee Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",93,000160
+BOURBON,South Scott Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",151,000170
+BOURBON,South Scott Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",25,000170
+BOURBON,South Scott Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",604,000170
+BOURBON,Timberhill Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",18,000180
+BOURBON,Timberhill Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000180
+BOURBON,Timberhill Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",79,000180
+BOURBON,Walnut Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",4,000190
+BOURBON,Walnut Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000190
+BOURBON,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",38,000190
+BOURBON,Fort Scott Ward 6 Exclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030

--- a/2012/20121106__ks__general__brown__precinct.csv
+++ b/2012/20121106__ks__general__brown__precinct.csv
@@ -1,0 +1,755 @@
+county,precinct,office,district,party,candidate,votes,vtd
+BROWN,Hamlin Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",18,000010
+BROWN,Hamlin Township,Kansas House of Representatives,62,Republican,"Garber, Randy",65,000010
+BROWN,Hiawatha City Ward 1,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",89,000020
+BROWN,Hiawatha City Ward 1,Kansas House of Representatives,62,Republican,"Garber, Randy",83,000020
+BROWN,Hiawatha City Ward 2,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",200,000030
+BROWN,Hiawatha City Ward 2,Kansas House of Representatives,62,Republican,"Garber, Randy",323,000030
+BROWN,Hiawatha City Ward 3,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",165,00004A
+BROWN,Hiawatha City Ward 3,Kansas House of Representatives,62,Republican,"Garber, Randy",287,00004A
+BROWN,Hiawatha City Ward 3 Exclave,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00004B
+BROWN,Hiawatha City Ward 4,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",17,00005A
+BROWN,Hiawatha City Ward 4,Kansas House of Representatives,62,Republican,"Garber, Randy",57,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00005B
+BROWN,Hiawatha Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",77,000060
+BROWN,Hiawatha Township,Kansas House of Representatives,62,Republican,"Garber, Randy",227,000060
+BROWN,Horton Ward 1,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",90,000070
+BROWN,Horton Ward 1,Kansas House of Representatives,62,Republican,"Garber, Randy",173,000070
+BROWN,Horton Ward 2,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",63,000080
+BROWN,Horton Ward 2,Kansas House of Representatives,62,Republican,"Garber, Randy",130,000080
+BROWN,Horton Ward 3,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",49,00009A
+BROWN,Horton Ward 3,Kansas House of Representatives,62,Republican,"Garber, Randy",77,00009A
+BROWN,Horton Ward 3 Exclave A,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,00009B
+BROWN,Horton Ward 3 Exclave A,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00009B
+BROWN,Horton Ward 3 Exclave B,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,00009C
+BROWN,Horton Ward 3 Exclave B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00009C
+BROWN,Irving Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",49,000100
+BROWN,Irving Township,Kansas House of Representatives,62,Republican,"Garber, Randy",82,000100
+BROWN,Mission Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",86,000110
+BROWN,Mission Township,Kansas House of Representatives,62,Republican,"Garber, Randy",203,000110
+BROWN,Morrill Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",59,000120
+BROWN,Morrill Township,Kansas House of Representatives,62,Republican,"Garber, Randy",159,000120
+BROWN,Padonia Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",37,000130
+BROWN,Padonia Township,Kansas House of Representatives,62,Republican,"Garber, Randy",53,000130
+BROWN,Powhattan Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",140,000140
+BROWN,Powhattan Township,Kansas House of Representatives,62,Republican,"Garber, Randy",119,000140
+BROWN,Reserve Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",19,000150
+BROWN,Reserve Township,Kansas House of Representatives,62,Republican,"Garber, Randy",28,000150
+BROWN,Robinson Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",65,000160
+BROWN,Robinson Township,Kansas House of Representatives,62,Republican,"Garber, Randy",129,000160
+BROWN,Sabetha Ward 1 Part A,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,00017A
+BROWN,Sabetha Ward 1 Part A,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00017A
+BROWN,Sabetha Ward 1 Part B,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,00017B
+BROWN,Sabetha Ward 1 Part B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00017B
+BROWN,Sabetha Ward 4 Part A,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,00018A
+BROWN,Sabetha Ward 4 Part A,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00018A
+BROWN,Sabetha Ward 4 Part B,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,00018B
+BROWN,Sabetha Ward 4 Part B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00018B
+BROWN,Sabetha Ward 5,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,000190
+BROWN,Sabetha Ward 5,Kansas House of Representatives,62,Republican,"Garber, Randy",0,000190
+BROWN,Walnut Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",105,000200
+BROWN,Walnut Township,Kansas House of Representatives,62,Republican,"Garber, Randy",194,000200
+BROWN,Washington Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",58,000210
+BROWN,Washington Township,Kansas House of Representatives,62,Republican,"Garber, Randy",174,000210
+BROWN,Hamlin Township,Kansas Senate,1,Democratic,"Lukert, Steve",42,000010
+BROWN,Hamlin Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",38,000010
+BROWN,Hiawatha City Ward 1,Kansas Senate,1,Democratic,"Lukert, Steve",117,000020
+BROWN,Hiawatha City Ward 1,Kansas Senate,1,Republican,"Pyle, Dennis D.",55,000020
+BROWN,Hiawatha City Ward 2,Kansas Senate,1,Democratic,"Lukert, Steve",336,000030
+BROWN,Hiawatha City Ward 2,Kansas Senate,1,Republican,"Pyle, Dennis D.",193,000030
+BROWN,Hiawatha City Ward 3,Kansas Senate,1,Democratic,"Lukert, Steve",293,00004A
+BROWN,Hiawatha City Ward 3,Kansas Senate,1,Republican,"Pyle, Dennis D.",166,00004A
+BROWN,Hiawatha City Ward 3 Exclave,Kansas Senate,1,Democratic,"Lukert, Steve",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00004B
+BROWN,Hiawatha City Ward 4,Kansas Senate,1,Democratic,"Lukert, Steve",33,00005A
+BROWN,Hiawatha City Ward 4,Kansas Senate,1,Republican,"Pyle, Dennis D.",42,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,Kansas Senate,1,Democratic,"Lukert, Steve",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00005B
+BROWN,Hiawatha Township,Kansas Senate,1,Democratic,"Lukert, Steve",165,000060
+BROWN,Hiawatha Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",141,000060
+BROWN,Horton Ward 1,Kansas Senate,1,Democratic,"Lukert, Steve",130,000070
+BROWN,Horton Ward 1,Kansas Senate,1,Republican,"Pyle, Dennis D.",137,000070
+BROWN,Horton Ward 2,Kansas Senate,1,Democratic,"Lukert, Steve",108,000080
+BROWN,Horton Ward 2,Kansas Senate,1,Republican,"Pyle, Dennis D.",90,000080
+BROWN,Horton Ward 3,Kansas Senate,1,Democratic,"Lukert, Steve",57,00009A
+BROWN,Horton Ward 3,Kansas Senate,1,Republican,"Pyle, Dennis D.",72,00009A
+BROWN,Horton Ward 3 Exclave A,Kansas Senate,1,Democratic,"Lukert, Steve",0,00009B
+BROWN,Horton Ward 3 Exclave A,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00009B
+BROWN,Horton Ward 3 Exclave B,Kansas Senate,1,Democratic,"Lukert, Steve",0,00009C
+BROWN,Horton Ward 3 Exclave B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00009C
+BROWN,Irving Township,Kansas Senate,1,Democratic,"Lukert, Steve",87,000100
+BROWN,Irving Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",48,000100
+BROWN,Mission Township,Kansas Senate,1,Democratic,"Lukert, Steve",174,000110
+BROWN,Mission Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",121,000110
+BROWN,Morrill Township,Kansas Senate,1,Democratic,"Lukert, Steve",90,000120
+BROWN,Morrill Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",123,000120
+BROWN,Padonia Township,Kansas Senate,1,Democratic,"Lukert, Steve",61,000130
+BROWN,Padonia Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",28,000130
+BROWN,Powhattan Township,Kansas Senate,1,Democratic,"Lukert, Steve",174,000140
+BROWN,Powhattan Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",86,000140
+BROWN,Reserve Township,Kansas Senate,1,Democratic,"Lukert, Steve",25,000150
+BROWN,Reserve Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",24,000150
+BROWN,Robinson Township,Kansas Senate,1,Democratic,"Lukert, Steve",116,000160
+BROWN,Robinson Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",79,000160
+BROWN,Sabetha Ward 1 Part A,Kansas Senate,1,Democratic,"Lukert, Steve",0,00017A
+BROWN,Sabetha Ward 1 Part A,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00017A
+BROWN,Sabetha Ward 1 Part B,Kansas Senate,1,Democratic,"Lukert, Steve",0,00017B
+BROWN,Sabetha Ward 1 Part B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00017B
+BROWN,Sabetha Ward 4 Part A,Kansas Senate,1,Democratic,"Lukert, Steve",0,00018A
+BROWN,Sabetha Ward 4 Part A,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00018A
+BROWN,Sabetha Ward 4 Part B,Kansas Senate,1,Democratic,"Lukert, Steve",0,00018B
+BROWN,Sabetha Ward 4 Part B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00018B
+BROWN,Sabetha Ward 5,Kansas Senate,1,Democratic,"Lukert, Steve",0,000190
+BROWN,Sabetha Ward 5,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,000190
+BROWN,Walnut Township,Kansas Senate,1,Democratic,"Lukert, Steve",165,000200
+BROWN,Walnut Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",137,000200
+BROWN,Washington Township,Kansas Senate,1,Democratic,"Lukert, Steve",128,000210
+BROWN,Washington Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",104,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,Kansas Senate,1,Democratic,"Lukert, Steve",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,900010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+BROWN,Hamlin Township,President / Vice President,,Democratic,"Obama, Barack",12,000010
+BROWN,Hamlin Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000010
+BROWN,Hamlin Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+BROWN,Hamlin Township,President / Vice President,,Republican,"Romney, Mitt",67,000010
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,Democratic,"Obama, Barack",73,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,Republican,"Romney, Mitt",98,000020
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,Democratic,"Obama, Barack",151,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",5,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",7,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,Republican,"Romney, Mitt",371,000030
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,Democratic,"Obama, Barack",140,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",6,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",4,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,Republican,"Romney, Mitt",303,00004A
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00004B
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Christensen, Will",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,Democratic,"Obama, Barack",22,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",3,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,Republican,"Romney, Mitt",52,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Ayers, Avery L",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Barnett, Andre",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Barr, Roseanne C",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Bush, Kent W",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Christensen, Will",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Duncan, Richard A",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Goode, Virgil",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Knill, Dennis J",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Reed, Jill A.",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Rogers, Rick L",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Stein, Jill E",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Thorne, Kevin M",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Warner, Gerald L.",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,Democratic,"Obama, Barack",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,Reform,"Baldwin, Chuck",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,Republican,"Romney, Mitt",0,00005B
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+BROWN,Hiawatha Township,President / Vice President,,Democratic,"Obama, Barack",58,000060
+BROWN,Hiawatha Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000060
+BROWN,Hiawatha Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+BROWN,Hiawatha Township,President / Vice President,,Republican,"Romney, Mitt",244,000060
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+BROWN,Horton Ward 1,President / Vice President,,Democratic,"Obama, Barack",72,000070
+BROWN,Horton Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",4,000070
+BROWN,Horton Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+BROWN,Horton Ward 1,President / Vice President,,Republican,"Romney, Mitt",187,000070
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+BROWN,Horton Ward 2,President / Vice President,,Democratic,"Obama, Barack",61,000080
+BROWN,Horton Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+BROWN,Horton Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000080
+BROWN,Horton Ward 2,President / Vice President,,Republican,"Romney, Mitt",132,000080
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,Democratic,"Obama, Barack",38,00009A
+BROWN,Horton Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",2,00009A
+BROWN,Horton Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,Republican,"Romney, Mitt",88,00009A
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00009B
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Christensen, Will",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,00009C
+BROWN,Irving Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+BROWN,Irving Township,President / Vice President,,Democratic,"Obama, Barack",42,000100
+BROWN,Irving Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+BROWN,Irving Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+BROWN,Irving Township,President / Vice President,,Republican,"Romney, Mitt",93,000100
+BROWN,Mission Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+BROWN,Mission Township,President / Vice President,,Democratic,"Obama, Barack",54,000110
+BROWN,Mission Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+BROWN,Mission Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000110
+BROWN,Mission Township,President / Vice President,,Republican,"Romney, Mitt",237,000110
+BROWN,Morrill Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+BROWN,Morrill Township,President / Vice President,,Democratic,"Obama, Barack",30,000120
+BROWN,Morrill Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+BROWN,Morrill Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000120
+BROWN,Morrill Township,President / Vice President,,Republican,"Romney, Mitt",180,000120
+BROWN,Padonia Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+BROWN,Padonia Township,President / Vice President,,Democratic,"Obama, Barack",16,000130
+BROWN,Padonia Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+BROWN,Padonia Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+BROWN,Padonia Township,President / Vice President,,Republican,"Romney, Mitt",74,000130
+BROWN,Powhattan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+BROWN,Powhattan Township,President / Vice President,,Democratic,"Obama, Barack",121,000140
+BROWN,Powhattan Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000140
+BROWN,Powhattan Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+BROWN,Powhattan Township,President / Vice President,,Republican,"Romney, Mitt",131,000140
+BROWN,Reserve Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+BROWN,Reserve Township,President / Vice President,,Democratic,"Obama, Barack",19,000150
+BROWN,Reserve Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+BROWN,Reserve Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+BROWN,Reserve Township,President / Vice President,,Republican,"Romney, Mitt",30,000150
+BROWN,Robinson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+BROWN,Robinson Township,President / Vice President,,Democratic,"Obama, Barack",53,000160
+BROWN,Robinson Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000160
+BROWN,Robinson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+BROWN,Robinson Township,President / Vice President,,Republican,"Romney, Mitt",141,000160
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Barnett, Andre",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Bush, Kent W",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Christensen, Will",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Goode, Virgil",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Stein, Jill E",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,Democratic,"Obama, Barack",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,Reform,"Baldwin, Chuck",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,Republican,"Romney, Mitt",0,00017A
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Ayers, Avery L",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Barnett, Andre",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Bush, Kent W",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Christensen, Will",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Duncan, Richard A",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Goode, Virgil",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Knill, Dennis J",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Reed, Jill A.",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Rogers, Rick L",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Stein, Jill E",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,Democratic,"Obama, Barack",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,Republican,"Romney, Mitt",0,00017B
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Barnett, Andre",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Bush, Kent W",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Christensen, Will",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Goode, Virgil",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Stein, Jill E",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,Democratic,"Obama, Barack",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,Reform,"Baldwin, Chuck",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,Republican,"Romney, Mitt",0,00018A
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Ayers, Avery L",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Barnett, Andre",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Bush, Kent W",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Christensen, Will",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Duncan, Richard A",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Goode, Virgil",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Knill, Dennis J",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Reed, Jill A.",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Rogers, Rick L",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Stein, Jill E",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,Democratic,"Obama, Barack",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,Republican,"Romney, Mitt",0,00018B
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Barnett, Andre",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Bush, Kent W",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Christensen, Will",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Goode, Virgil",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Stein, Jill E",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,Democratic,"Obama, Barack",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,Republican,"Romney, Mitt",0,000190
+BROWN,Walnut Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+BROWN,Walnut Township,President / Vice President,,Democratic,"Obama, Barack",65,000200
+BROWN,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000200
+BROWN,Walnut Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+BROWN,Walnut Township,President / Vice President,,Republican,"Romney, Mitt",222,000200
+BROWN,Washington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+BROWN,Washington Township,President / Vice President,,Democratic,"Obama, Barack",49,000210
+BROWN,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000210
+BROWN,Washington Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+BROWN,Washington Township,President / Vice President,,Republican,"Romney, Mitt",179,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900010
+BROWN,Hamlin Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",11,000010
+BROWN,Hamlin Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000010
+BROWN,Hamlin Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",70,000010
+BROWN,Hiawatha City Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",68,000020
+BROWN,Hiawatha City Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000020
+BROWN,Hiawatha City Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",98,000020
+BROWN,Hiawatha City Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",145,000030
+BROWN,Hiawatha City Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",25,000030
+BROWN,Hiawatha City Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",361,000030
+BROWN,Hiawatha City Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",123,00004A
+BROWN,Hiawatha City Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",30,00004A
+BROWN,Hiawatha City Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",299,00004A
+BROWN,Hiawatha City Ward 3 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00004B
+BROWN,Hiawatha City Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",14,00005A
+BROWN,Hiawatha City Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,00005A
+BROWN,Hiawatha City Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",54,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005B
+BROWN,Hiawatha Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",59,000060
+BROWN,Hiawatha Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",21,000060
+BROWN,Hiawatha Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",225,000060
+BROWN,Horton Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",64,000070
+BROWN,Horton Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",17,000070
+BROWN,Horton Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",178,000070
+BROWN,Horton Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",63,000080
+BROWN,Horton Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000080
+BROWN,Horton Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",128,000080
+BROWN,Horton Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",23,00009A
+BROWN,Horton Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,00009A
+BROWN,Horton Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",90,00009A
+BROWN,Horton Ward 3 Exclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00009B
+BROWN,Horton Ward 3 Exclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00009B
+BROWN,Horton Ward 3 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00009B
+BROWN,Horton Ward 3 Exclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00009C
+BROWN,Horton Ward 3 Exclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00009C
+BROWN,Horton Ward 3 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00009C
+BROWN,Irving Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",38,000100
+BROWN,Irving Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000100
+BROWN,Irving Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",91,000100
+BROWN,Mission Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",66,000110
+BROWN,Mission Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000110
+BROWN,Mission Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",219,000110
+BROWN,Morrill Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",27,000120
+BROWN,Morrill Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,000120
+BROWN,Morrill Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",175,000120
+BROWN,Padonia Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",13,000130
+BROWN,Padonia Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000130
+BROWN,Padonia Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",66,000130
+BROWN,Powhattan Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",108,000140
+BROWN,Powhattan Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,000140
+BROWN,Powhattan Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",130,000140
+BROWN,Reserve Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",21,000150
+BROWN,Reserve Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000150
+BROWN,Reserve Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",26,000150
+BROWN,Robinson Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",47,000160
+BROWN,Robinson Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,000160
+BROWN,Robinson Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",138,000160
+BROWN,Sabetha Ward 1 Part A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00017A
+BROWN,Sabetha Ward 1 Part A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00017A
+BROWN,Sabetha Ward 1 Part A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00017A
+BROWN,Sabetha Ward 1 Part B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00017B
+BROWN,Sabetha Ward 1 Part B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00017B
+BROWN,Sabetha Ward 1 Part B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00017B
+BROWN,Sabetha Ward 4 Part A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00018A
+BROWN,Sabetha Ward 4 Part A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00018A
+BROWN,Sabetha Ward 4 Part A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00018A
+BROWN,Sabetha Ward 4 Part B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00018B
+BROWN,Sabetha Ward 4 Part B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00018B
+BROWN,Sabetha Ward 4 Part B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00018B
+BROWN,Sabetha Ward 5,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,000190
+BROWN,Sabetha Ward 5,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000190
+BROWN,Sabetha Ward 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,000190
+BROWN,Walnut Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",74,000200
+BROWN,Walnut Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000200
+BROWN,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",214,000200
+BROWN,Washington Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",49,000210
+BROWN,Washington Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000210
+BROWN,Washington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",176,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010

--- a/2012/20121106__ks__general__butler__precinct.csv
+++ b/2012/20121106__ks__general__butler__precinct.csv
@@ -1,0 +1,1354 @@
+county,precinct,office,district,party,candidate,votes,vtd
+BUTLER,Andover North,Kansas House of Representatives,99,Republican,"Hedke, Dennis",1749,00001A
+BUTLER,Augusta City Ward 1,Kansas House of Representatives,77,Republican,"Crum, J. David",484,00002A
+BUTLER,Augusta City Ward 2,Kansas House of Representatives,77,Republican,"Crum, J. David",681,000030
+BUTLER,Augusta City Ward 3,Kansas House of Representatives,77,Republican,"Crum, J. David",777,00004A
+BUTLER,Augusta City Ward 4,Kansas House of Representatives,77,Republican,"Crum, J. David",1046,000050
+BUTLER,Benton Township / City,Kansas House of Representatives,85,Democratic,"Stanley, Barry",249,000070
+BUTLER,Benton Township / City,Kansas House of Representatives,85,Republican,"Brunk, Steve",846,000070
+BUTLER,Bloomington Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",67,000080
+BUTLER,Bloomington Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",142,000080
+BUTLER,Sycamore/Cassoday,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",53,000100
+BUTLER,Sycamore/Cassoday,Kansas House of Representatives,75,Republican,"Carpenter, Will",106,000100
+BUTLER,Clay Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",15,000110
+BUTLER,Clay Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",23,000110
+BUTLER,Clifford Township,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",19,000120
+BUTLER,Clifford Township,Kansas House of Representatives,75,Republican,"Carpenter, Will",92,000120
+BUTLER,Douglass Township/City,Kansas House of Representatives,77,Republican,"Crum, J. David",674,000130
+BUTLER,El Dorado Ward 1 Precinct 1,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",123,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,Kansas House of Representatives,75,Republican,"Carpenter, Will",121,00014A
+BUTLER,El Dorado Ward 1 Precinct 2,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",387,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,Kansas House of Representatives,75,Republican,"Carpenter, Will",944,00015A
+BUTLER,El Dorado Ward 2 Precinct 1,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",130,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,Kansas House of Representatives,75,Republican,"Carpenter, Will",156,00016A
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",108,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,Kansas House of Representatives,75,Republican,"Carpenter, Will",178,00016B
+BUTLER,El Dorado Ward 2 Precinct 3,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",155,000180
+BUTLER,El Dorado Ward 2 Precinct 3,Kansas House of Representatives,75,Republican,"Carpenter, Will",177,000180
+BUTLER,El Dorado Ward 3 Precinct 1,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",184,000190
+BUTLER,El Dorado Ward 3 Precinct 1,Kansas House of Representatives,75,Republican,"Carpenter, Will",212,000190
+BUTLER,El Dorado Ward 3 Precinct 2,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",124,000200
+BUTLER,El Dorado Ward 3 Precinct 2,Kansas House of Representatives,75,Republican,"Carpenter, Will",150,000200
+BUTLER,El Dorado Ward 3 Precinct 3,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",100,000210
+BUTLER,El Dorado Ward 3 Precinct 3,Kansas House of Representatives,75,Republican,"Carpenter, Will",152,000210
+BUTLER,El Dorado Ward 4 Precinct 1,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",156,000220
+BUTLER,El Dorado Ward 4 Precinct 1,Kansas House of Representatives,75,Republican,"Carpenter, Will",198,000220
+BUTLER,El Dorado Ward 4 Precinct 2,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",182,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,Kansas House of Representatives,75,Republican,"Carpenter, Will",244,00023A
+BUTLER,El Dorado Ward 4 Precinct 3,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",132,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,Kansas House of Representatives,75,Republican,"Carpenter, Will",213,00023B
+BUTLER,Fairmount Township/Elbing,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",55,000240
+BUTLER,Fairmount Township/Elbing,Kansas House of Representatives,75,Republican,"Carpenter, Will",222,000240
+BUTLER,Fairview Township,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",66,000250
+BUTLER,Fairview Township,Kansas House of Representatives,75,Republican,"Carpenter, Will",185,000250
+BUTLER,Glencoe Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",34,000260
+BUTLER,Glencoe Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",47,000260
+BUTLER,Hickory Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",16,000270
+BUTLER,Hickory Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",35,000270
+BUTLER,Lincoln Township,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",31,000280
+BUTLER,Lincoln Township,Kansas House of Representatives,75,Republican,"Carpenter, Will",89,000280
+BUTLER,Little Walnut Township/Leon,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",110,000290
+BUTLER,Little Walnut Township/Leon,Kansas House of Representatives,12,Republican,"Peck, Virgil",206,000290
+BUTLER,Logan Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",24,000300
+BUTLER,Logan Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",43,000300
+BUTLER,Murdock Township,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",40,000320
+BUTLER,Murdock Township,Kansas House of Representatives,75,Republican,"Carpenter, Will",160,000320
+BUTLER,El Dorado Township,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",105,000330
+BUTLER,El Dorado Township,Kansas House of Representatives,75,Republican,"Carpenter, Will",205,000330
+BUTLER,Pleasant Township,Kansas House of Representatives,77,Republican,"Crum, J. David",895,000340
+BUTLER,Plum Grove Township/Potwin,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",79,000350
+BUTLER,Plum Grove Township/Potwin,Kansas House of Representatives,75,Republican,"Carpenter, Will",179,000350
+BUTLER,Prospect Township,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",191,000360
+BUTLER,Prospect Township,Kansas House of Representatives,75,Republican,"Carpenter, Will",316,000360
+BUTLER,Rock Creek Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",41,000380
+BUTLER,Rock Creek Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",87,000380
+BUTLER,Rosalia Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",82,000390
+BUTLER,Rosalia Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",156,000390
+BUTLER,Spring Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",216,000410
+BUTLER,Spring Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",406,000410
+BUTLER,Towanda Township/City,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",331,000430
+BUTLER,Towanda Township/City,Kansas House of Representatives,75,Republican,"Carpenter, Will",810,000430
+BUTLER,Union Township / Latham,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",27,000440
+BUTLER,Union Township / Latham,Kansas House of Representatives,12,Republican,"Peck, Virgil",41,000440
+BUTLER,Walnut Township,Kansas House of Representatives,77,Republican,"Crum, J. David",258,000450
+BUTLER,Andover South H77,Kansas House of Representatives,77,Republican,"Crum, J. David",113,120020
+BUTLER,Andover South H99,Kansas House of Representatives,99,Republican,"Hedke, Dennis",2011,120030
+BUTLER,Augusta Township S14,Kansas House of Representatives,77,Republican,"Crum, J. David",138,120040
+BUTLER,Augusta Township S16,Kansas House of Representatives,77,Republican,"Crum, J. David",364,120050
+BUTLER,Bruno Township H77,Kansas House of Representatives,77,Republican,"Crum, J. David",573,120060
+BUTLER,Bruno Township H99,Kansas House of Representatives,99,Republican,"Hedke, Dennis",355,120070
+BUTLER,Whitewater / Milton Township H72,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",118,120080
+BUTLER,Whitewater / Milton Township H72,Kansas House of Representatives,72,Republican,"Rhoades, Marc",196,120080
+BUTLER,Whitewater / Milton Township H75,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",42,120090
+BUTLER,Whitewater / Milton Township H75,Kansas House of Representatives,75,Republican,"Carpenter, Will",168,120090
+BUTLER,Rose Hill City,Kansas House of Representatives,77,Republican,"Crum, J. David",1346,200010
+BUTLER,Richland Township H77,Kansas House of Representatives,77,Republican,"Crum, J. David",440,800040
+BUTLER,Chelsea Township,Kansas House of Representatives,75,Democratic,"Scribner, Suzanne",47,800050
+BUTLER,Chelsea Township,Kansas House of Representatives,75,Republican,"Carpenter, Will",52,800050
+BUTLER,Andover North,Kansas Senate,16,Republican,"Masterson, Ty",1789,00001A
+BUTLER,Augusta City Ward 1,Kansas Senate,16,Republican,"Masterson, Ty",468,00002A
+BUTLER,Augusta City Ward 2,Kansas Senate,16,Republican,"Masterson, Ty",638,000030
+BUTLER,Augusta City Ward 3,Kansas Senate,16,Republican,"Masterson, Ty",718,00004A
+BUTLER,Augusta City Ward 4,Kansas Senate,16,Republican,"Masterson, Ty",981,000050
+BUTLER,Benton Township / City,Kansas Senate,16,Republican,"Masterson, Ty",979,000070
+BUTLER,Bloomington Township,Kansas Senate,14,Democratic,"Fuson, Eden",67,000080
+BUTLER,Bloomington Township,Kansas Senate,14,Republican,"Knox, Forrest J.",144,000080
+BUTLER,Sycamore/Cassoday,Kansas Senate,14,Democratic,"Fuson, Eden",44,000100
+BUTLER,Sycamore/Cassoday,Kansas Senate,14,Republican,"Knox, Forrest J.",114,000100
+BUTLER,Clay Township,Kansas Senate,14,Democratic,"Fuson, Eden",12,000110
+BUTLER,Clay Township,Kansas Senate,14,Republican,"Knox, Forrest J.",29,000110
+BUTLER,Clifford Township,Kansas Senate,14,Democratic,"Fuson, Eden",27,000120
+BUTLER,Clifford Township,Kansas Senate,14,Republican,"Knox, Forrest J.",81,000120
+BUTLER,Douglass Township/City,Kansas Senate,14,Democratic,"Fuson, Eden",226,000130
+BUTLER,Douglass Township/City,Kansas Senate,14,Republican,"Knox, Forrest J.",552,000130
+BUTLER,El Dorado Ward 1 Precinct 1,Kansas Senate,14,Democratic,"Fuson, Eden",113,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,Kansas Senate,14,Republican,"Knox, Forrest J.",123,00014A
+BUTLER,El Dorado Ward 1 Precinct 2,Kansas Senate,14,Democratic,"Fuson, Eden",409,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,Kansas Senate,14,Republican,"Knox, Forrest J.",890,00015A
+BUTLER,El Dorado Ward 2 Precinct 1,Kansas Senate,14,Democratic,"Fuson, Eden",124,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,Kansas Senate,14,Republican,"Knox, Forrest J.",152,00016A
+BUTLER,El Dorado Ward 2 Precinct 2,Kansas Senate,14,Democratic,"Fuson, Eden",117,000170
+BUTLER,El Dorado Ward 2 Precinct 2,Kansas Senate,14,Republican,"Knox, Forrest J.",159,000170
+BUTLER,El Dorado Ward 2 Precinct 3,Kansas Senate,14,Democratic,"Fuson, Eden",138,000180
+BUTLER,El Dorado Ward 2 Precinct 3,Kansas Senate,14,Republican,"Knox, Forrest J.",186,000180
+BUTLER,El Dorado Ward 3 Precinct 1,Kansas Senate,14,Democratic,"Fuson, Eden",170,000190
+BUTLER,El Dorado Ward 3 Precinct 1,Kansas Senate,14,Republican,"Knox, Forrest J.",216,000190
+BUTLER,El Dorado Ward 3 Precinct 2,Kansas Senate,14,Democratic,"Fuson, Eden",109,000200
+BUTLER,El Dorado Ward 3 Precinct 2,Kansas Senate,14,Republican,"Knox, Forrest J.",160,000200
+BUTLER,El Dorado Ward 3 Precinct 3,Kansas Senate,14,Democratic,"Fuson, Eden",93,000210
+BUTLER,El Dorado Ward 3 Precinct 3,Kansas Senate,14,Republican,"Knox, Forrest J.",156,000210
+BUTLER,El Dorado Ward 4 Precinct 1,Kansas Senate,14,Democratic,"Fuson, Eden",141,000220
+BUTLER,El Dorado Ward 4 Precinct 1,Kansas Senate,14,Republican,"Knox, Forrest J.",211,000220
+BUTLER,El Dorado Ward 4 Precinct 2,Kansas Senate,14,Democratic,"Fuson, Eden",158,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,Kansas Senate,14,Republican,"Knox, Forrest J.",255,00023A
+BUTLER,El Dorado Ward 4 Precinct 3,Kansas Senate,14,Democratic,"Fuson, Eden",121,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,Kansas Senate,14,Republican,"Knox, Forrest J.",212,00023B
+BUTLER,Fairmount Township/Elbing,Kansas Senate,14,Democratic,"Fuson, Eden",49,000240
+BUTLER,Fairmount Township/Elbing,Kansas Senate,14,Republican,"Knox, Forrest J.",228,000240
+BUTLER,Fairview Township,Kansas Senate,14,Democratic,"Fuson, Eden",72,000250
+BUTLER,Fairview Township,Kansas Senate,14,Republican,"Knox, Forrest J.",170,000250
+BUTLER,Glencoe Township,Kansas Senate,14,Democratic,"Fuson, Eden",22,000260
+BUTLER,Glencoe Township,Kansas Senate,14,Republican,"Knox, Forrest J.",56,000260
+BUTLER,Hickory Township,Kansas Senate,14,Democratic,"Fuson, Eden",12,000270
+BUTLER,Hickory Township,Kansas Senate,14,Republican,"Knox, Forrest J.",40,000270
+BUTLER,Lincoln Township,Kansas Senate,14,Democratic,"Fuson, Eden",36,000280
+BUTLER,Lincoln Township,Kansas Senate,14,Republican,"Knox, Forrest J.",79,000280
+BUTLER,Little Walnut Township/Leon,Kansas Senate,14,Democratic,"Fuson, Eden",102,000290
+BUTLER,Little Walnut Township/Leon,Kansas Senate,14,Republican,"Knox, Forrest J.",219,000290
+BUTLER,Logan Township,Kansas Senate,14,Democratic,"Fuson, Eden",19,000300
+BUTLER,Logan Township,Kansas Senate,14,Republican,"Knox, Forrest J.",49,000300
+BUTLER,Murdock Township,Kansas Senate,16,Republican,"Masterson, Ty",184,000320
+BUTLER,El Dorado Township,Kansas Senate,14,Democratic,"Fuson, Eden",94,000330
+BUTLER,El Dorado Township,Kansas Senate,14,Republican,"Knox, Forrest J.",218,000330
+BUTLER,Pleasant Township,Kansas Senate,16,Republican,"Masterson, Ty",903,000340
+BUTLER,Plum Grove Township/Potwin,Kansas Senate,14,Democratic,"Fuson, Eden",81,000350
+BUTLER,Plum Grove Township/Potwin,Kansas Senate,14,Republican,"Knox, Forrest J.",172,000350
+BUTLER,Prospect Township,Kansas Senate,14,Democratic,"Fuson, Eden",172,000360
+BUTLER,Prospect Township,Kansas Senate,14,Republican,"Knox, Forrest J.",323,000360
+BUTLER,Rock Creek Township,Kansas Senate,14,Democratic,"Fuson, Eden",30,000380
+BUTLER,Rock Creek Township,Kansas Senate,14,Republican,"Knox, Forrest J.",98,000380
+BUTLER,Rosalia Township,Kansas Senate,14,Democratic,"Fuson, Eden",72,000390
+BUTLER,Rosalia Township,Kansas Senate,14,Republican,"Knox, Forrest J.",171,000390
+BUTLER,Spring Township,Kansas Senate,14,Democratic,"Fuson, Eden",185,000410
+BUTLER,Spring Township,Kansas Senate,14,Republican,"Knox, Forrest J.",446,000410
+BUTLER,Towanda Township/City,Kansas Senate,14,Democratic,"Fuson, Eden",349,000430
+BUTLER,Towanda Township/City,Kansas Senate,14,Republican,"Knox, Forrest J.",775,000430
+BUTLER,Union Township / Latham,Kansas Senate,14,Democratic,"Fuson, Eden",16,000440
+BUTLER,Union Township / Latham,Kansas Senate,14,Republican,"Knox, Forrest J.",55,000440
+BUTLER,Walnut Township,Kansas Senate,14,Democratic,"Fuson, Eden",91,000450
+BUTLER,Walnut Township,Kansas Senate,14,Republican,"Knox, Forrest J.",197,000450
+BUTLER,Andover South H77,Kansas Senate,16,Republican,"Masterson, Ty",117,120020
+BUTLER,Andover South H99,Kansas Senate,16,Republican,"Masterson, Ty",2077,120030
+BUTLER,Augusta Township S14,Kansas Senate,14,Democratic,"Fuson, Eden",52,120040
+BUTLER,Augusta Township S14,Kansas Senate,14,Republican,"Knox, Forrest J.",104,120040
+BUTLER,Augusta Township S16,Kansas Senate,16,Republican,"Masterson, Ty",347,120050
+BUTLER,Bruno Township H77,Kansas Senate,16,Republican,"Masterson, Ty",572,120060
+BUTLER,Bruno Township H99,Kansas Senate,16,Republican,"Masterson, Ty",369,120070
+BUTLER,Whitewater / Milton Township H72,Kansas Senate,16,Republican,"Masterson, Ty",275,120080
+BUTLER,Whitewater / Milton Township H75,Kansas Senate,16,Republican,"Masterson, Ty",193,120090
+BUTLER,Rose Hill City,Kansas Senate,16,Republican,"Masterson, Ty",1372,200010
+BUTLER,Richland Township H77,Kansas Senate,16,Republican,"Masterson, Ty",453,800040
+BUTLER,Chelsea Township,Kansas Senate,14,Democratic,"Fuson, Eden",36,800050
+BUTLER,Chelsea Township,Kansas Senate,14,Republican,"Knox, Forrest J.",59,800050
+BUTLER,Andover North,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Ayers, Avery L",0,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Barnett, Andre",0,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Barr, Roseanne C",0,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Bush, Kent W",1,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Christensen, Will",0,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Duncan, Richard A",0,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Goode, Virgil",0,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Hoefling, Tom",0,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Knill, Dennis J",0,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Reed, Jill A.",0,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Rogers, Rick L",0,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Stein, Jill E",0,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Thorne, Kevin M",0,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00001A
+BUTLER,Andover North,President / Vice President,,write - in,"Warner, Gerald L.",0,00001A
+BUTLER,Andover North,President / Vice President,,Democratic,"Obama, Barack",583,00001A
+BUTLER,Andover North,President / Vice President,,Libertarian,"Johnson, Gary",31,00001A
+BUTLER,Andover North,President / Vice President,,Reform,"Baldwin, Chuck",5,00001A
+BUTLER,Andover North,President / Vice President,,Republican,"Romney, Mitt",1529,00001A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Bush, Kent W",6,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Christensen, Will",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,Democratic,"Obama, Barack",183,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",17,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,Republican,"Romney, Mitt",357,00002A
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Bush, Kent W",7,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,Democratic,"Obama, Barack",267,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",10,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",5,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,Republican,"Romney, Mitt",486,000030
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Bush, Kent W",7,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,Democratic,"Obama, Barack",304,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",24,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",3,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,Republican,"Romney, Mitt",564,00004A
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Bush, Kent W",15,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,Democratic,"Obama, Barack",335,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",12,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",2,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,Republican,"Romney, Mitt",844,000050
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Barnett, Andre",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Bush, Kent W",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Christensen, Will",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Goode, Virgil",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Stein, Jill E",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+BUTLER,Benton Township / City,President / Vice President,,Democratic,"Obama, Barack",268,000070
+BUTLER,Benton Township / City,President / Vice President,,Libertarian,"Johnson, Gary",24,000070
+BUTLER,Benton Township / City,President / Vice President,,Reform,"Baldwin, Chuck",7,000070
+BUTLER,Benton Township / City,President / Vice President,,Republican,"Romney, Mitt",869,000070
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Barr, Roseanne C",1,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+BUTLER,Bloomington Township,President / Vice President,,Democratic,"Obama, Barack",54,000080
+BUTLER,Bloomington Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000080
+BUTLER,Bloomington Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000080
+BUTLER,Bloomington Township,President / Vice President,,Republican,"Romney, Mitt",154,000080
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Barnett, Andre",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Bush, Kent W",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Christensen, Will",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Goode, Virgil",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Stein, Jill E",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,Democratic,"Obama, Barack",32,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,Libertarian,"Johnson, Gary",4,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,Republican,"Romney, Mitt",128,000100
+BUTLER,Clay Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+BUTLER,Clay Township,President / Vice President,,Democratic,"Obama, Barack",13,000110
+BUTLER,Clay Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000110
+BUTLER,Clay Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+BUTLER,Clay Township,President / Vice President,,Republican,"Romney, Mitt",29,000110
+BUTLER,Clifford Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+BUTLER,Clifford Township,President / Vice President,,Democratic,"Obama, Barack",24,000120
+BUTLER,Clifford Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+BUTLER,Clifford Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+BUTLER,Clifford Township,President / Vice President,,Republican,"Romney, Mitt",86,000120
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Barnett, Andre",2,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Bush, Kent W",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Christensen, Will",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Goode, Virgil",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Stein, Jill E",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,Democratic,"Obama, Barack",213,000130
+BUTLER,Douglass Township/City,President / Vice President,,Libertarian,"Johnson, Gary",11,000130
+BUTLER,Douglass Township/City,President / Vice President,,Reform,"Baldwin, Chuck",9,000130
+BUTLER,Douglass Township/City,President / Vice President,,Republican,"Romney, Mitt",573,000130
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",1,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",118,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",5,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",123,00014A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",367,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",16,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",962,00015A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",1,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",123,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",10,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",161,00016A
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",2,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",103,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",5,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",179,000170
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",137,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",9,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",188,000180
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",161,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",230,000190
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",110,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",4,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",160,000200
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",1,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",94,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",6,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",159,000210
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",132,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",10,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",223,000220
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",1,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",167,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",5,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",260,00023A
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",117,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",11,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",1,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",222,00023B
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Barnett, Andre",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Bush, Kent W",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Christensen, Will",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Goode, Virgil",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Stein, Jill E",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,Democratic,"Obama, Barack",54,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,Libertarian,"Johnson, Gary",2,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,Reform,"Baldwin, Chuck",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,Republican,"Romney, Mitt",231,000240
+BUTLER,Fairview Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+BUTLER,Fairview Township,President / Vice President,,Democratic,"Obama, Barack",59,000250
+BUTLER,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000250
+BUTLER,Fairview Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000250
+BUTLER,Fairview Township,President / Vice President,,Republican,"Romney, Mitt",185,000250
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Barnett, Andre",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Bush, Kent W",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Christensen, Will",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Goode, Virgil",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Stein, Jill E",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+BUTLER,Glencoe Township,President / Vice President,,Democratic,"Obama, Barack",29,000260
+BUTLER,Glencoe Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+BUTLER,Glencoe Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000260
+BUTLER,Glencoe Township,President / Vice President,,Republican,"Romney, Mitt",49,000260
+BUTLER,Hickory Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Barnett, Andre",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Bush, Kent W",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Christensen, Will",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Goode, Virgil",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Stein, Jill E",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+BUTLER,Hickory Township,President / Vice President,,Democratic,"Obama, Barack",10,000270
+BUTLER,Hickory Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000270
+BUTLER,Hickory Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000270
+BUTLER,Hickory Township,President / Vice President,,Republican,"Romney, Mitt",41,000270
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+BUTLER,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",30,000280
+BUTLER,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000280
+BUTLER,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000280
+BUTLER,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",86,000280
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Barnett, Andre",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Bush, Kent W",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Christensen, Will",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Goode, Virgil",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Stein, Jill E",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,Democratic,"Obama, Barack",102,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,Libertarian,"Johnson, Gary",8,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,Reform,"Baldwin, Chuck",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,Republican,"Romney, Mitt",217,000290
+BUTLER,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+BUTLER,Logan Township,President / Vice President,,Democratic,"Obama, Barack",17,000300
+BUTLER,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000300
+BUTLER,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000300
+BUTLER,Logan Township,President / Vice President,,Republican,"Romney, Mitt",52,000300
+BUTLER,Murdock Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Barnett, Andre",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Bush, Kent W",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Christensen, Will",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Goode, Virgil",1,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Stein, Jill E",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+BUTLER,Murdock Township,President / Vice President,,Democratic,"Obama, Barack",37,000320
+BUTLER,Murdock Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000320
+BUTLER,Murdock Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000320
+BUTLER,Murdock Township,President / Vice President,,Republican,"Romney, Mitt",167,000320
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Ayers, Avery L",0,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Barnett, Andre",0,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Bush, Kent W",1,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Christensen, Will",0,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Duncan, Richard A",0,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Goode, Virgil",0,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Knill, Dennis J",0,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Reed, Jill A.",0,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Rogers, Rick L",0,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Stein, Jill E",0,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000330
+BUTLER,El Dorado Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000330
+BUTLER,El Dorado Township,President / Vice President,,Democratic,"Obama, Barack",86,000330
+BUTLER,El Dorado Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000330
+BUTLER,El Dorado Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000330
+BUTLER,El Dorado Township,President / Vice President,,Republican,"Romney, Mitt",221,000330
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Barnett, Andre",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Bush, Kent W",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Christensen, Will",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Goode, Virgil",8,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Stein, Jill E",1,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000340
+BUTLER,Pleasant Township,President / Vice President,,Democratic,"Obama, Barack",265,000340
+BUTLER,Pleasant Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000340
+BUTLER,Pleasant Township,President / Vice President,,Reform,"Baldwin, Chuck",7,000340
+BUTLER,Pleasant Township,President / Vice President,,Republican,"Romney, Mitt",803,000340
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Ayers, Avery L",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Barnett, Andre",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Barr, Roseanne C",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Bush, Kent W",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Christensen, Will",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Duncan, Richard A",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Goode, Virgil",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Knill, Dennis J",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Reed, Jill A.",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Rogers, Rick L",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Stein, Jill E",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Thorne, Kevin M",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Warner, Gerald L.",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,Democratic,"Obama, Barack",92,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,Libertarian,"Johnson, Gary",4,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,Reform,"Baldwin, Chuck",2,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,Republican,"Romney, Mitt",162,000350
+BUTLER,Prospect Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Ayers, Avery L",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Barnett, Andre",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Barr, Roseanne C",1,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Bush, Kent W",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Christensen, Will",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Duncan, Richard A",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Goode, Virgil",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Knill, Dennis J",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Reed, Jill A.",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Rogers, Rick L",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Stein, Jill E",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000360
+BUTLER,Prospect Township,President / Vice President,,Democratic,"Obama, Barack",162,000360
+BUTLER,Prospect Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000360
+BUTLER,Prospect Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000360
+BUTLER,Prospect Township,President / Vice President,,Republican,"Romney, Mitt",344,000360
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,Democratic,"Obama, Barack",34,000380
+BUTLER,Rock Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000380
+BUTLER,Rock Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,Republican,"Romney, Mitt",100,000380
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",2,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Ayers, Avery L",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Barnett, Andre",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Bush, Kent W",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Christensen, Will",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Duncan, Richard A",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Goode, Virgil",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Knill, Dennis J",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Reed, Jill A.",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Rogers, Rick L",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Stein, Jill E",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000390
+BUTLER,Rosalia Township,President / Vice President,,Democratic,"Obama, Barack",67,000390
+BUTLER,Rosalia Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000390
+BUTLER,Rosalia Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000390
+BUTLER,Rosalia Township,President / Vice President,,Republican,"Romney, Mitt",180,000390
+BUTLER,Spring Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Ayers, Avery L",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Barnett, Andre",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Bush, Kent W",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Christensen, Will",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Duncan, Richard A",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Goode, Virgil",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Hoefling, Tom",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Knill, Dennis J",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Reed, Jill A.",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Rogers, Rick L",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Stein, Jill E",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000410
+BUTLER,Spring Township,President / Vice President,,Democratic,"Obama, Barack",186,000410
+BUTLER,Spring Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000410
+BUTLER,Spring Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000410
+BUTLER,Spring Township,President / Vice President,,Republican,"Romney, Mitt",459,000410
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Ayers, Avery L",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Barnett, Andre",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Barr, Roseanne C",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Bush, Kent W",1,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Christensen, Will",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Duncan, Richard A",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Goode, Virgil",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Hoefling, Tom",1,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Knill, Dennis J",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Reed, Jill A.",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Rogers, Rick L",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Stein, Jill E",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Thorne, Kevin M",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Warner, Gerald L.",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,Democratic,"Obama, Barack",287,000430
+BUTLER,Towanda Township/City,President / Vice President,,Libertarian,"Johnson, Gary",28,000430
+BUTLER,Towanda Township/City,President / Vice President,,Reform,"Baldwin, Chuck",5,000430
+BUTLER,Towanda Township/City,President / Vice President,,Republican,"Romney, Mitt",861,000430
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Ayers, Avery L",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Barnett, Andre",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Barr, Roseanne C",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Bush, Kent W",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Christensen, Will",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Duncan, Richard A",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Goode, Virgil",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Hoefling, Tom",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Knill, Dennis J",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Reed, Jill A.",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Rogers, Rick L",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Stein, Jill E",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Thorne, Kevin M",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Warner, Gerald L.",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,Democratic,"Obama, Barack",14,000440
+BUTLER,Union Township / Latham,President / Vice President,,Libertarian,"Johnson, Gary",3,000440
+BUTLER,Union Township / Latham,President / Vice President,,Reform,"Baldwin, Chuck",2,000440
+BUTLER,Union Township / Latham,President / Vice President,,Republican,"Romney, Mitt",56,000440
+BUTLER,Walnut Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Ayers, Avery L",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Barnett, Andre",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Bush, Kent W",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Christensen, Will",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Duncan, Richard A",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Goode, Virgil",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Knill, Dennis J",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Reed, Jill A.",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Rogers, Rick L",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Stein, Jill E",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000450
+BUTLER,Walnut Township,President / Vice President,,Democratic,"Obama, Barack",76,000450
+BUTLER,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000450
+BUTLER,Walnut Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000450
+BUTLER,Walnut Township,President / Vice President,,Republican,"Romney, Mitt",219,000450
+BUTLER,Andover South H77,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Barnett, Andre",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Bush, Kent W",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Christensen, Will",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Goode, Virgil",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Stein, Jill E",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+BUTLER,Andover South H77,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+BUTLER,Andover South H77,President / Vice President,,Democratic,"Obama, Barack",23,120020
+BUTLER,Andover South H77,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+BUTLER,Andover South H77,President / Vice President,,Reform,"Baldwin, Chuck",2,120020
+BUTLER,Andover South H77,President / Vice President,,Republican,"Romney, Mitt",117,120020
+BUTLER,Andover South H99,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Barnett, Andre",0,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Bush, Kent W",1,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Christensen, Will",0,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Goode, Virgil",0,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Stein, Jill E",0,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+BUTLER,Andover South H99,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+BUTLER,Andover South H99,President / Vice President,,Democratic,"Obama, Barack",685,120030
+BUTLER,Andover South H99,President / Vice President,,Libertarian,"Johnson, Gary",42,120030
+BUTLER,Andover South H99,President / Vice President,,Reform,"Baldwin, Chuck",6,120030
+BUTLER,Andover South H99,President / Vice President,,Republican,"Romney, Mitt",1804,120030
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Barnett, Andre",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Bush, Kent W",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Christensen, Will",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Goode, Virgil",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Stein, Jill E",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,Democratic,"Obama, Barack",52,120040
+BUTLER,Augusta Township S14,President / Vice President,,Libertarian,"Johnson, Gary",3,120040
+BUTLER,Augusta Township S14,President / Vice President,,Reform,"Baldwin, Chuck",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,Republican,"Romney, Mitt",114,120040
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Barnett, Andre",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Bush, Kent W",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Christensen, Will",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Goode, Virgil",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Stein, Jill E",1,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,Democratic,"Obama, Barack",77,120050
+BUTLER,Augusta Township S16,President / Vice President,,Libertarian,"Johnson, Gary",5,120050
+BUTLER,Augusta Township S16,President / Vice President,,Reform,"Baldwin, Chuck",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,Republican,"Romney, Mitt",312,120050
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Ayers, Avery L",0,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Barnett, Andre",0,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Barr, Roseanne C",0,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Bush, Kent W",0,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Christensen, Will",0,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Duncan, Richard A",0,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Goode, Virgil",2,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Knill, Dennis J",0,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Reed, Jill A.",0,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Rogers, Rick L",0,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Stein, Jill E",1,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Thorne, Kevin M",0,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120060
+BUTLER,Bruno Township H77,President / Vice President,,write - in,"Warner, Gerald L.",0,120060
+BUTLER,Bruno Township H77,President / Vice President,,Democratic,"Obama, Barack",131,120060
+BUTLER,Bruno Township H77,President / Vice President,,Libertarian,"Johnson, Gary",15,120060
+BUTLER,Bruno Township H77,President / Vice President,,Reform,"Baldwin, Chuck",1,120060
+BUTLER,Bruno Township H77,President / Vice President,,Republican,"Romney, Mitt",502,120060
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Ayers, Avery L",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Barnett, Andre",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Barr, Roseanne C",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Bush, Kent W",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Christensen, Will",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Duncan, Richard A",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Goode, Virgil",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Knill, Dennis J",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Reed, Jill A.",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Rogers, Rick L",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Stein, Jill E",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Thorne, Kevin M",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,write - in,"Warner, Gerald L.",0,120070
+BUTLER,Bruno Township H99,President / Vice President,,Democratic,"Obama, Barack",114,120070
+BUTLER,Bruno Township H99,President / Vice President,,Libertarian,"Johnson, Gary",8,120070
+BUTLER,Bruno Township H99,President / Vice President,,Reform,"Baldwin, Chuck",3,120070
+BUTLER,Bruno Township H99,President / Vice President,,Republican,"Romney, Mitt",334,120070
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Ayers, Avery L",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Barnett, Andre",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Barr, Roseanne C",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Bush, Kent W",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Christensen, Will",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Duncan, Richard A",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Goode, Virgil",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Knill, Dennis J",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Reed, Jill A.",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Rogers, Rick L",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Stein, Jill E",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Thorne, Kevin M",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Warner, Gerald L.",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,Democratic,"Obama, Barack",65,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,Libertarian,"Johnson, Gary",4,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,Reform,"Baldwin, Chuck",3,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,Republican,"Romney, Mitt",250,120080
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Ayers, Avery L",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Barnett, Andre",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Barr, Roseanne C",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Bush, Kent W",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Christensen, Will",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Duncan, Richard A",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Goode, Virgil",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Knill, Dennis J",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Reed, Jill A.",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Rogers, Rick L",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Stein, Jill E",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Thorne, Kevin M",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Warner, Gerald L.",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,Democratic,"Obama, Barack",36,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,Libertarian,"Johnson, Gary",1,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,Reform,"Baldwin, Chuck",7,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,Republican,"Romney, Mitt",179,120090
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Ayers, Avery L",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Barnett, Andre",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Barr, Roseanne C",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Bush, Kent W",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Christensen, Will",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Duncan, Richard A",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Goode, Virgil",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Hoefling, Tom",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Knill, Dennis J",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Reed, Jill A.",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Rogers, Rick L",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Stein, Jill E",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Thorne, Kevin M",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Warner, Gerald L.",0,200010
+BUTLER,Rose Hill City,President / Vice President,,Democratic,"Obama, Barack",434,200010
+BUTLER,Rose Hill City,President / Vice President,,Libertarian,"Johnson, Gary",32,200010
+BUTLER,Rose Hill City,President / Vice President,,Reform,"Baldwin, Chuck",8,200010
+BUTLER,Rose Hill City,President / Vice President,,Republican,"Romney, Mitt",1149,200010
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Ayers, Avery L",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Barnett, Andre",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Barr, Roseanne C",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Bush, Kent W",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Christensen, Will",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Duncan, Richard A",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Goode, Virgil",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Hoefling, Tom",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Knill, Dennis J",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Reed, Jill A.",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Rogers, Rick L",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Stein, Jill E",1,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Thorne, Kevin M",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Warner, Gerald L.",0,800040
+BUTLER,Richland Township H77,President / Vice President,,Democratic,"Obama, Barack",122,800040
+BUTLER,Richland Township H77,President / Vice President,,Libertarian,"Johnson, Gary",3,800040
+BUTLER,Richland Township H77,President / Vice President,,Reform,"Baldwin, Chuck",1,800040
+BUTLER,Richland Township H77,President / Vice President,,Republican,"Romney, Mitt",411,800040
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Ayers, Avery L",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Barnett, Andre",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Barr, Roseanne C",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Bush, Kent W",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Christensen, Will",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Duncan, Richard A",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Goode, Virgil",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Hoefling, Tom",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Knill, Dennis J",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Reed, Jill A.",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Rogers, Rick L",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Stein, Jill E",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Thorne, Kevin M",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Warner, Gerald L.",0,800050
+BUTLER,Chelsea Township,President / Vice President,,Democratic,"Obama, Barack",31,800050
+BUTLER,Chelsea Township,President / Vice President,,Libertarian,"Johnson, Gary",1,800050
+BUTLER,Chelsea Township,President / Vice President,,Reform,"Baldwin, Chuck",1,800050
+BUTLER,Chelsea Township,President / Vice President,,Republican,"Romney, Mitt",66,800050
+BUTLER,Andover North,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",494,00001A
+BUTLER,Andover North,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",115,00001A
+BUTLER,Andover North,United States House of Representatives,4,Republican,"Pompeo, Mike",1505,00001A
+BUTLER,Augusta City Ward 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",141,00002A
+BUTLER,Augusta City Ward 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",40,00002A
+BUTLER,Augusta City Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",370,00002A
+BUTLER,Augusta City Ward 1 Exclave A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00002B
+BUTLER,Augusta City Ward 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",221,000030
+BUTLER,Augusta City Ward 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",56,000030
+BUTLER,Augusta City Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",484,000030
+BUTLER,Augusta City Ward 3,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",259,00004A
+BUTLER,Augusta City Ward 3,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",58,00004A
+BUTLER,Augusta City Ward 3,United States House of Representatives,4,Republican,"Pompeo, Mike",562,00004A
+BUTLER,Augusta City Ward 3 Exclave,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00004B
+BUTLER,Augusta City Ward 4,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",282,000050
+BUTLER,Augusta City Ward 4,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",56,000050
+BUTLER,Augusta City Ward 4,United States House of Representatives,4,Republican,"Pompeo, Mike",841,000050
+BUTLER,Benton Township / City,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",227,000070
+BUTLER,Benton Township / City,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",48,000070
+BUTLER,Benton Township / City,United States House of Representatives,4,Republican,"Pompeo, Mike",881,000070
+BUTLER,Bloomington Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",50,000080
+BUTLER,Bloomington Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",17,000080
+BUTLER,Bloomington Township,United States House of Representatives,4,Republican,"Pompeo, Mike",150,000080
+BUTLER,Sycamore/Cassoday,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",29,000100
+BUTLER,Sycamore/Cassoday,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",7,000100
+BUTLER,Sycamore/Cassoday,United States House of Representatives,4,Republican,"Pompeo, Mike",124,000100
+BUTLER,Clay Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",14,000110
+BUTLER,Clay Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000110
+BUTLER,Clay Township,United States House of Representatives,4,Republican,"Pompeo, Mike",27,000110
+BUTLER,Clifford Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",19,000120
+BUTLER,Clifford Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000120
+BUTLER,Clifford Township,United States House of Representatives,4,Republican,"Pompeo, Mike",84,000120
+BUTLER,Douglass Township/City,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",186,000130
+BUTLER,Douglass Township/City,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",59,000130
+BUTLER,Douglass Township/City,United States House of Representatives,4,Republican,"Pompeo, Mike",547,000130
+BUTLER,El Dorado Ward 1 Precinct 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",102,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",19,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",121,00014A
+BUTLER,El Dorado Ward 1 Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",322,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",49,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",952,00015A
+BUTLER,El Dorado Ward 2 Precinct 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",104,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",21,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",159,00016A
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",83,000170
+BUTLER,El Dorado Ward 2 Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",25,000170
+BUTLER,El Dorado Ward 2 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",179,000170
+BUTLER,El Dorado Ward 2 Precinct 3,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",123,000180
+BUTLER,El Dorado Ward 2 Precinct 3,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",27,000180
+BUTLER,El Dorado Ward 2 Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Mike",182,000180
+BUTLER,El Dorado Ward 3 Precinct 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",139,000190
+BUTLER,El Dorado Ward 3 Precinct 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",28,000190
+BUTLER,El Dorado Ward 3 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",226,000190
+BUTLER,El Dorado Ward 3 Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",90,000200
+BUTLER,El Dorado Ward 3 Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",17,000200
+BUTLER,El Dorado Ward 3 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",163,000200
+BUTLER,El Dorado Ward 3 Precinct 3,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",73,000210
+BUTLER,El Dorado Ward 3 Precinct 3,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",16,000210
+BUTLER,El Dorado Ward 3 Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Mike",163,000210
+BUTLER,El Dorado Ward 4 Precinct 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",119,000220
+BUTLER,El Dorado Ward 4 Precinct 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",21,000220
+BUTLER,El Dorado Ward 4 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",221,000220
+BUTLER,El Dorado Ward 4 Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",146,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",18,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",260,00023A
+BUTLER,El Dorado Ward 4 Precinct 3,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",95,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",29,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Mike",218,00023B
+BUTLER,Fairmount Township/Elbing,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",42,000240
+BUTLER,Fairmount Township/Elbing,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",12,000240
+BUTLER,Fairmount Township/Elbing,United States House of Representatives,4,Republican,"Pompeo, Mike",232,000240
+BUTLER,Fairview Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",53,000250
+BUTLER,Fairview Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",19,000250
+BUTLER,Fairview Township,United States House of Representatives,4,Republican,"Pompeo, Mike",180,000250
+BUTLER,Glencoe Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",26,000260
+BUTLER,Glencoe Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000260
+BUTLER,Glencoe Township,United States House of Representatives,4,Republican,"Pompeo, Mike",50,000260
+BUTLER,Hickory Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",13,000270
+BUTLER,Hickory Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,000270
+BUTLER,Hickory Township,United States House of Representatives,4,Republican,"Pompeo, Mike",35,000270
+BUTLER,Lincoln Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",25,000280
+BUTLER,Lincoln Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000280
+BUTLER,Lincoln Township,United States House of Representatives,4,Republican,"Pompeo, Mike",89,000280
+BUTLER,Little Walnut Township/Leon,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",84,000290
+BUTLER,Little Walnut Township/Leon,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",23,000290
+BUTLER,Little Walnut Township/Leon,United States House of Representatives,4,Republican,"Pompeo, Mike",212,000290
+BUTLER,Logan Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",15,000300
+BUTLER,Logan Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,000300
+BUTLER,Logan Township,United States House of Representatives,4,Republican,"Pompeo, Mike",48,000300
+BUTLER,Murdock Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",36,000320
+BUTLER,Murdock Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000320
+BUTLER,Murdock Township,United States House of Representatives,4,Republican,"Pompeo, Mike",163,000320
+BUTLER,El Dorado Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",81,000330
+BUTLER,El Dorado Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",18,000330
+BUTLER,El Dorado Township,United States House of Representatives,4,Republican,"Pompeo, Mike",215,000330
+BUTLER,Pleasant Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",233,000340
+BUTLER,Pleasant Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",69,000340
+BUTLER,Pleasant Township,United States House of Representatives,4,Republican,"Pompeo, Mike",778,000340
+BUTLER,Plum Grove Township/Potwin,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",74,000350
+BUTLER,Plum Grove Township/Potwin,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",16,000350
+BUTLER,Plum Grove Township/Potwin,United States House of Representatives,4,Republican,"Pompeo, Mike",166,000350
+BUTLER,Prospect Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",138,000360
+BUTLER,Prospect Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",32,000360
+BUTLER,Prospect Township,United States House of Representatives,4,Republican,"Pompeo, Mike",338,000360
+BUTLER,Rock Creek Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",32,000380
+BUTLER,Rock Creek Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000380
+BUTLER,Rock Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",98,000380
+BUTLER,Rosalia Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",62,000390
+BUTLER,Rosalia Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",14,000390
+BUTLER,Rosalia Township,United States House of Representatives,4,Republican,"Pompeo, Mike",169,000390
+BUTLER,Spring Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",175,000410
+BUTLER,Spring Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",29,000410
+BUTLER,Spring Township,United States House of Representatives,4,Republican,"Pompeo, Mike",434,000410
+BUTLER,Towanda Township/City,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",256,000430
+BUTLER,Towanda Township/City,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",74,000430
+BUTLER,Towanda Township/City,United States House of Representatives,4,Republican,"Pompeo, Mike",828,000430
+BUTLER,Union Township / Latham,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",17,000440
+BUTLER,Union Township / Latham,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",9,000440
+BUTLER,Union Township / Latham,United States House of Representatives,4,Republican,"Pompeo, Mike",46,000440
+BUTLER,Walnut Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",64,000450
+BUTLER,Walnut Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",17,000450
+BUTLER,Walnut Township,United States House of Representatives,4,Republican,"Pompeo, Mike",217,000450
+BUTLER,Andover South H77,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",20,120020
+BUTLER,Andover South H77,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,120020
+BUTLER,Andover South H77,United States House of Representatives,4,Republican,"Pompeo, Mike",116,120020
+BUTLER,Andover South H99,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",570,120030
+BUTLER,Andover South H99,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",140,120030
+BUTLER,Andover South H99,United States House of Representatives,4,Republican,"Pompeo, Mike",1781,120030
+BUTLER,Augusta Township S14,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",42,120040
+BUTLER,Augusta Township S14,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",9,120040
+BUTLER,Augusta Township S14,United States House of Representatives,4,Republican,"Pompeo, Mike",116,120040
+BUTLER,Augusta Township S16,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",74,120050
+BUTLER,Augusta Township S16,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",25,120050
+BUTLER,Augusta Township S16,United States House of Representatives,4,Republican,"Pompeo, Mike",290,120050
+BUTLER,Bruno Township H77,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",107,120060
+BUTLER,Bruno Township H77,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",37,120060
+BUTLER,Bruno Township H77,United States House of Representatives,4,Republican,"Pompeo, Mike",505,120060
+BUTLER,Bruno Township H99,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",87,120070
+BUTLER,Bruno Township H99,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",45,120070
+BUTLER,Bruno Township H99,United States House of Representatives,4,Republican,"Pompeo, Mike",310,120070
+BUTLER,Whitewater / Milton Township H72,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",54,120080
+BUTLER,Whitewater / Milton Township H72,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",19,120080
+BUTLER,Whitewater / Milton Township H72,United States House of Representatives,4,Republican,"Pompeo, Mike",243,120080
+BUTLER,Whitewater / Milton Township H75,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",38,120090
+BUTLER,Whitewater / Milton Township H75,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",15,120090
+BUTLER,Whitewater / Milton Township H75,United States House of Representatives,4,Republican,"Pompeo, Mike",170,120090
+BUTLER,Rose Hill City,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",338,200010
+BUTLER,Rose Hill City,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",108,200010
+BUTLER,Rose Hill City,United States House of Representatives,4,Republican,"Pompeo, Mike",1139,200010
+BUTLER,Richland Township H77,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",111,800040
+BUTLER,Richland Township H77,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",27,800040
+BUTLER,Richland Township H77,United States House of Representatives,4,Republican,"Pompeo, Mike",393,800040
+BUTLER,Chelsea Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",27,800050
+BUTLER,Chelsea Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",12,800050
+BUTLER,Chelsea Township,United States House of Representatives,4,Republican,"Pompeo, Mike",61,800050

--- a/2012/20121106__ks__general__chase__precinct.csv
+++ b/2012/20121106__ks__general__chase__precinct.csv
@@ -1,0 +1,265 @@
+county,precinct,office,district,party,candidate,votes,vtd
+CHASE,Bazaar Township,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",32,000010
+CHASE,Cedar Township,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",43,000020
+CHASE,Cottonwood Township,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",45,000030
+CHASE,Diamond Township,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",105,000040
+CHASE,East Falls Township,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",168,000050
+CHASE,East Strong Township,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",178,000060
+CHASE,Homestead Township,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",20,000070
+CHASE,Matfield Township,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",49,000080
+CHASE,Toledo Township,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",136,000090
+CHASE,West Falls Township,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",215,000100
+CHASE,West Strong Township,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",56,000110
+CHASE,Bazaar Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",10,000010
+CHASE,Bazaar Township,Kansas Senate,35,Republican,"Emler, Jay Scott",25,000010
+CHASE,Cedar Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",20,000020
+CHASE,Cedar Township,Kansas Senate,35,Republican,"Emler, Jay Scott",28,000020
+CHASE,Cottonwood Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",28,000030
+CHASE,Cottonwood Township,Kansas Senate,35,Republican,"Emler, Jay Scott",33,000030
+CHASE,Diamond Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",29,000040
+CHASE,Diamond Township,Kansas Senate,35,Republican,"Emler, Jay Scott",79,000040
+CHASE,East Falls Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",47,000050
+CHASE,East Falls Township,Kansas Senate,35,Republican,"Emler, Jay Scott",130,000050
+CHASE,East Strong Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",56,000060
+CHASE,East Strong Township,Kansas Senate,35,Republican,"Emler, Jay Scott",132,000060
+CHASE,Homestead Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",4,000070
+CHASE,Homestead Township,Kansas Senate,35,Republican,"Emler, Jay Scott",18,000070
+CHASE,Matfield Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",19,000080
+CHASE,Matfield Township,Kansas Senate,35,Republican,"Emler, Jay Scott",35,000080
+CHASE,Toledo Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",43,000090
+CHASE,Toledo Township,Kansas Senate,35,Republican,"Emler, Jay Scott",98,000090
+CHASE,West Falls Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",58,000100
+CHASE,West Falls Township,Kansas Senate,35,Republican,"Emler, Jay Scott",156,000100
+CHASE,West Strong Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",17,000110
+CHASE,West Strong Township,Kansas Senate,35,Republican,"Emler, Jay Scott",44,000110
+CHASE,Bazaar Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+CHASE,Bazaar Township,President / Vice President,,Democratic,"Obama, Barack",5,000010
+CHASE,Bazaar Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+CHASE,Bazaar Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+CHASE,Bazaar Township,President / Vice President,,Republican,"Romney, Mitt",36,000010
+CHASE,Cedar Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+CHASE,Cedar Township,President / Vice President,,Democratic,"Obama, Barack",11,000020
+CHASE,Cedar Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+CHASE,Cedar Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+CHASE,Cedar Township,President / Vice President,,Republican,"Romney, Mitt",41,000020
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Stein, Jill E",1,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+CHASE,Cottonwood Township,President / Vice President,,Democratic,"Obama, Barack",20,000030
+CHASE,Cottonwood Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+CHASE,Cottonwood Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+CHASE,Cottonwood Township,President / Vice President,,Republican,"Romney, Mitt",45,000030
+CHASE,Diamond Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+CHASE,Diamond Township,President / Vice President,,Democratic,"Obama, Barack",19,000040
+CHASE,Diamond Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+CHASE,Diamond Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+CHASE,Diamond Township,President / Vice President,,Republican,"Romney, Mitt",102,000040
+CHASE,East Falls Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Goode, Virgil",1,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+CHASE,East Falls Township,President / Vice President,,Democratic,"Obama, Barack",36,000050
+CHASE,East Falls Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000050
+CHASE,East Falls Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000050
+CHASE,East Falls Township,President / Vice President,,Republican,"Romney, Mitt",156,000050
+CHASE,East Strong Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+CHASE,East Strong Township,President / Vice President,,Democratic,"Obama, Barack",73,000060
+CHASE,East Strong Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000060
+CHASE,East Strong Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000060
+CHASE,East Strong Township,President / Vice President,,Republican,"Romney, Mitt",128,000060
+CHASE,Homestead Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+CHASE,Homestead Township,President / Vice President,,Democratic,"Obama, Barack",8,000070
+CHASE,Homestead Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+CHASE,Homestead Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+CHASE,Homestead Township,President / Vice President,,Republican,"Romney, Mitt",18,000070
+CHASE,Matfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+CHASE,Matfield Township,President / Vice President,,Democratic,"Obama, Barack",21,000080
+CHASE,Matfield Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+CHASE,Matfield Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+CHASE,Matfield Township,President / Vice President,,Republican,"Romney, Mitt",48,000080
+CHASE,Toledo Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+CHASE,Toledo Township,President / Vice President,,Democratic,"Obama, Barack",47,000090
+CHASE,Toledo Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000090
+CHASE,Toledo Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+CHASE,Toledo Township,President / Vice President,,Republican,"Romney, Mitt",110,000090
+CHASE,West Falls Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+CHASE,West Falls Township,President / Vice President,,Democratic,"Obama, Barack",93,000100
+CHASE,West Falls Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+CHASE,West Falls Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000100
+CHASE,West Falls Township,President / Vice President,,Republican,"Romney, Mitt",151,000100
+CHASE,West Strong Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+CHASE,West Strong Township,President / Vice President,,Democratic,"Obama, Barack",25,000110
+CHASE,West Strong Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+CHASE,West Strong Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+CHASE,West Strong Township,President / Vice President,,Republican,"Romney, Mitt",40,000110
+CHASE,Bazaar Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000010
+CHASE,Cedar Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000020
+CHASE,Cottonwood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000030
+CHASE,Diamond Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",103,000040
+CHASE,East Falls Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",164,000050
+CHASE,East Strong Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",167,000060
+CHASE,Homestead Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000070
+CHASE,Matfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000080
+CHASE,Toledo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000090
+CHASE,West Falls Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",89,000100
+CHASE,West Strong Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",50,000110

--- a/2012/20121106__ks__general__chautauqua__precinct.csv
+++ b/2012/20121106__ks__general__chautauqua__precinct.csv
@@ -1,0 +1,379 @@
+county,precinct,office,district,party,candidate,votes,vtd
+CHAUTAUQUA,Caneyville Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",12,000010
+CHAUTAUQUA,Caneyville Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",34,000010
+CHAUTAUQUA,Center Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",12,000020
+CHAUTAUQUA,Center Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",23,000020
+CHAUTAUQUA,Chautauqua,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",24,000030
+CHAUTAUQUA,Chautauqua,Kansas House of Representatives,12,Republican,"Peck, Virgil",95,000030
+CHAUTAUQUA,Harrison Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",11,000040
+CHAUTAUQUA,Harrison Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",31,000040
+CHAUTAUQUA,Hendricks Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",21,000050
+CHAUTAUQUA,Hendricks Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",22,000050
+CHAUTAUQUA,Jefferson Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",99,000060
+CHAUTAUQUA,Jefferson Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",163,000060
+CHAUTAUQUA,Lafayette Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",8,000070
+CHAUTAUQUA,Lafayette Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",15,000070
+CHAUTAUQUA,Little Caney Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",39,000080
+CHAUTAUQUA,Little Caney Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",82,000080
+CHAUTAUQUA,North Sedan,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",136,000090
+CHAUTAUQUA,North Sedan,Kansas House of Representatives,12,Republican,"Peck, Virgil",224,000090
+CHAUTAUQUA,Peru,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",43,000100
+CHAUTAUQUA,Peru,Kansas House of Representatives,12,Republican,"Peck, Virgil",115,000100
+CHAUTAUQUA,Salt Creek Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",10,000110
+CHAUTAUQUA,Salt Creek Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",51,000110
+CHAUTAUQUA,South Sedan,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",76,000120
+CHAUTAUQUA,South Sedan,Kansas House of Representatives,12,Republican,"Peck, Virgil",167,000120
+CHAUTAUQUA,Summit Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",11,000130
+CHAUTAUQUA,Summit Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",35,000130
+CHAUTAUQUA,Washington Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",8,000140
+CHAUTAUQUA,Washington Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",33,000140
+CHAUTAUQUA,Caneyville Township,Kansas Senate,14,Democratic,"Fuson, Eden",5,000010
+CHAUTAUQUA,Caneyville Township,Kansas Senate,14,Republican,"Knox, Forrest J.",42,000010
+CHAUTAUQUA,Center Township,Kansas Senate,14,Democratic,"Fuson, Eden",2,000020
+CHAUTAUQUA,Center Township,Kansas Senate,14,Republican,"Knox, Forrest J.",37,000020
+CHAUTAUQUA,Chautauqua,Kansas Senate,14,Democratic,"Fuson, Eden",13,000030
+CHAUTAUQUA,Chautauqua,Kansas Senate,14,Republican,"Knox, Forrest J.",104,000030
+CHAUTAUQUA,Harrison Township,Kansas Senate,14,Democratic,"Fuson, Eden",4,000040
+CHAUTAUQUA,Harrison Township,Kansas Senate,14,Republican,"Knox, Forrest J.",37,000040
+CHAUTAUQUA,Hendricks Township,Kansas Senate,14,Democratic,"Fuson, Eden",11,000050
+CHAUTAUQUA,Hendricks Township,Kansas Senate,14,Republican,"Knox, Forrest J.",32,000050
+CHAUTAUQUA,Jefferson Township,Kansas Senate,14,Democratic,"Fuson, Eden",51,000060
+CHAUTAUQUA,Jefferson Township,Kansas Senate,14,Republican,"Knox, Forrest J.",209,000060
+CHAUTAUQUA,Lafayette Township,Kansas Senate,14,Democratic,"Fuson, Eden",3,000070
+CHAUTAUQUA,Lafayette Township,Kansas Senate,14,Republican,"Knox, Forrest J.",19,000070
+CHAUTAUQUA,Little Caney Township,Kansas Senate,14,Democratic,"Fuson, Eden",19,000080
+CHAUTAUQUA,Little Caney Township,Kansas Senate,14,Republican,"Knox, Forrest J.",100,000080
+CHAUTAUQUA,North Sedan,Kansas Senate,14,Democratic,"Fuson, Eden",79,000090
+CHAUTAUQUA,North Sedan,Kansas Senate,14,Republican,"Knox, Forrest J.",278,000090
+CHAUTAUQUA,Peru,Kansas Senate,14,Democratic,"Fuson, Eden",19,000100
+CHAUTAUQUA,Peru,Kansas Senate,14,Republican,"Knox, Forrest J.",137,000100
+CHAUTAUQUA,Salt Creek Township,Kansas Senate,14,Democratic,"Fuson, Eden",7,000110
+CHAUTAUQUA,Salt Creek Township,Kansas Senate,14,Republican,"Knox, Forrest J.",52,000110
+CHAUTAUQUA,South Sedan,Kansas Senate,14,Democratic,"Fuson, Eden",44,000120
+CHAUTAUQUA,South Sedan,Kansas Senate,14,Republican,"Knox, Forrest J.",191,000120
+CHAUTAUQUA,Summit Township,Kansas Senate,14,Democratic,"Fuson, Eden",3,000130
+CHAUTAUQUA,Summit Township,Kansas Senate,14,Republican,"Knox, Forrest J.",43,000130
+CHAUTAUQUA,Washington Township,Kansas Senate,14,Democratic,"Fuson, Eden",3,000140
+CHAUTAUQUA,Washington Township,Kansas Senate,14,Republican,"Knox, Forrest J.",38,000140
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,Democratic,"Obama, Barack",7,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,Republican,"Romney, Mitt",40,000010
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,Democratic,"Obama, Barack",3,000020
+CHAUTAUQUA,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+CHAUTAUQUA,Center Township,President / Vice President,,Republican,"Romney, Mitt",35,000020
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Barnett, Andre",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Bush, Kent W",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Christensen, Will",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Goode, Virgil",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Stein, Jill E",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,Democratic,"Obama, Barack",14,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,Republican,"Romney, Mitt",103,000030
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,Democratic,"Obama, Barack",3,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,Republican,"Romney, Mitt",39,000040
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,Democratic,"Obama, Barack",13,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,Republican,"Romney, Mitt",30,000050
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,Democratic,"Obama, Barack",53,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,Republican,"Romney, Mitt",202,000060
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,Democratic,"Obama, Barack",4,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,Republican,"Romney, Mitt",19,000070
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,Democratic,"Obama, Barack",15,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,Republican,"Romney, Mitt",103,000080
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Barnett, Andre",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Bush, Kent W",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Christensen, Will",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Goode, Virgil",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Stein, Jill E",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,Democratic,"Obama, Barack",78,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,Libertarian,"Johnson, Gary",6,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,Republican,"Romney, Mitt",283,000090
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Barnett, Andre",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Bush, Kent W",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Christensen, Will",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Goode, Virgil",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Stein, Jill E",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,Democratic,"Obama, Barack",22,000100
+CHAUTAUQUA,Peru,President / Vice President,,Libertarian,"Johnson, Gary",6,000100
+CHAUTAUQUA,Peru,President / Vice President,,Reform,"Baldwin, Chuck",2,000100
+CHAUTAUQUA,Peru,President / Vice President,,Republican,"Romney, Mitt",127,000100
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,Democratic,"Obama, Barack",9,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,Republican,"Romney, Mitt",52,000110
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Barnett, Andre",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Bush, Kent W",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Christensen, Will",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Goode, Virgil",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Stein, Jill E",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,Democratic,"Obama, Barack",49,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,Libertarian,"Johnson, Gary",3,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,Republican,"Romney, Mitt",196,000120
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,Democratic,"Obama, Barack",4,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,Republican,"Romney, Mitt",41,000130
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,Democratic,"Obama, Barack",6,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,Republican,"Romney, Mitt",34,000140
+CHAUTAUQUA,Caneyville Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",5,000010
+CHAUTAUQUA,Caneyville Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000010
+CHAUTAUQUA,Caneyville Township,United States House of Representatives,4,Republican,"Pompeo, Mike",39,000010
+CHAUTAUQUA,Center Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",4,000020
+CHAUTAUQUA,Center Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000020
+CHAUTAUQUA,Center Township,United States House of Representatives,4,Republican,"Pompeo, Mike",34,000020
+CHAUTAUQUA,Chautauqua,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",15,000030
+CHAUTAUQUA,Chautauqua,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000030
+CHAUTAUQUA,Chautauqua,United States House of Representatives,4,Republican,"Pompeo, Mike",102,000030
+CHAUTAUQUA,Harrison Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000040
+CHAUTAUQUA,Harrison Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000040
+CHAUTAUQUA,Harrison Township,United States House of Representatives,4,Republican,"Pompeo, Mike",41,000040
+CHAUTAUQUA,Hendricks Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",11,000050
+CHAUTAUQUA,Hendricks Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,000050
+CHAUTAUQUA,Hendricks Township,United States House of Representatives,4,Republican,"Pompeo, Mike",27,000050
+CHAUTAUQUA,Jefferson Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",52,000060
+CHAUTAUQUA,Jefferson Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",26,000060
+CHAUTAUQUA,Jefferson Township,United States House of Representatives,4,Republican,"Pompeo, Mike",181,000060
+CHAUTAUQUA,Lafayette Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",6,000070
+CHAUTAUQUA,Lafayette Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000070
+CHAUTAUQUA,Lafayette Township,United States House of Representatives,4,Republican,"Pompeo, Mike",17,000070
+CHAUTAUQUA,Little Caney Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",17,000080
+CHAUTAUQUA,Little Caney Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000080
+CHAUTAUQUA,Little Caney Township,United States House of Representatives,4,Republican,"Pompeo, Mike",94,000080
+CHAUTAUQUA,North Sedan,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",54,000090
+CHAUTAUQUA,North Sedan,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",20,000090
+CHAUTAUQUA,North Sedan,United States House of Representatives,4,Republican,"Pompeo, Mike",278,000090
+CHAUTAUQUA,Peru,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",23,000100
+CHAUTAUQUA,Peru,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",14,000100
+CHAUTAUQUA,Peru,United States House of Representatives,4,Republican,"Pompeo, Mike",120,000100
+CHAUTAUQUA,Salt Creek Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",7,000110
+CHAUTAUQUA,Salt Creek Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000110
+CHAUTAUQUA,Salt Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",50,000110
+CHAUTAUQUA,South Sedan,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",45,000120
+CHAUTAUQUA,South Sedan,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",12,000120
+CHAUTAUQUA,South Sedan,United States House of Representatives,4,Republican,"Pompeo, Mike",181,000120
+CHAUTAUQUA,Summit Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",1,000130
+CHAUTAUQUA,Summit Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,000130
+CHAUTAUQUA,Summit Township,United States House of Representatives,4,Republican,"Pompeo, Mike",42,000130
+CHAUTAUQUA,Washington Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",3,000140
+CHAUTAUQUA,Washington Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000140
+CHAUTAUQUA,Washington Township,United States House of Representatives,4,Republican,"Pompeo, Mike",35,000140

--- a/2012/20121106__ks__general__cherokee__precinct.csv
+++ b/2012/20121106__ks__general__cherokee__precinct.csv
@@ -1,0 +1,1459 @@
+county,precinct,office,district,party,candidate,votes,vtd
+CHEROKEE,Baxter Springs Ward 1,Kansas House of Representatives,1,Democratic,"Randall, Grant",184,000010
+CHEROKEE,Baxter Springs Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",149,000010
+CHEROKEE,Baxter Springs Ward 2,Kansas House of Representatives,1,Democratic,"Randall, Grant",144,000020
+CHEROKEE,Baxter Springs Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",105,000020
+CHEROKEE,Baxter Springs Ward 3,Kansas House of Representatives,1,Democratic,"Randall, Grant",335,000030
+CHEROKEE,Baxter Springs Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",278,000030
+CHEROKEE,Baxter Springs Ward 4,Kansas House of Representatives,1,Democratic,"Randall, Grant",194,00004A
+CHEROKEE,Baxter Springs Ward 4,Kansas House of Representatives,1,Republican,"Houser, Michael",150,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00004B
+CHEROKEE,Cherokee Township,Kansas House of Representatives,1,Democratic,"Randall, Grant",73,000050
+CHEROKEE,Cherokee Township,Kansas House of Representatives,1,Republican,"Houser, Michael",76,000050
+CHEROKEE,Columbus Ward 1,Kansas House of Representatives,1,Democratic,"Randall, Grant",62,000060
+CHEROKEE,Columbus Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",137,000060
+CHEROKEE,Columbus Ward 2,Kansas House of Representatives,1,Democratic,"Randall, Grant",150,000070
+CHEROKEE,Columbus Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",235,000070
+CHEROKEE,Columbus Ward 3,Kansas House of Representatives,1,Democratic,"Randall, Grant",119,000080
+CHEROKEE,Columbus Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",215,000080
+CHEROKEE,Columbus Ward 4,Kansas House of Representatives,1,Democratic,"Randall, Grant",80,000090
+CHEROKEE,Columbus Ward 4,Kansas House of Representatives,1,Republican,"Houser, Michael",97,000090
+CHEROKEE,Columbus Ward 5,Kansas House of Representatives,1,Democratic,"Randall, Grant",101,00010A
+CHEROKEE,Columbus Ward 5,Kansas House of Representatives,1,Republican,"Houser, Michael",183,00010A
+CHEROKEE,Columbus Ward 5 Exclave,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00010B
+CHEROKEE,Crawford Township,Kansas House of Representatives,1,Democratic,"Randall, Grant",120,000110
+CHEROKEE,Crawford Township,Kansas House of Representatives,1,Republican,"Houser, Michael",211,000110
+CHEROKEE,Galena Ward 1,Kansas House of Representatives,1,Democratic,"Randall, Grant",131,000120
+CHEROKEE,Galena Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",112,000120
+CHEROKEE,Galena Ward 2,Kansas House of Representatives,1,Democratic,"Randall, Grant",100,00013A
+CHEROKEE,Galena Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",113,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00013D
+CHEROKEE,Galena Ward 3,Kansas House of Representatives,1,Democratic,"Randall, Grant",180,000140
+CHEROKEE,Galena Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",165,000140
+CHEROKEE,Galena Ward 4,Kansas House of Representatives,1,Democratic,"Randall, Grant",87,00015A
+CHEROKEE,Galena Ward 4,Kansas House of Representatives,1,Republican,"Houser, Michael",64,00015A
+CHEROKEE,Galena Ward 4 Exclave,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00015B
+CHEROKEE,Galena Ward 5,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,000160
+CHEROKEE,Galena Ward 5,Kansas House of Representatives,1,Republican,"Houser, Michael",0,000160
+CHEROKEE,Garden Township Lowell,Kansas House of Representatives,1,Democratic,"Randall, Grant",490,000170
+CHEROKEE,Garden Township Lowell,Kansas House of Representatives,1,Republican,"Houser, Michael",467,000170
+CHEROKEE,Garden Township Stanley Mine,Kansas House of Representatives,1,Democratic,"Randall, Grant",117,00018A
+CHEROKEE,Garden Township Stanley Mine,Kansas House of Representatives,1,Republican,"Houser, Michael",148,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00018C
+CHEROKEE,Lola Township,Kansas House of Representatives,1,Democratic,"Randall, Grant",40,000190
+CHEROKEE,Lola Township,Kansas House of Representatives,1,Republican,"Houser, Michael",102,000190
+CHEROKEE,Lowell Township,Kansas House of Representatives,1,Democratic,"Randall, Grant",110,000200
+CHEROKEE,Lowell Township,Kansas House of Representatives,1,Republican,"Houser, Michael",156,000200
+CHEROKEE,Lyon Township,Kansas House of Representatives,1,Democratic,"Randall, Grant",67,000210
+CHEROKEE,Lyon Township,Kansas House of Representatives,1,Republican,"Houser, Michael",108,000210
+CHEROKEE,Mineral Township,Kansas House of Representatives,1,Democratic,"Randall, Grant",35,000220
+CHEROKEE,Mineral Township,Kansas House of Representatives,1,Republican,"Houser, Michael",62,000220
+CHEROKEE,Neosho Township Faulkner,Kansas House of Representatives,1,Democratic,"Randall, Grant",11,000230
+CHEROKEE,Neosho Township Faulkner,Kansas House of Representatives,1,Republican,"Houser, Michael",29,000230
+CHEROKEE,Neosho Township Melrose,Kansas House of Representatives,1,Democratic,"Randall, Grant",37,000240
+CHEROKEE,Neosho Township Melrose,Kansas House of Representatives,1,Republican,"Houser, Michael",36,000240
+CHEROKEE,Pleasant View Township,Kansas House of Representatives,1,Democratic,"Randall, Grant",99,000250
+CHEROKEE,Pleasant View Township,Kansas House of Representatives,1,Republican,"Houser, Michael",181,000250
+CHEROKEE,Roseland City,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,000260
+CHEROKEE,Roseland City,Kansas House of Representatives,1,Republican,"Houser, Michael",0,000260
+CHEROKEE,Ross Township Belleview,Kansas House of Representatives,1,Democratic,"Randall, Grant",47,000270
+CHEROKEE,Ross Township Belleview,Kansas House of Representatives,1,Republican,"Houser, Michael",49,000270
+CHEROKEE,Ross Township Roseland,Kansas House of Representatives,1,Democratic,"Randall, Grant",67,000280
+CHEROKEE,Ross Township Roseland,Kansas House of Representatives,1,Republican,"Houser, Michael",59,000280
+CHEROKEE,Ross Township West Mineral,Kansas House of Representatives,1,Democratic,"Randall, Grant",52,000290
+CHEROKEE,Ross Township West Mineral,Kansas House of Representatives,1,Republican,"Houser, Michael",62,000290
+CHEROKEE,Salamanca Township,Kansas House of Representatives,1,Democratic,"Randall, Grant",100,00030A
+CHEROKEE,Salamanca Township,Kansas House of Representatives,1,Republican,"Houser, Michael",192,00030A
+CHEROKEE,Salamanca Township Enclave,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,00030B
+CHEROKEE,Salamanca Township Enclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00030B
+CHEROKEE,Scammon Ward 1,Kansas House of Representatives,1,Democratic,"Randall, Grant",34,000310
+CHEROKEE,Scammon Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",17,000310
+CHEROKEE,Scammon Ward 2,Kansas House of Representatives,1,Democratic,"Randall, Grant",32,000320
+CHEROKEE,Scammon Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",34,000320
+CHEROKEE,Scammon Ward 3,Kansas House of Representatives,1,Democratic,"Randall, Grant",38,000330
+CHEROKEE,Scammon Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",40,000330
+CHEROKEE,Shawnee Township,Kansas House of Representatives,1,Democratic,"Randall, Grant",75,000340
+CHEROKEE,Shawnee Township,Kansas House of Representatives,1,Republican,"Houser, Michael",142,000340
+CHEROKEE,Sheridan Township,Kansas House of Representatives,1,Democratic,"Randall, Grant",34,000350
+CHEROKEE,Sheridan Township,Kansas House of Representatives,1,Republican,"Houser, Michael",65,000350
+CHEROKEE,Spring Valley Township Neutral,Kansas House of Representatives,1,Democratic,"Randall, Grant",140,000360
+CHEROKEE,Spring Valley Township Neutral,Kansas House of Representatives,1,Republican,"Houser, Michael",146,000360
+CHEROKEE,Spring Valley Township Spring Valley,Kansas House of Representatives,1,Democratic,"Randall, Grant",98,00037A
+CHEROKEE,Spring Valley Township Spring Valley,Kansas House of Representatives,1,Republican,"Houser, Michael",97,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00037C
+CHEROKEE,Treece City,Kansas House of Representatives,1,Democratic,"Randall, Grant",1,000380
+CHEROKEE,Treece City,Kansas House of Representatives,1,Republican,"Houser, Michael",0,000380
+CHEROKEE,Weir Ward 1,Kansas House of Representatives,1,Democratic,"Randall, Grant",35,00039A
+CHEROKEE,Weir Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",24,00039A
+CHEROKEE,Weir Ward 2,Kansas House of Representatives,1,Democratic,"Randall, Grant",74,000400
+CHEROKEE,Weir Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",48,000400
+CHEROKEE,Weir Ward 3,Kansas House of Representatives,1,Democratic,"Randall, Grant",45,000410
+CHEROKEE,Weir Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",30,000410
+CHEROKEE,West Mineral City,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,00042A
+CHEROKEE,West Mineral City,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00042B
+CHEROKEE,Baxter Springs Ward 1,Kansas Senate,13,Democratic,"Garman, Gene",92,000010
+CHEROKEE,Baxter Springs Ward 1,Kansas Senate,13,Republican,"LaTurner, Jacob",235,000010
+CHEROKEE,Baxter Springs Ward 2,Kansas Senate,13,Democratic,"Garman, Gene",71,000020
+CHEROKEE,Baxter Springs Ward 2,Kansas Senate,13,Republican,"LaTurner, Jacob",180,000020
+CHEROKEE,Baxter Springs Ward 3,Kansas Senate,13,Democratic,"Garman, Gene",140,000030
+CHEROKEE,Baxter Springs Ward 3,Kansas Senate,13,Republican,"LaTurner, Jacob",462,000030
+CHEROKEE,Baxter Springs Ward 4,Kansas Senate,13,Democratic,"Garman, Gene",106,00004A
+CHEROKEE,Baxter Springs Ward 4,Kansas Senate,13,Republican,"LaTurner, Jacob",231,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,Kansas Senate,13,Democratic,"Garman, Gene",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00004B
+CHEROKEE,Cherokee Township,Kansas Senate,13,Democratic,"Garman, Gene",54,000050
+CHEROKEE,Cherokee Township,Kansas Senate,13,Republican,"LaTurner, Jacob",94,000050
+CHEROKEE,Columbus Ward 1,Kansas Senate,13,Democratic,"Garman, Gene",61,000060
+CHEROKEE,Columbus Ward 1,Kansas Senate,13,Republican,"LaTurner, Jacob",133,000060
+CHEROKEE,Columbus Ward 2,Kansas Senate,13,Democratic,"Garman, Gene",100,000070
+CHEROKEE,Columbus Ward 2,Kansas Senate,13,Republican,"LaTurner, Jacob",274,000070
+CHEROKEE,Columbus Ward 3,Kansas Senate,13,Democratic,"Garman, Gene",89,000080
+CHEROKEE,Columbus Ward 3,Kansas Senate,13,Republican,"LaTurner, Jacob",242,000080
+CHEROKEE,Columbus Ward 4,Kansas Senate,13,Democratic,"Garman, Gene",51,000090
+CHEROKEE,Columbus Ward 4,Kansas Senate,13,Republican,"LaTurner, Jacob",123,000090
+CHEROKEE,Columbus Ward 5,Kansas Senate,13,Democratic,"Garman, Gene",98,00010A
+CHEROKEE,Columbus Ward 5,Kansas Senate,13,Republican,"LaTurner, Jacob",179,00010A
+CHEROKEE,Columbus Ward 5 Exclave,Kansas Senate,13,Democratic,"Garman, Gene",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00010B
+CHEROKEE,Crawford Township,Kansas Senate,13,Democratic,"Garman, Gene",86,000110
+CHEROKEE,Crawford Township,Kansas Senate,13,Republican,"LaTurner, Jacob",240,000110
+CHEROKEE,Galena Ward 1,Kansas Senate,13,Democratic,"Garman, Gene",65,000120
+CHEROKEE,Galena Ward 1,Kansas Senate,13,Republican,"LaTurner, Jacob",181,000120
+CHEROKEE,Galena Ward 2,Kansas Senate,13,Democratic,"Garman, Gene",64,00013A
+CHEROKEE,Galena Ward 2,Kansas Senate,13,Republican,"LaTurner, Jacob",149,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,Kansas Senate,13,Democratic,"Garman, Gene",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,Kansas Senate,13,Democratic,"Garman, Gene",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,Kansas Senate,13,Democratic,"Garman, Gene",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00013D
+CHEROKEE,Galena Ward 3,Kansas Senate,13,Democratic,"Garman, Gene",103,000140
+CHEROKEE,Galena Ward 3,Kansas Senate,13,Republican,"LaTurner, Jacob",247,000140
+CHEROKEE,Galena Ward 4,Kansas Senate,13,Democratic,"Garman, Gene",38,00015A
+CHEROKEE,Galena Ward 4,Kansas Senate,13,Republican,"LaTurner, Jacob",112,00015A
+CHEROKEE,Galena Ward 4 Exclave,Kansas Senate,13,Democratic,"Garman, Gene",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00015B
+CHEROKEE,Galena Ward 5,Kansas Senate,13,Democratic,"Garman, Gene",0,000160
+CHEROKEE,Galena Ward 5,Kansas Senate,13,Republican,"LaTurner, Jacob",0,000160
+CHEROKEE,Garden Township Lowell,Kansas Senate,13,Democratic,"Garman, Gene",269,000170
+CHEROKEE,Garden Township Lowell,Kansas Senate,13,Republican,"LaTurner, Jacob",682,000170
+CHEROKEE,Garden Township Stanley Mine,Kansas Senate,13,Democratic,"Garman, Gene",61,00018A
+CHEROKEE,Garden Township Stanley Mine,Kansas Senate,13,Republican,"LaTurner, Jacob",204,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,Kansas Senate,13,Democratic,"Garman, Gene",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,Kansas Senate,13,Democratic,"Garman, Gene",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00018C
+CHEROKEE,Lola Township,Kansas Senate,13,Democratic,"Garman, Gene",44,000190
+CHEROKEE,Lola Township,Kansas Senate,13,Republican,"LaTurner, Jacob",98,000190
+CHEROKEE,Lowell Township,Kansas Senate,13,Democratic,"Garman, Gene",65,000200
+CHEROKEE,Lowell Township,Kansas Senate,13,Republican,"LaTurner, Jacob",199,000200
+CHEROKEE,Lyon Township,Kansas Senate,13,Democratic,"Garman, Gene",47,000210
+CHEROKEE,Lyon Township,Kansas Senate,13,Republican,"LaTurner, Jacob",124,000210
+CHEROKEE,Mineral Township,Kansas Senate,13,Democratic,"Garman, Gene",25,000220
+CHEROKEE,Mineral Township,Kansas Senate,13,Republican,"LaTurner, Jacob",72,000220
+CHEROKEE,Neosho Township Faulkner,Kansas Senate,13,Democratic,"Garman, Gene",6,000230
+CHEROKEE,Neosho Township Faulkner,Kansas Senate,13,Republican,"LaTurner, Jacob",34,000230
+CHEROKEE,Neosho Township Melrose,Kansas Senate,13,Democratic,"Garman, Gene",26,000240
+CHEROKEE,Neosho Township Melrose,Kansas Senate,13,Republican,"LaTurner, Jacob",46,000240
+CHEROKEE,Pleasant View Township,Kansas Senate,13,Democratic,"Garman, Gene",90,000250
+CHEROKEE,Pleasant View Township,Kansas Senate,13,Republican,"LaTurner, Jacob",193,000250
+CHEROKEE,Roseland City,Kansas Senate,13,Democratic,"Garman, Gene",0,000260
+CHEROKEE,Roseland City,Kansas Senate,13,Republican,"LaTurner, Jacob",0,000260
+CHEROKEE,Ross Township Belleview,Kansas Senate,13,Democratic,"Garman, Gene",33,000270
+CHEROKEE,Ross Township Belleview,Kansas Senate,13,Republican,"LaTurner, Jacob",63,000270
+CHEROKEE,Ross Township Roseland,Kansas Senate,13,Democratic,"Garman, Gene",54,000280
+CHEROKEE,Ross Township Roseland,Kansas Senate,13,Republican,"LaTurner, Jacob",67,000280
+CHEROKEE,Ross Township West Mineral,Kansas Senate,13,Democratic,"Garman, Gene",53,000290
+CHEROKEE,Ross Township West Mineral,Kansas Senate,13,Republican,"LaTurner, Jacob",57,000290
+CHEROKEE,Salamanca Township,Kansas Senate,13,Democratic,"Garman, Gene",75,00030A
+CHEROKEE,Salamanca Township,Kansas Senate,13,Republican,"LaTurner, Jacob",213,00030A
+CHEROKEE,Salamanca Township Enclave,Kansas Senate,13,Democratic,"Garman, Gene",0,00030B
+CHEROKEE,Salamanca Township Enclave,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00030B
+CHEROKEE,Scammon Ward 1,Kansas Senate,13,Democratic,"Garman, Gene",26,000310
+CHEROKEE,Scammon Ward 1,Kansas Senate,13,Republican,"LaTurner, Jacob",24,000310
+CHEROKEE,Scammon Ward 2,Kansas Senate,13,Democratic,"Garman, Gene",22,000320
+CHEROKEE,Scammon Ward 2,Kansas Senate,13,Republican,"LaTurner, Jacob",44,000320
+CHEROKEE,Scammon Ward 3,Kansas Senate,13,Democratic,"Garman, Gene",29,000330
+CHEROKEE,Scammon Ward 3,Kansas Senate,13,Republican,"LaTurner, Jacob",47,000330
+CHEROKEE,Shawnee Township,Kansas Senate,13,Democratic,"Garman, Gene",50,000340
+CHEROKEE,Shawnee Township,Kansas Senate,13,Republican,"LaTurner, Jacob",166,000340
+CHEROKEE,Sheridan Township,Kansas Senate,13,Democratic,"Garman, Gene",33,000350
+CHEROKEE,Sheridan Township,Kansas Senate,13,Republican,"LaTurner, Jacob",66,000350
+CHEROKEE,Spring Valley Township Neutral,Kansas Senate,13,Democratic,"Garman, Gene",87,000360
+CHEROKEE,Spring Valley Township Neutral,Kansas Senate,13,Republican,"LaTurner, Jacob",196,000360
+CHEROKEE,Spring Valley Township Spring Valley,Kansas Senate,13,Democratic,"Garman, Gene",39,00037A
+CHEROKEE,Spring Valley Township Spring Valley,Kansas Senate,13,Republican,"LaTurner, Jacob",152,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas Senate,13,Democratic,"Garman, Gene",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas Senate,13,Democratic,"Garman, Gene",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00037C
+CHEROKEE,Treece City,Kansas Senate,13,Democratic,"Garman, Gene",1,000380
+CHEROKEE,Treece City,Kansas Senate,13,Republican,"LaTurner, Jacob",0,000380
+CHEROKEE,Weir Ward 1,Kansas Senate,13,Democratic,"Garman, Gene",27,00039A
+CHEROKEE,Weir Ward 1,Kansas Senate,13,Republican,"LaTurner, Jacob",29,00039A
+CHEROKEE,Weir Ward 2,Kansas Senate,13,Democratic,"Garman, Gene",57,000400
+CHEROKEE,Weir Ward 2,Kansas Senate,13,Republican,"LaTurner, Jacob",63,000400
+CHEROKEE,Weir Ward 3,Kansas Senate,13,Democratic,"Garman, Gene",31,000410
+CHEROKEE,Weir Ward 3,Kansas Senate,13,Republican,"LaTurner, Jacob",42,000410
+CHEROKEE,West Mineral City,Kansas Senate,13,Democratic,"Garman, Gene",0,00042A
+CHEROKEE,West Mineral City,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,Kansas Senate,13,Democratic,"Garman, Gene",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,Kansas Senate,13,Republican,"LaTurner, Jacob",0,00042B
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,Democratic,"Obama, Barack",101,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,Republican,"Romney, Mitt",229,000010
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,Democratic,"Obama, Barack",93,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",8,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,Republican,"Romney, Mitt",152,000020
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,Democratic,"Obama, Barack",173,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,Republican,"Romney, Mitt",440,000030
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Christensen, Will",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,Democratic,"Obama, Barack",111,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",8,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",2,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,Republican,"Romney, Mitt",224,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00004B
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,Democratic,"Obama, Barack",64,000050
+CHEROKEE,Cherokee Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+CHEROKEE,Cherokee Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,Republican,"Romney, Mitt",82,000050
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,Democratic,"Obama, Barack",72,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,Republican,"Romney, Mitt",118,000060
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,Democratic,"Obama, Barack",122,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",4,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,Republican,"Romney, Mitt",257,000070
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,Democratic,"Obama, Barack",102,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",7,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,Republican,"Romney, Mitt",226,000080
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,Democratic,"Obama, Barack",59,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",4,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,Republican,"Romney, Mitt",116,000090
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Ayers, Avery L",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Barnett, Andre",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Barr, Roseanne C",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Bush, Kent W",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Christensen, Will",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Duncan, Richard A",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Goode, Virgil",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Knill, Dennis J",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Reed, Jill A.",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Rogers, Rick L",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Stein, Jill E",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Thorne, Kevin M",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Warner, Gerald L.",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,Democratic,"Obama, Barack",115,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",9,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,Reform,"Baldwin, Chuck",3,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,Republican,"Romney, Mitt",157,00010A
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00010B
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,Democratic,"Obama, Barack",87,000110
+CHEROKEE,Crawford Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000110
+CHEROKEE,Crawford Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+CHEROKEE,Crawford Township,President / Vice President,,Republican,"Romney, Mitt",235,000110
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,Democratic,"Obama, Barack",117,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",6,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,Republican,"Romney, Mitt",125,000120
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,Democratic,"Obama, Barack",84,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",3,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,Republican,"Romney, Mitt",123,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Ayers, Avery L",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Barnett, Andre",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Barr, Roseanne C",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Bush, Kent W",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Christensen, Will",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Duncan, Richard A",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Goode, Virgil",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Hoefling, Tom",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Knill, Dennis J",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Reed, Jill A.",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Rogers, Rick L",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Stein, Jill E",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Thorne, Kevin M",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Warner, Gerald L.",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,Democratic,"Obama, Barack",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,Libertarian,"Johnson, Gary",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,Reform,"Baldwin, Chuck",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,Republican,"Romney, Mitt",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Christensen, Will",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Ayers, Avery L",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Barnett, Andre",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Barr, Roseanne C",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Bush, Kent W",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Christensen, Will",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Duncan, Richard A",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Goode, Virgil",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Knill, Dennis J",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Reed, Jill A.",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Rogers, Rick L",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Stein, Jill E",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Thorne, Kevin M",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Warner, Gerald L.",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,Democratic,"Obama, Barack",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,Reform,"Baldwin, Chuck",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,Republican,"Romney, Mitt",0,00013D
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,Democratic,"Obama, Barack",139,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",4,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",2,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,Republican,"Romney, Mitt",211,000140
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Christensen, Will",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,Democratic,"Obama, Barack",68,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",2,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",1,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,Republican,"Romney, Mitt",80,00015A
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00015B
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Barnett, Andre",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Bush, Kent W",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Christensen, Will",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Goode, Virgil",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Stein, Jill E",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,Democratic,"Obama, Barack",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+CHEROKEE,Galena Ward 5,President / Vice President,,Republican,"Romney, Mitt",0,000160
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Barnett, Andre",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Bush, Kent W",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Christensen, Will",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Goode, Virgil",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Stein, Jill E",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,Democratic,"Obama, Barack",354,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,Libertarian,"Johnson, Gary",9,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,Reform,"Baldwin, Chuck",4,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,Republican,"Romney, Mitt",604,000170
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Ayers, Avery L",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Barnett, Andre",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Barr, Roseanne C",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Bush, Kent W",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Christensen, Will",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Duncan, Richard A",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Goode, Virgil",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Hoefling, Tom",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Knill, Dennis J",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Reed, Jill A.",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Rogers, Rick L",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Stein, Jill E",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Thorne, Kevin M",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Warner, Gerald L.",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,Democratic,"Obama, Barack",76,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,Libertarian,"Johnson, Gary",3,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,Reform,"Baldwin, Chuck",2,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,Republican,"Romney, Mitt",187,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Barnett, Andre",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Bush, Kent W",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Christensen, Will",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Goode, Virgil",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Stein, Jill E",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,Democratic,"Obama, Barack",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,Republican,"Romney, Mitt",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Barnett, Andre",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Bush, Kent W",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Christensen, Will",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Goode, Virgil",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Stein, Jill E",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,Democratic,"Obama, Barack",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,Republican,"Romney, Mitt",0,00018C
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+CHEROKEE,Lola Township,President / Vice President,,Democratic,"Obama, Barack",46,000190
+CHEROKEE,Lola Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000190
+CHEROKEE,Lola Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+CHEROKEE,Lola Township,President / Vice President,,Republican,"Romney, Mitt",95,000190
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,Democratic,"Obama, Barack",77,000200
+CHEROKEE,Lowell Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000200
+CHEROKEE,Lowell Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000200
+CHEROKEE,Lowell Township,President / Vice President,,Republican,"Romney, Mitt",188,000200
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+CHEROKEE,Lyon Township,President / Vice President,,Democratic,"Obama, Barack",50,000210
+CHEROKEE,Lyon Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000210
+CHEROKEE,Lyon Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000210
+CHEROKEE,Lyon Township,President / Vice President,,Republican,"Romney, Mitt",116,000210
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,Democratic,"Obama, Barack",24,000220
+CHEROKEE,Mineral Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,Republican,"Romney, Mitt",73,000220
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Barnett, Andre",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Bush, Kent W",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Christensen, Will",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Goode, Virgil",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Stein, Jill E",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,Democratic,"Obama, Barack",9,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,Republican,"Romney, Mitt",32,000230
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Barnett, Andre",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Bush, Kent W",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Christensen, Will",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Goode, Virgil",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Stein, Jill E",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,Democratic,"Obama, Barack",21,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,Libertarian,"Johnson, Gary",2,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,Reform,"Baldwin, Chuck",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,Republican,"Romney, Mitt",50,000240
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,Democratic,"Obama, Barack",89,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,Republican,"Romney, Mitt",187,000250
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Barnett, Andre",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Bush, Kent W",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Christensen, Will",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Goode, Virgil",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Stein, Jill E",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+CHEROKEE,Roseland City,President / Vice President,,Democratic,"Obama, Barack",0,000260
+CHEROKEE,Roseland City,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+CHEROKEE,Roseland City,President / Vice President,,Reform,"Baldwin, Chuck",0,000260
+CHEROKEE,Roseland City,President / Vice President,,Republican,"Romney, Mitt",0,000260
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Barnett, Andre",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Bush, Kent W",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Christensen, Will",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Goode, Virgil",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Stein, Jill E",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,Democratic,"Obama, Barack",41,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,Libertarian,"Johnson, Gary",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,Reform,"Baldwin, Chuck",1,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,Republican,"Romney, Mitt",54,000270
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Barnett, Andre",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Bush, Kent W",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Christensen, Will",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Goode, Virgil",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Stein, Jill E",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,Democratic,"Obama, Barack",55,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,Libertarian,"Johnson, Gary",3,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,Reform,"Baldwin, Chuck",1,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,Republican,"Romney, Mitt",70,000280
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Barnett, Andre",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Bush, Kent W",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Christensen, Will",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Goode, Virgil",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Stein, Jill E",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,Democratic,"Obama, Barack",52,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,Libertarian,"Johnson, Gary",6,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,Reform,"Baldwin, Chuck",2,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,Republican,"Romney, Mitt",51,000290
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Ayers, Avery L",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Barnett, Andre",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Bush, Kent W",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Christensen, Will",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Duncan, Richard A",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Goode, Virgil",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Hoefling, Tom",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Knill, Dennis J",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Reed, Jill A.",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Rogers, Rick L",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Stein, Jill E",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,Democratic,"Obama, Barack",77,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,Libertarian,"Johnson, Gary",4,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,Reform,"Baldwin, Chuck",1,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,Republican,"Romney, Mitt",210,00030A
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Christensen, Will",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00030B
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,Democratic,"Obama, Barack",26,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,Republican,"Romney, Mitt",23,000310
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,Democratic,"Obama, Barack",27,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",4,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,Republican,"Romney, Mitt",35,000320
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,Democratic,"Obama, Barack",29,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",3,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,Republican,"Romney, Mitt",47,000330
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Ayers, Avery L",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Barnett, Andre",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Bush, Kent W",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Christensen, Will",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Duncan, Richard A",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Goode, Virgil",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Knill, Dennis J",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Reed, Jill A.",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Rogers, Rick L",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Stein, Jill E",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,Democratic,"Obama, Barack",52,000340
+CHEROKEE,Shawnee Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000340
+CHEROKEE,Shawnee Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000340
+CHEROKEE,Shawnee Township,President / Vice President,,Republican,"Romney, Mitt",158,000340
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Barnett, Andre",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Bush, Kent W",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Christensen, Will",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Goode, Virgil",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Stein, Jill E",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,Democratic,"Obama, Barack",40,000350
+CHEROKEE,Sheridan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000350
+CHEROKEE,Sheridan Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000350
+CHEROKEE,Sheridan Township,President / Vice President,,Republican,"Romney, Mitt",58,000350
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Ayers, Avery L",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Barnett, Andre",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Barr, Roseanne C",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Bush, Kent W",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Christensen, Will",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Duncan, Richard A",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Goode, Virgil",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Knill, Dennis J",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Reed, Jill A.",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Rogers, Rick L",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Stein, Jill E",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Thorne, Kevin M",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Warner, Gerald L.",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,Democratic,"Obama, Barack",86,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,Libertarian,"Johnson, Gary",4,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,Reform,"Baldwin, Chuck",1,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,Republican,"Romney, Mitt",195,000360
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Ayers, Avery L",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Barnett, Andre",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Barr, Roseanne C",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Bush, Kent W",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Christensen, Will",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Duncan, Richard A",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Goode, Virgil",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Hoefling, Tom",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Knill, Dennis J",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Reed, Jill A.",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Rogers, Rick L",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Stein, Jill E",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Thorne, Kevin M",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Warner, Gerald L.",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,Democratic,"Obama, Barack",52,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,Libertarian,"Johnson, Gary",2,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,Reform,"Baldwin, Chuck",2,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,Republican,"Romney, Mitt",141,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Christensen, Will",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Christensen, Will",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00037C
+CHEROKEE,Treece City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Ayers, Avery L",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Barnett, Andre",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Barr, Roseanne C",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Bush, Kent W",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Christensen, Will",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Duncan, Richard A",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Goode, Virgil",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Knill, Dennis J",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Reed, Jill A.",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Rogers, Rick L",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Stein, Jill E",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Thorne, Kevin M",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000380
+CHEROKEE,Treece City,President / Vice President,,write - in,"Warner, Gerald L.",0,000380
+CHEROKEE,Treece City,President / Vice President,,Democratic,"Obama, Barack",1,000380
+CHEROKEE,Treece City,President / Vice President,,Libertarian,"Johnson, Gary",0,000380
+CHEROKEE,Treece City,President / Vice President,,Reform,"Baldwin, Chuck",0,000380
+CHEROKEE,Treece City,President / Vice President,,Republican,"Romney, Mitt",0,000380
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Christensen, Will",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,Democratic,"Obama, Barack",34,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,Republican,"Romney, Mitt",26,00039A
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,Democratic,"Obama, Barack",64,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",8,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,Republican,"Romney, Mitt",49,000400
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,Democratic,"Obama, Barack",41,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",2,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,Republican,"Romney, Mitt",32,000410
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Ayers, Avery L",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Barnett, Andre",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Barr, Roseanne C",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Bush, Kent W",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Christensen, Will",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Duncan, Richard A",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Goode, Virgil",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Hoefling, Tom",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Knill, Dennis J",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Reed, Jill A.",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Rogers, Rick L",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Stein, Jill E",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Thorne, Kevin M",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Warner, Gerald L.",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,Democratic,"Obama, Barack",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,Libertarian,"Johnson, Gary",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,Reform,"Baldwin, Chuck",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,Republican,"Romney, Mitt",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Ayers, Avery L",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Barnett, Andre",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Barr, Roseanne C",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Bush, Kent W",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Christensen, Will",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Duncan, Richard A",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Goode, Virgil",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Hoefling, Tom",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Knill, Dennis J",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Reed, Jill A.",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Rogers, Rick L",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Stein, Jill E",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Thorne, Kevin M",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Warner, Gerald L.",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,Democratic,"Obama, Barack",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,Libertarian,"Johnson, Gary",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,Reform,"Baldwin, Chuck",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,Republican,"Romney, Mitt",0,00042B
+CHEROKEE,Baxter Springs Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",86,000010
+CHEROKEE,Baxter Springs Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,000010
+CHEROKEE,Baxter Springs Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",227,000010
+CHEROKEE,Baxter Springs Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",74,000020
+CHEROKEE,Baxter Springs Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000020
+CHEROKEE,Baxter Springs Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",166,000020
+CHEROKEE,Baxter Springs Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",146,000030
+CHEROKEE,Baxter Springs Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000030
+CHEROKEE,Baxter Springs Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",444,000030
+CHEROKEE,Baxter Springs Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",92,00004A
+CHEROKEE,Baxter Springs Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",20,00004A
+CHEROKEE,Baxter Springs Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",228,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00004B
+CHEROKEE,Cherokee Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",54,000050
+CHEROKEE,Cherokee Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000050
+CHEROKEE,Cherokee Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",92,000050
+CHEROKEE,Columbus Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",50,000060
+CHEROKEE,Columbus Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,000060
+CHEROKEE,Columbus Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",135,000060
+CHEROKEE,Columbus Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",104,000070
+CHEROKEE,Columbus Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000070
+CHEROKEE,Columbus Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",260,000070
+CHEROKEE,Columbus Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",95,000080
+CHEROKEE,Columbus Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000080
+CHEROKEE,Columbus Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",221,000080
+CHEROKEE,Columbus Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",55,000090
+CHEROKEE,Columbus Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000090
+CHEROKEE,Columbus Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",117,000090
+CHEROKEE,Columbus Ward 5,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",112,00010A
+CHEROKEE,Columbus Ward 5,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,00010A
+CHEROKEE,Columbus Ward 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",156,00010A
+CHEROKEE,Columbus Ward 5 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00010B
+CHEROKEE,Crawford Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",79,000110
+CHEROKEE,Crawford Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000110
+CHEROKEE,Crawford Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",239,000110
+CHEROKEE,Galena Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",74,000120
+CHEROKEE,Galena Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000120
+CHEROKEE,Galena Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",163,000120
+CHEROKEE,Galena Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",66,00013A
+CHEROKEE,Galena Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,00013A
+CHEROKEE,Galena Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",136,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013D
+CHEROKEE,Galena Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",103,000140
+CHEROKEE,Galena Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000140
+CHEROKEE,Galena Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",238,000140
+CHEROKEE,Galena Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",55,00015A
+CHEROKEE,Galena Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,00015A
+CHEROKEE,Galena Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",90,00015A
+CHEROKEE,Galena Ward 4 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00015B
+CHEROKEE,Galena Ward 5,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,000160
+CHEROKEE,Galena Ward 5,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000160
+CHEROKEE,Galena Ward 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,000160
+CHEROKEE,Garden Township Lowell,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",294,000170
+CHEROKEE,Garden Township Lowell,United States House of Representatives,2,Libertarian,"Hawver, Dennis",37,000170
+CHEROKEE,Garden Township Lowell,United States House of Representatives,2,Republican,"Jenkins, Lynn",624,000170
+CHEROKEE,Garden Township Stanley Mine,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",63,00018A
+CHEROKEE,Garden Township Stanley Mine,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,00018A
+CHEROKEE,Garden Township Stanley Mine,United States House of Representatives,2,Republican,"Jenkins, Lynn",188,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00018C
+CHEROKEE,Lola Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",35,000190
+CHEROKEE,Lola Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000190
+CHEROKEE,Lola Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",103,000190
+CHEROKEE,Lowell Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",63,000200
+CHEROKEE,Lowell Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000200
+CHEROKEE,Lowell Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",198,000200
+CHEROKEE,Lyon Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",45,000210
+CHEROKEE,Lyon Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000210
+CHEROKEE,Lyon Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",120,000210
+CHEROKEE,Mineral Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",20,000220
+CHEROKEE,Mineral Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000220
+CHEROKEE,Mineral Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",75,000220
+CHEROKEE,Neosho Township Faulkner,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",7,000230
+CHEROKEE,Neosho Township Faulkner,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000230
+CHEROKEE,Neosho Township Faulkner,United States House of Representatives,2,Republican,"Jenkins, Lynn",33,000230
+CHEROKEE,Neosho Township Melrose,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",27,000240
+CHEROKEE,Neosho Township Melrose,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000240
+CHEROKEE,Neosho Township Melrose,United States House of Representatives,2,Republican,"Jenkins, Lynn",46,000240
+CHEROKEE,Pleasant View Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",75,000250
+CHEROKEE,Pleasant View Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000250
+CHEROKEE,Pleasant View Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",198,000250
+CHEROKEE,Roseland City,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,000260
+CHEROKEE,Roseland City,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000260
+CHEROKEE,Roseland City,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,000260
+CHEROKEE,Ross Township Belleview,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",37,000270
+CHEROKEE,Ross Township Belleview,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000270
+CHEROKEE,Ross Township Belleview,United States House of Representatives,2,Republican,"Jenkins, Lynn",55,000270
+CHEROKEE,Ross Township Roseland,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",59,000280
+CHEROKEE,Ross Township Roseland,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000280
+CHEROKEE,Ross Township Roseland,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,000280
+CHEROKEE,Ross Township West Mineral,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",47,000290
+CHEROKEE,Ross Township West Mineral,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000290
+CHEROKEE,Ross Township West Mineral,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,000290
+CHEROKEE,Salamanca Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",67,00030A
+CHEROKEE,Salamanca Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,00030A
+CHEROKEE,Salamanca Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",213,00030A
+CHEROKEE,Salamanca Township Enclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00030B
+CHEROKEE,Salamanca Township Enclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00030B
+CHEROKEE,Salamanca Township Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00030B
+CHEROKEE,Scammon Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",28,000310
+CHEROKEE,Scammon Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000310
+CHEROKEE,Scammon Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",22,000310
+CHEROKEE,Scammon Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",24,000320
+CHEROKEE,Scammon Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000320
+CHEROKEE,Scammon Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",37,000320
+CHEROKEE,Scammon Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",29,000330
+CHEROKEE,Scammon Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000330
+CHEROKEE,Scammon Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",48,000330
+CHEROKEE,Shawnee Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",52,000340
+CHEROKEE,Shawnee Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000340
+CHEROKEE,Shawnee Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",154,000340
+CHEROKEE,Sheridan Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",33,000350
+CHEROKEE,Sheridan Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000350
+CHEROKEE,Sheridan Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",58,000350
+CHEROKEE,Spring Valley Township Neutral,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",87,000360
+CHEROKEE,Spring Valley Township Neutral,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000360
+CHEROKEE,Spring Valley Township Neutral,United States House of Representatives,2,Republican,"Jenkins, Lynn",191,000360
+CHEROKEE,Spring Valley Township Spring Valley,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",46,00037A
+CHEROKEE,Spring Valley Township Spring Valley,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,00037A
+CHEROKEE,Spring Valley Township Spring Valley,United States House of Representatives,2,Republican,"Jenkins, Lynn",143,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00037C
+CHEROKEE,Treece City,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",1,000380
+CHEROKEE,Treece City,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000380
+CHEROKEE,Treece City,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,000380
+CHEROKEE,Weir Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",27,00039A
+CHEROKEE,Weir Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00039A
+CHEROKEE,Weir Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",32,00039A
+CHEROKEE,Weir Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",53,000400
+CHEROKEE,Weir Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000400
+CHEROKEE,Weir Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",61,000400
+CHEROKEE,Weir Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",40,000410
+CHEROKEE,Weir Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000410
+CHEROKEE,Weir Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",33,000410
+CHEROKEE,West Mineral City,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00042A
+CHEROKEE,West Mineral City,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00042A
+CHEROKEE,West Mineral City,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00042B

--- a/2012/20121106__ks__general__cheyenne__precinct.csv
+++ b/2012/20121106__ks__general__cheyenne__precinct.csv
@@ -1,0 +1,193 @@
+county,precinct,office,district,party,candidate,votes,vtd
+CHEYENNE,Benkelman Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",16,000010
+CHEYENNE,Bird City Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",258,000020
+CHEYENNE,Calhoun Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",27,000030
+CHEYENNE,Cleveland Run Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",29,000040
+CHEYENNE,Jaqua Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",8,000050
+CHEYENNE,Orlando Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",23,000060
+CHEYENNE,Wano 1 Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",354,000070
+CHEYENNE,Wano 2 Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",486,000080
+CHEYENNE,Benkelman Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000010
+CHEYENNE,Benkelman Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",16,000010
+CHEYENNE,Bird City Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",54,000020
+CHEYENNE,Bird City Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",257,000020
+CHEYENNE,Calhoun Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000030
+CHEYENNE,Calhoun Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",27,000030
+CHEYENNE,Cleveland Run Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",7,000040
+CHEYENNE,Cleveland Run Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",30,000040
+CHEYENNE,Jaqua Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",3,000050
+CHEYENNE,Jaqua Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",8,000050
+CHEYENNE,Orlando Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",3,000060
+CHEYENNE,Orlando Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",28,000060
+CHEYENNE,Wano 1 Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",101,000070
+CHEYENNE,Wano 1 Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",287,000070
+CHEYENNE,Wano 2 Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",133,000080
+CHEYENNE,Wano 2 Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",426,000080
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,Democratic,"Obama, Barack",3,000010
+CHEYENNE,Benkelman Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,Republican,"Romney, Mitt",18,000010
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,Democratic,"Obama, Barack",62,000020
+CHEYENNE,Bird City Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000020
+CHEYENNE,Bird City Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000020
+CHEYENNE,Bird City Township,President / Vice President,,Republican,"Romney, Mitt",244,000020
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,Democratic,"Obama, Barack",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,Republican,"Romney, Mitt",31,000030
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,Democratic,"Obama, Barack",4,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,Republican,"Romney, Mitt",34,000040
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,Democratic,"Obama, Barack",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,Republican,"Romney, Mitt",11,000050
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,Democratic,"Obama, Barack",1,000060
+CHEYENNE,Orlando Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,Republican,"Romney, Mitt",32,000060
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,Democratic,"Obama, Barack",67,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,Republican,"Romney, Mitt",320,000070
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,Democratic,"Obama, Barack",96,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,Republican,"Romney, Mitt",469,000080
+CHEYENNE,Benkelman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000010
+CHEYENNE,Bird City Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",273,000020
+CHEYENNE,Calhoun Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000030
+CHEYENNE,Cleveland Run Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000040
+CHEYENNE,Jaqua Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000050
+CHEYENNE,Orlando Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000060
+CHEYENNE,Wano 1 Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",335,000070
+CHEYENNE,Wano 2 Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",485,000080

--- a/2012/20121106__ks__general__clark__precinct.csv
+++ b/2012/20121106__ks__general__clark__precinct.csv
@@ -1,0 +1,176 @@
+county,precinct,office,district,party,candidate,votes,vtd
+CLARK,Appleton Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",63,000010
+CLARK,Appleton Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",318,000010
+CLARK,Center 1,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",60,000020
+CLARK,Center 1,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",196,000020
+CLARK,Center 2,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",27,000030
+CLARK,Center 2,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",151,000030
+CLARK,Englewood Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",14,000040
+CLARK,Englewood Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",51,000040
+CLARK,Lexington Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",8,000050
+CLARK,Lexington Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",22,000050
+CLARK,Liberty Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",3,000060
+CLARK,Liberty Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",25,000060
+CLARK,Sitka Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",7,000070
+CLARK,Sitka Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",31,000070
+CLARK,Appleton Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",45,000010
+CLARK,Appleton Township,Kansas Senate,38,Republican,"Love, Garrett",352,000010
+CLARK,Center 1,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",56,000020
+CLARK,Center 1,Kansas Senate,38,Republican,"Love, Garrett",213,000020
+CLARK,Center 2,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",29,000030
+CLARK,Center 2,Kansas Senate,38,Republican,"Love, Garrett",154,000030
+CLARK,Englewood Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",21,000040
+CLARK,Englewood Township,Kansas Senate,38,Republican,"Love, Garrett",46,000040
+CLARK,Lexington Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",9,000050
+CLARK,Lexington Township,Kansas Senate,38,Republican,"Love, Garrett",21,000050
+CLARK,Liberty Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",3,000060
+CLARK,Liberty Township,Kansas Senate,38,Republican,"Love, Garrett",25,000060
+CLARK,Sitka Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",9,000070
+CLARK,Sitka Township,Kansas Senate,38,Republican,"Love, Garrett",30,000070
+CLARK,Appleton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+CLARK,Appleton Township,President / Vice President,,Democratic,"Obama, Barack",54,000010
+CLARK,Appleton Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000010
+CLARK,Appleton Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000010
+CLARK,Appleton Township,President / Vice President,,Republican,"Romney, Mitt",322,000010
+CLARK,Center 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Barnett, Andre",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Bush, Kent W",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Christensen, Will",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Goode, Virgil",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Stein, Jill E",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+CLARK,Center 1,President / Vice President,,Democratic,"Obama, Barack",68,000020
+CLARK,Center 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000020
+CLARK,Center 1,President / Vice President,,Reform,"Baldwin, Chuck",5,000020
+CLARK,Center 1,President / Vice President,,Republican,"Romney, Mitt",193,000020
+CLARK,Center 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Barnett, Andre",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Bush, Kent W",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Christensen, Will",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Goode, Virgil",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Stein, Jill E",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+CLARK,Center 2,President / Vice President,,Democratic,"Obama, Barack",26,000030
+CLARK,Center 2,President / Vice President,,Libertarian,"Johnson, Gary",9,000030
+CLARK,Center 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+CLARK,Center 2,President / Vice President,,Republican,"Romney, Mitt",156,000030
+CLARK,Englewood Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+CLARK,Englewood Township,President / Vice President,,Democratic,"Obama, Barack",17,000040
+CLARK,Englewood Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+CLARK,Englewood Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+CLARK,Englewood Township,President / Vice President,,Republican,"Romney, Mitt",51,000040
+CLARK,Lexington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+CLARK,Lexington Township,President / Vice President,,Democratic,"Obama, Barack",4,000050
+CLARK,Lexington Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+CLARK,Lexington Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000050
+CLARK,Lexington Township,President / Vice President,,Republican,"Romney, Mitt",23,000050
+CLARK,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+CLARK,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",0,000060
+CLARK,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+CLARK,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+CLARK,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",26,000060
+CLARK,Sitka Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+CLARK,Sitka Township,President / Vice President,,Democratic,"Obama, Barack",5,000070
+CLARK,Sitka Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+CLARK,Sitka Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+CLARK,Sitka Township,President / Vice President,,Republican,"Romney, Mitt",34,000070
+CLARK,Appleton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",324,000010
+CLARK,Center 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",219,000020
+CLARK,Center 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",165,000030
+CLARK,Englewood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,000040
+CLARK,Lexington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000050
+CLARK,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000060
+CLARK,Sitka Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000070

--- a/2012/20121106__ks__general__clay__precinct.csv
+++ b/2012/20121106__ks__general__clay__precinct.csv
@@ -1,0 +1,584 @@
+county,precinct,office,district,party,candidate,votes,vtd
+CLAY,Athelstane Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",4,000010
+CLAY,Athelstane Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",50,000010
+CLAY,Blaine Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",9,000020
+CLAY,Blaine Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",123,000020
+CLAY,Bloom Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",4,000030
+CLAY,Bloom Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",50,000030
+CLAY,Chapman Township,Kansas House of Representatives,70,Republican,"Barker, John E",65,000040
+CLAY,Clay Center Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",26,00005A
+CLAY,Clay Center Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",157,00005A
+CLAY,Clay Center Township Enclave,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",0,00005B
+CLAY,Clay Center Township Enclave,Kansas House of Representatives,64,Republican,"Swanson, Vern",0,00005B
+CLAY,Clay Center Ward 1,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",58,00006A
+CLAY,Clay Center Ward 1,Kansas House of Representatives,64,Republican,"Swanson, Vern",503,00006A
+CLAY,Clay Center Ward 1 Exclave,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",0,00006B
+CLAY,Clay Center Ward 1 Exclave,Kansas House of Representatives,64,Republican,"Swanson, Vern",0,00006B
+CLAY,Clay Center Ward 2,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",71,000070
+CLAY,Clay Center Ward 2,Kansas House of Representatives,64,Republican,"Swanson, Vern",520,000070
+CLAY,Clay Center Ward 3,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",28,000080
+CLAY,Clay Center Ward 3,Kansas House of Representatives,64,Republican,"Swanson, Vern",323,000080
+CLAY,Clay Center Ward 4,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",47,000090
+CLAY,Clay Center Ward 4,Kansas House of Representatives,64,Republican,"Swanson, Vern",250,000090
+CLAY,Exeter Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",9,000100
+CLAY,Exeter Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",36,000100
+CLAY,Five Creeks Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",8,000110
+CLAY,Five Creeks Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",50,000110
+CLAY,Garfield Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",3,000120
+CLAY,Garfield Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",45,000120
+CLAY,Gill Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",8,000130
+CLAY,Gill Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",69,000130
+CLAY,Goshen Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",8,000140
+CLAY,Goshen Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",20,000140
+CLAY,Grant Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",10,000150
+CLAY,Grant Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",76,000150
+CLAY,Hayes Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",16,000160
+CLAY,Hayes Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",90,000160
+CLAY,Highland Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",14,000170
+CLAY,Highland Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",110,000170
+CLAY,Mulberry Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",10,000180
+CLAY,Mulberry Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",101,000180
+CLAY,Oakland Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",7,000190
+CLAY,Oakland Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",30,000190
+CLAY,Republican Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",62,000200
+CLAY,Republican Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",316,000200
+CLAY,Sherman Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",12,000210
+CLAY,Sherman Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",93,000210
+CLAY,Union Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",14,000220
+CLAY,Union Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",74,000220
+CLAY,Clay Center Ward 4 Exclave,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",0,900230
+CLAY,Clay Center Ward 4 Exclave,Kansas House of Representatives,64,Republican,"Swanson, Vern",0,900230
+CLAY,Athelstane Township,Kansas Senate,22,Democratic,"Hawk, Tom",9,000010
+CLAY,Athelstane Township,Kansas Senate,22,Republican,"Reader, Bob",47,000010
+CLAY,Blaine Township,Kansas Senate,22,Democratic,"Hawk, Tom",52,000020
+CLAY,Blaine Township,Kansas Senate,22,Republican,"Reader, Bob",84,000020
+CLAY,Bloom Township,Kansas Senate,22,Democratic,"Hawk, Tom",21,000030
+CLAY,Bloom Township,Kansas Senate,22,Republican,"Reader, Bob",37,000030
+CLAY,Chapman Township,Kansas Senate,22,Democratic,"Hawk, Tom",24,000040
+CLAY,Chapman Township,Kansas Senate,22,Republican,"Reader, Bob",48,000040
+CLAY,Clay Center Township,Kansas Senate,22,Democratic,"Hawk, Tom",73,00005A
+CLAY,Clay Center Township,Kansas Senate,22,Republican,"Reader, Bob",110,00005A
+CLAY,Clay Center Township Enclave,Kansas Senate,22,Democratic,"Hawk, Tom",0,00005B
+CLAY,Clay Center Township Enclave,Kansas Senate,22,Republican,"Reader, Bob",0,00005B
+CLAY,Clay Center Ward 1,Kansas Senate,22,Democratic,"Hawk, Tom",284,00006A
+CLAY,Clay Center Ward 1,Kansas Senate,22,Republican,"Reader, Bob",280,00006A
+CLAY,Clay Center Ward 1 Exclave,Kansas Senate,22,Democratic,"Hawk, Tom",0,00006B
+CLAY,Clay Center Ward 1 Exclave,Kansas Senate,22,Republican,"Reader, Bob",0,00006B
+CLAY,Clay Center Ward 2,Kansas Senate,22,Democratic,"Hawk, Tom",261,000070
+CLAY,Clay Center Ward 2,Kansas Senate,22,Republican,"Reader, Bob",329,000070
+CLAY,Clay Center Ward 3,Kansas Senate,22,Democratic,"Hawk, Tom",127,000080
+CLAY,Clay Center Ward 3,Kansas Senate,22,Republican,"Reader, Bob",226,000080
+CLAY,Clay Center Ward 4,Kansas Senate,22,Democratic,"Hawk, Tom",130,000090
+CLAY,Clay Center Ward 4,Kansas Senate,22,Republican,"Reader, Bob",169,000090
+CLAY,Exeter Township,Kansas Senate,22,Democratic,"Hawk, Tom",11,000100
+CLAY,Exeter Township,Kansas Senate,22,Republican,"Reader, Bob",35,000100
+CLAY,Five Creeks Township,Kansas Senate,22,Democratic,"Hawk, Tom",22,000110
+CLAY,Five Creeks Township,Kansas Senate,22,Republican,"Reader, Bob",34,000110
+CLAY,Garfield Township,Kansas Senate,22,Democratic,"Hawk, Tom",10,000120
+CLAY,Garfield Township,Kansas Senate,22,Republican,"Reader, Bob",38,000120
+CLAY,Gill Township,Kansas Senate,22,Democratic,"Hawk, Tom",21,000130
+CLAY,Gill Township,Kansas Senate,22,Republican,"Reader, Bob",60,000130
+CLAY,Goshen Township,Kansas Senate,22,Democratic,"Hawk, Tom",14,000140
+CLAY,Goshen Township,Kansas Senate,22,Republican,"Reader, Bob",15,000140
+CLAY,Grant Township,Kansas Senate,22,Democratic,"Hawk, Tom",22,000150
+CLAY,Grant Township,Kansas Senate,22,Republican,"Reader, Bob",66,000150
+CLAY,Hayes Township,Kansas Senate,22,Democratic,"Hawk, Tom",36,000160
+CLAY,Hayes Township,Kansas Senate,22,Republican,"Reader, Bob",70,000160
+CLAY,Highland Township,Kansas Senate,22,Democratic,"Hawk, Tom",50,000170
+CLAY,Highland Township,Kansas Senate,22,Republican,"Reader, Bob",81,000170
+CLAY,Mulberry Township,Kansas Senate,22,Democratic,"Hawk, Tom",25,000180
+CLAY,Mulberry Township,Kansas Senate,22,Republican,"Reader, Bob",88,000180
+CLAY,Oakland Township,Kansas Senate,22,Democratic,"Hawk, Tom",16,000190
+CLAY,Oakland Township,Kansas Senate,22,Republican,"Reader, Bob",22,000190
+CLAY,Republican Township,Kansas Senate,22,Democratic,"Hawk, Tom",97,000200
+CLAY,Republican Township,Kansas Senate,22,Republican,"Reader, Bob",288,000200
+CLAY,Sherman Township,Kansas Senate,22,Democratic,"Hawk, Tom",41,000210
+CLAY,Sherman Township,Kansas Senate,22,Republican,"Reader, Bob",68,000210
+CLAY,Union Township,Kansas Senate,22,Democratic,"Hawk, Tom",32,000220
+CLAY,Union Township,Kansas Senate,22,Republican,"Reader, Bob",54,000220
+CLAY,Clay Center Ward 4 Exclave,Kansas Senate,22,Democratic,"Hawk, Tom",0,900230
+CLAY,Clay Center Ward 4 Exclave,Kansas Senate,22,Republican,"Reader, Bob",0,900230
+CLAY,Athelstane Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+CLAY,Athelstane Township,President / Vice President,,Democratic,"Obama, Barack",2,000010
+CLAY,Athelstane Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+CLAY,Athelstane Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+CLAY,Athelstane Township,President / Vice President,,Republican,"Romney, Mitt",54,000010
+CLAY,Blaine Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+CLAY,Blaine Township,President / Vice President,,Democratic,"Obama, Barack",26,000020
+CLAY,Blaine Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+CLAY,Blaine Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+CLAY,Blaine Township,President / Vice President,,Republican,"Romney, Mitt",112,000020
+CLAY,Bloom Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+CLAY,Bloom Township,President / Vice President,,Democratic,"Obama, Barack",6,000030
+CLAY,Bloom Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+CLAY,Bloom Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+CLAY,Bloom Township,President / Vice President,,Republican,"Romney, Mitt",52,000030
+CLAY,Chapman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+CLAY,Chapman Township,President / Vice President,,Democratic,"Obama, Barack",22,000040
+CLAY,Chapman Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+CLAY,Chapman Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+CLAY,Chapman Township,President / Vice President,,Republican,"Romney, Mitt",48,000040
+CLAY,Clay Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Barnett, Andre",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Bush, Kent W",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Christensen, Will",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Goode, Virgil",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Stein, Jill E",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00005A
+CLAY,Clay Center Township,President / Vice President,,Democratic,"Obama, Barack",23,00005A
+CLAY,Clay Center Township,President / Vice President,,Libertarian,"Johnson, Gary",3,00005A
+CLAY,Clay Center Township,President / Vice President,,Reform,"Baldwin, Chuck",2,00005A
+CLAY,Clay Center Township,President / Vice President,,Republican,"Romney, Mitt",155,00005A
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Christensen, Will",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00005B
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Christensen, Will",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,Democratic,"Obama, Barack",158,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",7,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,Republican,"Romney, Mitt",409,00006A
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,Democratic,"Obama, Barack",163,000070
+CLAY,Clay Center Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",8,000070
+CLAY,Clay Center Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000070
+CLAY,Clay Center Ward 2,President / Vice President,,Republican,"Romney, Mitt",432,000070
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,Democratic,"Obama, Barack",83,000080
+CLAY,Clay Center Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",5,000080
+CLAY,Clay Center Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+CLAY,Clay Center Ward 3,President / Vice President,,Republican,"Romney, Mitt",264,000080
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,Democratic,"Obama, Barack",101,000090
+CLAY,Clay Center Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",2,000090
+CLAY,Clay Center Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",2,000090
+CLAY,Clay Center Ward 4,President / Vice President,,Republican,"Romney, Mitt",207,000090
+CLAY,Exeter Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+CLAY,Exeter Township,President / Vice President,,Democratic,"Obama, Barack",4,000100
+CLAY,Exeter Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+CLAY,Exeter Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+CLAY,Exeter Township,President / Vice President,,Republican,"Romney, Mitt",42,000100
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+CLAY,Five Creeks Township,President / Vice President,,Democratic,"Obama, Barack",7,000110
+CLAY,Five Creeks Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+CLAY,Five Creeks Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+CLAY,Five Creeks Township,President / Vice President,,Republican,"Romney, Mitt",50,000110
+CLAY,Garfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+CLAY,Garfield Township,President / Vice President,,Democratic,"Obama, Barack",7,000120
+CLAY,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000120
+CLAY,Garfield Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+CLAY,Garfield Township,President / Vice President,,Republican,"Romney, Mitt",42,000120
+CLAY,Gill Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+CLAY,Gill Township,President / Vice President,,Democratic,"Obama, Barack",16,000130
+CLAY,Gill Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+CLAY,Gill Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+CLAY,Gill Township,President / Vice President,,Republican,"Romney, Mitt",65,000130
+CLAY,Goshen Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+CLAY,Goshen Township,President / Vice President,,Democratic,"Obama, Barack",12,000140
+CLAY,Goshen Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+CLAY,Goshen Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+CLAY,Goshen Township,President / Vice President,,Republican,"Romney, Mitt",16,000140
+CLAY,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+CLAY,Grant Township,President / Vice President,,Democratic,"Obama, Barack",9,000150
+CLAY,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000150
+CLAY,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+CLAY,Grant Township,President / Vice President,,Republican,"Romney, Mitt",75,000150
+CLAY,Hayes Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+CLAY,Hayes Township,President / Vice President,,Democratic,"Obama, Barack",12,000160
+CLAY,Hayes Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+CLAY,Hayes Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+CLAY,Hayes Township,President / Vice President,,Republican,"Romney, Mitt",95,000160
+CLAY,Highland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+CLAY,Highland Township,President / Vice President,,Democratic,"Obama, Barack",29,000170
+CLAY,Highland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+CLAY,Highland Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000170
+CLAY,Highland Township,President / Vice President,,Republican,"Romney, Mitt",104,000170
+CLAY,Mulberry Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+CLAY,Mulberry Township,President / Vice President,,Democratic,"Obama, Barack",19,000180
+CLAY,Mulberry Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000180
+CLAY,Mulberry Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+CLAY,Mulberry Township,President / Vice President,,Republican,"Romney, Mitt",95,000180
+CLAY,Oakland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+CLAY,Oakland Township,President / Vice President,,Democratic,"Obama, Barack",9,000190
+CLAY,Oakland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+CLAY,Oakland Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000190
+CLAY,Oakland Township,President / Vice President,,Republican,"Romney, Mitt",27,000190
+CLAY,Republican Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+CLAY,Republican Township,President / Vice President,,Democratic,"Obama, Barack",76,000200
+CLAY,Republican Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000200
+CLAY,Republican Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000200
+CLAY,Republican Township,President / Vice President,,Republican,"Romney, Mitt",298,000200
+CLAY,Sherman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+CLAY,Sherman Township,President / Vice President,,Democratic,"Obama, Barack",27,000210
+CLAY,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+CLAY,Sherman Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000210
+CLAY,Sherman Township,President / Vice President,,Republican,"Romney, Mitt",81,000210
+CLAY,Union Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+CLAY,Union Township,President / Vice President,,Democratic,"Obama, Barack",23,000220
+CLAY,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+CLAY,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000220
+CLAY,Union Township,President / Vice President,,Republican,"Romney, Mitt",65,000220
+CLAY,Athelstane Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000010
+CLAY,Blaine Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",118,000020
+CLAY,Bloom Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000030
+CLAY,Chapman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,000040
+CLAY,Clay Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",159,00005A
+CLAY,Clay Center Township Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00005B
+CLAY,Clay Center Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",448,00006A
+CLAY,Clay Center Ward 1 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006B
+CLAY,Clay Center Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",483,000070
+CLAY,Clay Center Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",316,000080
+CLAY,Clay Center Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",250,000090
+CLAY,Exeter Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",41,000100
+CLAY,Five Creeks Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",50,000110
+CLAY,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",42,000120
+CLAY,Gill Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",74,000130
+CLAY,Goshen Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000140
+CLAY,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",81,000150
+CLAY,Hayes Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",94,000160
+CLAY,Highland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",110,000170
+CLAY,Mulberry Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",100,000180
+CLAY,Oakland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000190
+CLAY,Republican Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",357,000200
+CLAY,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",92,000210
+CLAY,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",78,000220

--- a/2012/20121106__ks__general__cloud__precinct.csv
+++ b/2012/20121106__ks__general__cloud__precinct.csv
@@ -1,0 +1,697 @@
+county,precinct,office,district,party,candidate,votes,vtd
+CLOUD,Arion Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",43,000010
+CLOUD,Aurora Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",52,000020
+CLOUD,Buffalo Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",50,000030
+CLOUD,Center Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",77,000040
+CLOUD,Colfax Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",20,000050
+CLOUD,Concordia Ward 1,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",298,00006A
+CLOUD,Concordia Ward 1 Exclave A,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",336,000070
+CLOUD,Concordia Ward 2 Precinct 2,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",412,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00008B
+CLOUD,Concordia Ward 3,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",530,000090
+CLOUD,Concordia Ward 4,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",237,000100
+CLOUD,East Lincoln,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",98,00011A
+CLOUD,East Lincoln Enclave,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00011B
+CLOUD,East Meredith,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",16,000120
+CLOUD,Elk Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",273,000130
+CLOUD,Grant Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",122,000140
+CLOUD,Lyon Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",44,000150
+CLOUD,Nelson Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",43,000160
+CLOUD,North Lawrence,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",24,000170
+CLOUD,Oakland Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",19,000180
+CLOUD,Shirley Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",53,000190
+CLOUD,Sibley Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",75,000200
+CLOUD,Solomon Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",213,000210
+CLOUD,South Lawrence,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",23,000220
+CLOUD,Starr Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",217,000230
+CLOUD,Summit Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",25,000240
+CLOUD,West Lincoln,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",65,000250
+CLOUD,West Meredith,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",10,000260
+CLOUD,Arion Township,Kansas Senate,36,Democratic,"Clark, Marquis",11,000010
+CLOUD,Arion Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",40,000010
+CLOUD,Aurora Township,Kansas Senate,36,Democratic,"Clark, Marquis",10,000020
+CLOUD,Aurora Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",55,000020
+CLOUD,Buffalo Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000030
+CLOUD,Buffalo Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",61,000030
+CLOUD,Center Township,Kansas Senate,36,Democratic,"Clark, Marquis",9,000040
+CLOUD,Center Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",93,000040
+CLOUD,Colfax Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000050
+CLOUD,Colfax Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",22,000050
+CLOUD,Concordia Ward 1,Kansas Senate,36,Democratic,"Clark, Marquis",85,00006A
+CLOUD,Concordia Ward 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",275,00006A
+CLOUD,Concordia Ward 1 Exclave A,Kansas Senate,36,Democratic,"Clark, Marquis",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,Kansas Senate,36,Democratic,"Clark, Marquis",64,000070
+CLOUD,Concordia Ward 2 Precinct 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",326,000070
+CLOUD,Concordia Ward 2 Precinct 2,Kansas Senate,36,Democratic,"Clark, Marquis",83,00008A
+CLOUD,Concordia Ward 2 Precinct 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",403,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Kansas Senate,36,Democratic,"Clark, Marquis",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00008B
+CLOUD,Concordia Ward 3,Kansas Senate,36,Democratic,"Clark, Marquis",87,000090
+CLOUD,Concordia Ward 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",539,000090
+CLOUD,Concordia Ward 4,Kansas Senate,36,Democratic,"Clark, Marquis",43,000100
+CLOUD,Concordia Ward 4,Kansas Senate,36,Republican,"Bowers, Elaine S.",244,000100
+CLOUD,East Lincoln,Kansas Senate,36,Democratic,"Clark, Marquis",25,00011A
+CLOUD,East Lincoln,Kansas Senate,36,Republican,"Bowers, Elaine S.",95,00011A
+CLOUD,East Lincoln Enclave,Kansas Senate,36,Democratic,"Clark, Marquis",0,00011B
+CLOUD,East Lincoln Enclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00011B
+CLOUD,East Meredith,Kansas Senate,36,Democratic,"Clark, Marquis",1,000120
+CLOUD,East Meredith,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000120
+CLOUD,Elk Township,Kansas Senate,36,Democratic,"Clark, Marquis",50,000130
+CLOUD,Elk Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",310,000130
+CLOUD,Grant Township,Kansas Senate,36,Democratic,"Clark, Marquis",17,000140
+CLOUD,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",124,000140
+CLOUD,Lyon Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000150
+CLOUD,Lyon Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",46,000150
+CLOUD,Nelson Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000160
+CLOUD,Nelson Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",49,000160
+CLOUD,North Lawrence,Kansas Senate,36,Democratic,"Clark, Marquis",3,000170
+CLOUD,North Lawrence,Kansas Senate,36,Republican,"Bowers, Elaine S.",28,000170
+CLOUD,Oakland Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000180
+CLOUD,Oakland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",20,000180
+CLOUD,Shirley Township,Kansas Senate,36,Democratic,"Clark, Marquis",9,000190
+CLOUD,Shirley Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",58,000190
+CLOUD,Sibley Township,Kansas Senate,36,Democratic,"Clark, Marquis",23,000200
+CLOUD,Sibley Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",79,000200
+CLOUD,Solomon Township,Kansas Senate,36,Democratic,"Clark, Marquis",29,000210
+CLOUD,Solomon Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",209,000210
+CLOUD,South Lawrence,Kansas Senate,36,Democratic,"Clark, Marquis",4,000220
+CLOUD,South Lawrence,Kansas Senate,36,Republican,"Bowers, Elaine S.",25,000220
+CLOUD,Starr Township,Kansas Senate,36,Democratic,"Clark, Marquis",28,000230
+CLOUD,Starr Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",218,000230
+CLOUD,Summit Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000240
+CLOUD,Summit Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",25,000240
+CLOUD,West Lincoln,Kansas Senate,36,Democratic,"Clark, Marquis",9,000250
+CLOUD,West Lincoln,Kansas Senate,36,Republican,"Bowers, Elaine S.",70,000250
+CLOUD,West Meredith,Kansas Senate,36,Democratic,"Clark, Marquis",0,000260
+CLOUD,West Meredith,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000260
+CLOUD,Arion Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Stein, Jill E",2,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+CLOUD,Arion Township,President / Vice President,,Democratic,"Obama, Barack",11,000010
+CLOUD,Arion Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+CLOUD,Arion Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+CLOUD,Arion Township,President / Vice President,,Republican,"Romney, Mitt",37,000010
+CLOUD,Aurora Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+CLOUD,Aurora Township,President / Vice President,,Democratic,"Obama, Barack",13,000020
+CLOUD,Aurora Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+CLOUD,Aurora Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+CLOUD,Aurora Township,President / Vice President,,Republican,"Romney, Mitt",52,000020
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+CLOUD,Buffalo Township,President / Vice President,,Democratic,"Obama, Barack",7,000030
+CLOUD,Buffalo Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+CLOUD,Buffalo Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+CLOUD,Buffalo Township,President / Vice President,,Republican,"Romney, Mitt",56,000030
+CLOUD,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+CLOUD,Center Township,President / Vice President,,Democratic,"Obama, Barack",9,000040
+CLOUD,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+CLOUD,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+CLOUD,Center Township,President / Vice President,,Republican,"Romney, Mitt",92,000040
+CLOUD,Colfax Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+CLOUD,Colfax Township,President / Vice President,,Democratic,"Obama, Barack",3,000050
+CLOUD,Colfax Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+CLOUD,Colfax Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+CLOUD,Colfax Township,President / Vice President,,Republican,"Romney, Mitt",18,000050
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",1,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Christensen, Will",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,Democratic,"Obama, Barack",115,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",12,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,Republican,"Romney, Mitt",236,00006A
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",108,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",10,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",262,000070
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",140,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",10,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",333,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00008B
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,Democratic,"Obama, Barack",160,000090
+CLOUD,Concordia Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",21,000090
+CLOUD,Concordia Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+CLOUD,Concordia Ward 3,President / Vice President,,Republican,"Romney, Mitt",444,000090
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,Democratic,"Obama, Barack",70,000100
+CLOUD,Concordia Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",4,000100
+CLOUD,Concordia Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",2,000100
+CLOUD,Concordia Ward 4,President / Vice President,,Republican,"Romney, Mitt",207,000100
+CLOUD,East Lincoln,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Ayers, Avery L",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Barnett, Andre",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Barr, Roseanne C",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Bush, Kent W",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Christensen, Will",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Duncan, Richard A",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Goode, Virgil",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Hoefling, Tom",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Knill, Dennis J",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Reed, Jill A.",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Rogers, Rick L",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Stein, Jill E",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Thorne, Kevin M",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Warner, Gerald L.",0,00011A
+CLOUD,East Lincoln,President / Vice President,,Democratic,"Obama, Barack",18,00011A
+CLOUD,East Lincoln,President / Vice President,,Libertarian,"Johnson, Gary",3,00011A
+CLOUD,East Lincoln,President / Vice President,,Reform,"Baldwin, Chuck",1,00011A
+CLOUD,East Lincoln,President / Vice President,,Republican,"Romney, Mitt",100,00011A
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Christensen, Will",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00011B
+CLOUD,East Meredith,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Barnett, Andre",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Bush, Kent W",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Christensen, Will",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Goode, Virgil",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Stein, Jill E",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+CLOUD,East Meredith,President / Vice President,,Democratic,"Obama, Barack",3,000120
+CLOUD,East Meredith,President / Vice President,,Libertarian,"Johnson, Gary",1,000120
+CLOUD,East Meredith,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+CLOUD,East Meredith,President / Vice President,,Republican,"Romney, Mitt",14,000120
+CLOUD,Elk Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Stein, Jill E",1,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+CLOUD,Elk Township,President / Vice President,,Democratic,"Obama, Barack",92,000130
+CLOUD,Elk Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000130
+CLOUD,Elk Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000130
+CLOUD,Elk Township,President / Vice President,,Republican,"Romney, Mitt",262,000130
+CLOUD,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+CLOUD,Grant Township,President / Vice President,,Democratic,"Obama, Barack",32,000140
+CLOUD,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000140
+CLOUD,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000140
+CLOUD,Grant Township,President / Vice President,,Republican,"Romney, Mitt",106,000140
+CLOUD,Lyon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+CLOUD,Lyon Township,President / Vice President,,Democratic,"Obama, Barack",9,000150
+CLOUD,Lyon Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+CLOUD,Lyon Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+CLOUD,Lyon Township,President / Vice President,,Republican,"Romney, Mitt",38,000150
+CLOUD,Nelson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+CLOUD,Nelson Township,President / Vice President,,Democratic,"Obama, Barack",9,000160
+CLOUD,Nelson Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000160
+CLOUD,Nelson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+CLOUD,Nelson Township,President / Vice President,,Republican,"Romney, Mitt",42,000160
+CLOUD,North Lawrence,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Barnett, Andre",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Bush, Kent W",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Christensen, Will",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Goode, Virgil",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Stein, Jill E",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+CLOUD,North Lawrence,President / Vice President,,Democratic,"Obama, Barack",1,000170
+CLOUD,North Lawrence,President / Vice President,,Libertarian,"Johnson, Gary",1,000170
+CLOUD,North Lawrence,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+CLOUD,North Lawrence,President / Vice President,,Republican,"Romney, Mitt",29,000170
+CLOUD,Oakland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+CLOUD,Oakland Township,President / Vice President,,Democratic,"Obama, Barack",1,000180
+CLOUD,Oakland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+CLOUD,Oakland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+CLOUD,Oakland Township,President / Vice President,,Republican,"Romney, Mitt",21,000180
+CLOUD,Shirley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+CLOUD,Shirley Township,President / Vice President,,Democratic,"Obama, Barack",10,000190
+CLOUD,Shirley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+CLOUD,Shirley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+CLOUD,Shirley Township,President / Vice President,,Republican,"Romney, Mitt",55,000190
+CLOUD,Sibley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+CLOUD,Sibley Township,President / Vice President,,Democratic,"Obama, Barack",31,000200
+CLOUD,Sibley Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000200
+CLOUD,Sibley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+CLOUD,Sibley Township,President / Vice President,,Republican,"Romney, Mitt",67,000200
+CLOUD,Solomon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+CLOUD,Solomon Township,President / Vice President,,Democratic,"Obama, Barack",51,000210
+CLOUD,Solomon Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000210
+CLOUD,Solomon Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000210
+CLOUD,Solomon Township,President / Vice President,,Republican,"Romney, Mitt",184,000210
+CLOUD,South Lawrence,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Barnett, Andre",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Bush, Kent W",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Christensen, Will",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Goode, Virgil",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Stein, Jill E",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+CLOUD,South Lawrence,President / Vice President,,Democratic,"Obama, Barack",9,000220
+CLOUD,South Lawrence,President / Vice President,,Libertarian,"Johnson, Gary",2,000220
+CLOUD,South Lawrence,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+CLOUD,South Lawrence,President / Vice President,,Republican,"Romney, Mitt",18,000220
+CLOUD,Starr Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+CLOUD,Starr Township,President / Vice President,,Democratic,"Obama, Barack",44,000230
+CLOUD,Starr Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000230
+CLOUD,Starr Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000230
+CLOUD,Starr Township,President / Vice President,,Republican,"Romney, Mitt",191,000230
+CLOUD,Summit Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+CLOUD,Summit Township,President / Vice President,,Democratic,"Obama, Barack",1,000240
+CLOUD,Summit Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000240
+CLOUD,Summit Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000240
+CLOUD,Summit Township,President / Vice President,,Republican,"Romney, Mitt",25,000240
+CLOUD,West Lincoln,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Barnett, Andre",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Bush, Kent W",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Christensen, Will",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Goode, Virgil",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Stein, Jill E",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+CLOUD,West Lincoln,President / Vice President,,Democratic,"Obama, Barack",22,000250
+CLOUD,West Lincoln,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+CLOUD,West Lincoln,President / Vice President,,Reform,"Baldwin, Chuck",1,000250
+CLOUD,West Lincoln,President / Vice President,,Republican,"Romney, Mitt",55,000250
+CLOUD,West Meredith,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Barnett, Andre",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Bush, Kent W",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Christensen, Will",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Goode, Virgil",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Stein, Jill E",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+CLOUD,West Meredith,President / Vice President,,Democratic,"Obama, Barack",5,000260
+CLOUD,West Meredith,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+CLOUD,West Meredith,President / Vice President,,Reform,"Baldwin, Chuck",0,000260
+CLOUD,West Meredith,President / Vice President,,Republican,"Romney, Mitt",10,000260
+CLOUD,Arion Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",41,000010
+CLOUD,Aurora Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000020
+CLOUD,Buffalo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",56,000030
+CLOUD,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",80,000040
+CLOUD,Colfax Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000050
+CLOUD,Concordia Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",289,00006A
+CLOUD,Concordia Ward 1 Exclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",322,000070
+CLOUD,Concordia Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",386,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00008B
+CLOUD,Concordia Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",517,000090
+CLOUD,Concordia Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",232,000100
+CLOUD,East Lincoln,United States House of Representatives,1,Republican,"Huelskamp, Tim",99,00011A
+CLOUD,East Lincoln Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00011B
+CLOUD,East Meredith,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000120
+CLOUD,Elk Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",270,000130
+CLOUD,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",119,000140
+CLOUD,Lyon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",42,000150
+CLOUD,Nelson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",46,000160
+CLOUD,North Lawrence,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000170
+CLOUD,Oakland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000180
+CLOUD,Shirley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",54,000190
+CLOUD,Sibley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",74,000200
+CLOUD,Solomon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",202,000210
+CLOUD,South Lawrence,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000220
+CLOUD,Starr Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",212,000230
+CLOUD,Summit Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000240
+CLOUD,West Lincoln,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,000250
+CLOUD,West Meredith,United States House of Representatives,1,Republican,"Huelskamp, Tim",10,000260

--- a/2012/20121106__ks__general__coffey__precinct.csv
+++ b/2012/20121106__ks__general__coffey__precinct.csv
@@ -1,0 +1,562 @@
+county,precinct,office,district,party,candidate,votes,vtd
+COFFEY,Avon Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",33,000010
+COFFEY,Avon Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",65,000010
+COFFEY,Burlington Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",40,000020
+COFFEY,Burlington Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",146,000020
+COFFEY,Burlington Ward 1,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",121,000030
+COFFEY,Burlington Ward 1,Kansas House of Representatives,76,Republican,"Mast, Peggy",282,000030
+COFFEY,Burlington Ward 2,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",93,00004A
+COFFEY,Burlington Ward 2,Kansas House of Representatives,76,Republican,"Mast, Peggy",238,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,Kansas House of Representatives,76,Republican,"Mast, Peggy",0,00004B
+COFFEY,Burlington Ward 3,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",109,00005A
+COFFEY,Burlington Ward 3,Kansas House of Representatives,76,Republican,"Mast, Peggy",261,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Kansas House of Representatives,76,Republican,"Mast, Peggy",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Kansas House of Representatives,76,Republican,"Mast, Peggy",0,00005C
+COFFEY,Hampden Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",23,000060
+COFFEY,Hampden Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",49,000060
+COFFEY,Key West Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",41,000070
+COFFEY,Key West Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",83,000070
+COFFEY,Leroy Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",91,000080
+COFFEY,Leroy Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",185,000080
+COFFEY,Liberty Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",108,000090
+COFFEY,Liberty Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",158,000090
+COFFEY,Lincoln Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",240,000100
+COFFEY,Lincoln Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",307,000100
+COFFEY,Neosho Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",22,000110
+COFFEY,Neosho Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",48,000110
+COFFEY,Ottumwa Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",106,000120
+COFFEY,Ottumwa Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",269,000120
+COFFEY,Pleasant Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",41,000130
+COFFEY,Pleasant Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",78,000130
+COFFEY,Pottawatomie Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",26,000140
+COFFEY,Pottawatomie Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",63,000140
+COFFEY,Rock Creek Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",117,000150
+COFFEY,Rock Creek Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",270,000150
+COFFEY,Spring Creek Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",21,000160
+COFFEY,Spring Creek Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",58,000160
+COFFEY,Star Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",12,000170
+COFFEY,Star Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",57,000170
+COFFEY,Burlington Ward 2 Exclave 2,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,Kansas House of Representatives,76,Republican,"Mast, Peggy",0,900010
+COFFEY,Burlington Township Enclave 1,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",0,900020
+COFFEY,Burlington Township Enclave 1,Kansas House of Representatives,76,Republican,"Mast, Peggy",0,900020
+COFFEY,Burlington Township Enclave 2,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",0,900030
+COFFEY,Burlington Township Enclave 2,Kansas House of Representatives,76,Republican,"Mast, Peggy",0,900030
+COFFEY,Avon Township,Kansas Senate,14,Democratic,"Fuson, Eden",20,000010
+COFFEY,Avon Township,Kansas Senate,14,Republican,"Knox, Forrest J.",73,000010
+COFFEY,Burlington Township,Kansas Senate,14,Democratic,"Fuson, Eden",35,000020
+COFFEY,Burlington Township,Kansas Senate,14,Republican,"Knox, Forrest J.",147,000020
+COFFEY,Burlington Ward 1,Kansas Senate,14,Democratic,"Fuson, Eden",84,000030
+COFFEY,Burlington Ward 1,Kansas Senate,14,Republican,"Knox, Forrest J.",305,000030
+COFFEY,Burlington Ward 2,Kansas Senate,14,Democratic,"Fuson, Eden",67,00004A
+COFFEY,Burlington Ward 2,Kansas Senate,14,Republican,"Knox, Forrest J.",257,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,Kansas Senate,14,Democratic,"Fuson, Eden",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,Kansas Senate,14,Republican,"Knox, Forrest J.",0,00004B
+COFFEY,Burlington Ward 3,Kansas Senate,14,Democratic,"Fuson, Eden",74,00005A
+COFFEY,Burlington Ward 3,Kansas Senate,14,Republican,"Knox, Forrest J.",284,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Kansas Senate,14,Democratic,"Fuson, Eden",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Kansas Senate,14,Republican,"Knox, Forrest J.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Kansas Senate,14,Democratic,"Fuson, Eden",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Kansas Senate,14,Republican,"Knox, Forrest J.",0,00005C
+COFFEY,Hampden Township,Kansas Senate,14,Democratic,"Fuson, Eden",16,000060
+COFFEY,Hampden Township,Kansas Senate,14,Republican,"Knox, Forrest J.",53,000060
+COFFEY,Key West Township,Kansas Senate,14,Democratic,"Fuson, Eden",22,000070
+COFFEY,Key West Township,Kansas Senate,14,Republican,"Knox, Forrest J.",95,000070
+COFFEY,Leroy Township,Kansas Senate,14,Democratic,"Fuson, Eden",46,000080
+COFFEY,Leroy Township,Kansas Senate,14,Republican,"Knox, Forrest J.",228,000080
+COFFEY,Liberty Township,Kansas Senate,14,Democratic,"Fuson, Eden",49,000090
+COFFEY,Liberty Township,Kansas Senate,14,Republican,"Knox, Forrest J.",209,000090
+COFFEY,Lincoln Township,Kansas Senate,14,Democratic,"Fuson, Eden",126,000100
+COFFEY,Lincoln Township,Kansas Senate,14,Republican,"Knox, Forrest J.",393,000100
+COFFEY,Neosho Township,Kansas Senate,14,Democratic,"Fuson, Eden",14,000110
+COFFEY,Neosho Township,Kansas Senate,14,Republican,"Knox, Forrest J.",54,000110
+COFFEY,Ottumwa Township,Kansas Senate,14,Democratic,"Fuson, Eden",83,000120
+COFFEY,Ottumwa Township,Kansas Senate,14,Republican,"Knox, Forrest J.",282,000120
+COFFEY,Pleasant Township,Kansas Senate,14,Democratic,"Fuson, Eden",32,000130
+COFFEY,Pleasant Township,Kansas Senate,14,Republican,"Knox, Forrest J.",82,000130
+COFFEY,Pottawatomie Township,Kansas Senate,14,Democratic,"Fuson, Eden",15,000140
+COFFEY,Pottawatomie Township,Kansas Senate,14,Republican,"Knox, Forrest J.",71,000140
+COFFEY,Rock Creek Township,Kansas Senate,14,Democratic,"Fuson, Eden",85,000150
+COFFEY,Rock Creek Township,Kansas Senate,14,Republican,"Knox, Forrest J.",294,000150
+COFFEY,Spring Creek Township,Kansas Senate,14,Democratic,"Fuson, Eden",10,000160
+COFFEY,Spring Creek Township,Kansas Senate,14,Republican,"Knox, Forrest J.",66,000160
+COFFEY,Star Township,Kansas Senate,14,Democratic,"Fuson, Eden",10,000170
+COFFEY,Star Township,Kansas Senate,14,Republican,"Knox, Forrest J.",56,000170
+COFFEY,Burlington Ward 2 Exclave 2,Kansas Senate,14,Democratic,"Fuson, Eden",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,Kansas Senate,14,Republican,"Knox, Forrest J.",0,900010
+COFFEY,Burlington Township Enclave 1,Kansas Senate,14,Democratic,"Fuson, Eden",0,900020
+COFFEY,Burlington Township Enclave 1,Kansas Senate,14,Republican,"Knox, Forrest J.",0,900020
+COFFEY,Burlington Township Enclave 2,Kansas Senate,14,Democratic,"Fuson, Eden",0,900030
+COFFEY,Burlington Township Enclave 2,Kansas Senate,14,Republican,"Knox, Forrest J.",0,900030
+COFFEY,Avon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+COFFEY,Avon Township,President / Vice President,,Democratic,"Obama, Barack",22,000010
+COFFEY,Avon Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+COFFEY,Avon Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+COFFEY,Avon Township,President / Vice President,,Republican,"Romney, Mitt",77,000010
+COFFEY,Burlington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Goode, Virgil",2,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+COFFEY,Burlington Township,President / Vice President,,Democratic,"Obama, Barack",47,000020
+COFFEY,Burlington Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000020
+COFFEY,Burlington Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+COFFEY,Burlington Township,President / Vice President,,Republican,"Romney, Mitt",133,000020
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,Democratic,"Obama, Barack",95,000030
+COFFEY,Burlington Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",12,000030
+COFFEY,Burlington Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",3,000030
+COFFEY,Burlington Ward 1,President / Vice President,,Republican,"Romney, Mitt",304,000030
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Goode, Virgil",1,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,Democratic,"Obama, Barack",65,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",10,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",3,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,Republican,"Romney, Mitt",254,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Ayers, Avery L",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Barnett, Andre",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Barr, Roseanne C",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Bush, Kent W",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Christensen, Will",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Duncan, Richard A",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Goode, Virgil",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Hoefling, Tom",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Knill, Dennis J",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Reed, Jill A.",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Rogers, Rick L",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Stein, Jill E",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Thorne, Kevin M",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Warner, Gerald L.",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,Democratic,"Obama, Barack",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,Libertarian,"Johnson, Gary",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,Reform,"Baldwin, Chuck",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,Republican,"Romney, Mitt",0,00004B
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,Democratic,"Obama, Barack",70,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",2,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",6,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,Republican,"Romney, Mitt",291,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Ayers, Avery L",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Barnett, Andre",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Barr, Roseanne C",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Bush, Kent W",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Christensen, Will",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Duncan, Richard A",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Goode, Virgil",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Knill, Dennis J",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Reed, Jill A.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Rogers, Rick L",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Stein, Jill E",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Thorne, Kevin M",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Warner, Gerald L.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,Democratic,"Obama, Barack",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,Reform,"Baldwin, Chuck",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,Republican,"Romney, Mitt",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Ayers, Avery L",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Barnett, Andre",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Bush, Kent W",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Christensen, Will",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Duncan, Richard A",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Goode, Virgil",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Hoefling, Tom",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Knill, Dennis J",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Reed, Jill A.",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Rogers, Rick L",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Stein, Jill E",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,Democratic,"Obama, Barack",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,Libertarian,"Johnson, Gary",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,Reform,"Baldwin, Chuck",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,Republican,"Romney, Mitt",0,00005C
+COFFEY,Hampden Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+COFFEY,Hampden Township,President / Vice President,,Democratic,"Obama, Barack",15,000060
+COFFEY,Hampden Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+COFFEY,Hampden Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+COFFEY,Hampden Township,President / Vice President,,Republican,"Romney, Mitt",57,000060
+COFFEY,Key West Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+COFFEY,Key West Township,President / Vice President,,Democratic,"Obama, Barack",25,000070
+COFFEY,Key West Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000070
+COFFEY,Key West Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+COFFEY,Key West Township,President / Vice President,,Republican,"Romney, Mitt",95,000070
+COFFEY,Leroy Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Stein, Jill E",1,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+COFFEY,Leroy Township,President / Vice President,,Democratic,"Obama, Barack",67,000080
+COFFEY,Leroy Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000080
+COFFEY,Leroy Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+COFFEY,Leroy Township,President / Vice President,,Republican,"Romney, Mitt",211,000080
+COFFEY,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+COFFEY,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",54,000090
+COFFEY,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000090
+COFFEY,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+COFFEY,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",215,000090
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+COFFEY,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",156,000100
+COFFEY,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000100
+COFFEY,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+COFFEY,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",379,000100
+COFFEY,Neosho Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+COFFEY,Neosho Township,President / Vice President,,Democratic,"Obama, Barack",12,000110
+COFFEY,Neosho Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+COFFEY,Neosho Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+COFFEY,Neosho Township,President / Vice President,,Republican,"Romney, Mitt",58,000110
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,Democratic,"Obama, Barack",98,000120
+COFFEY,Ottumwa Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000120
+COFFEY,Ottumwa Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000120
+COFFEY,Ottumwa Township,President / Vice President,,Republican,"Romney, Mitt",266,000120
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+COFFEY,Pleasant Township,President / Vice President,,Democratic,"Obama, Barack",35,000130
+COFFEY,Pleasant Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+COFFEY,Pleasant Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+COFFEY,Pleasant Township,President / Vice President,,Republican,"Romney, Mitt",85,000130
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,Democratic,"Obama, Barack",18,000140
+COFFEY,Pottawatomie Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000140
+COFFEY,Pottawatomie Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,Republican,"Romney, Mitt",69,000140
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,Democratic,"Obama, Barack",98,000150
+COFFEY,Rock Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000150
+COFFEY,Rock Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000150
+COFFEY,Rock Creek Township,President / Vice President,,Republican,"Romney, Mitt",283,000150
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,Democratic,"Obama, Barack",10,000160
+COFFEY,Spring Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+COFFEY,Spring Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,Republican,"Romney, Mitt",71,000160
+COFFEY,Star Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+COFFEY,Star Township,President / Vice President,,Democratic,"Obama, Barack",11,000170
+COFFEY,Star Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+COFFEY,Star Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000170
+COFFEY,Star Township,President / Vice President,,Republican,"Romney, Mitt",55,000170
+COFFEY,Avon Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",23,000010
+COFFEY,Avon Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000010
+COFFEY,Avon Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",72,000010
+COFFEY,Burlington Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",41,000020
+COFFEY,Burlington Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000020
+COFFEY,Burlington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",138,000020
+COFFEY,Burlington Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",97,000030
+COFFEY,Burlington Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,000030
+COFFEY,Burlington Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",293,000030
+COFFEY,Burlington Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",76,00004A
+COFFEY,Burlington Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,00004A
+COFFEY,Burlington Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",243,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00004B
+COFFEY,Burlington Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",75,00005A
+COFFEY,Burlington Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",22,00005A
+COFFEY,Burlington Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",274,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005C
+COFFEY,Hampden Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",18,000060
+COFFEY,Hampden Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000060
+COFFEY,Hampden Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",50,000060
+COFFEY,Key West Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",30,000070
+COFFEY,Key West Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000070
+COFFEY,Key West Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",86,000070
+COFFEY,Leroy Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",58,000080
+COFFEY,Leroy Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000080
+COFFEY,Leroy Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",208,000080
+COFFEY,Liberty Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",62,000090
+COFFEY,Liberty Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000090
+COFFEY,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",201,000090
+COFFEY,Lincoln Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",144,000100
+COFFEY,Lincoln Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",24,000100
+COFFEY,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",378,000100
+COFFEY,Neosho Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",13,000110
+COFFEY,Neosho Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000110
+COFFEY,Neosho Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",53,000110
+COFFEY,Ottumwa Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",91,000120
+COFFEY,Ottumwa Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",22,000120
+COFFEY,Ottumwa Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",263,000120
+COFFEY,Pleasant Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",41,000130
+COFFEY,Pleasant Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000130
+COFFEY,Pleasant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000130
+COFFEY,Pottawatomie Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",19,000140
+COFFEY,Pottawatomie Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000140
+COFFEY,Pottawatomie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",64,000140
+COFFEY,Rock Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",91,000150
+COFFEY,Rock Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",24,000150
+COFFEY,Rock Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",275,000150
+COFFEY,Spring Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",14,000160
+COFFEY,Spring Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000160
+COFFEY,Spring Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,000160
+COFFEY,Star Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",16,000170
+COFFEY,Star Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000170
+COFFEY,Star Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",50,000170
+COFFEY,Burlington Ward 2 Exclave 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900010
+COFFEY,Burlington Ward 2 Exclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+COFFEY,Burlington Township Enclave 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900020
+COFFEY,Burlington Township Enclave 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900020
+COFFEY,Burlington Township Enclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+COFFEY,Burlington Township Enclave 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900030
+COFFEY,Burlington Township Enclave 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900030
+COFFEY,Burlington Township Enclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030

--- a/2012/20121106__ks__general__comanche__precinct.csv
+++ b/2012/20121106__ks__general__comanche__precinct.csv
@@ -1,0 +1,131 @@
+county,precinct,office,district,party,candidate,votes,vtd
+COMANCHE,Avilla Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",12,000010
+COMANCHE,Avilla Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",35,000010
+COMANCHE,Coldwater Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",135,000020
+COMANCHE,Coldwater Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",343,000020
+COMANCHE,Powell Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",7,000030
+COMANCHE,Powell Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",30,000030
+COMANCHE,Protection Township H115,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",38,120020
+COMANCHE,Protection Township H115,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",237,120020
+COMANCHE,Protection Township H116,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",15,120030
+COMANCHE,Protection Township H116,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",44,120030
+COMANCHE,Avilla Township,Kansas Senate,32,Republican,"Abrams, Steve E",42,000010
+COMANCHE,Coldwater Township,Kansas Senate,32,Republican,"Abrams, Steve E",426,000020
+COMANCHE,Powell Township,Kansas Senate,32,Republican,"Abrams, Steve E",36,000030
+COMANCHE,Protection Township H115,Kansas Senate,32,Republican,"Abrams, Steve E",252,120020
+COMANCHE,Protection Township H116,Kansas Senate,32,Republican,"Abrams, Steve E",47,120030
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+COMANCHE,Avilla Township,President / Vice President,,Democratic,"Obama, Barack",0,000010
+COMANCHE,Avilla Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+COMANCHE,Avilla Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+COMANCHE,Avilla Township,President / Vice President,,Republican,"Romney, Mitt",44,000010
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,Democratic,"Obama, Barack",103,000020
+COMANCHE,Coldwater Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000020
+COMANCHE,Coldwater Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,Republican,"Romney, Mitt",396,000020
+COMANCHE,Powell Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+COMANCHE,Powell Township,President / Vice President,,Democratic,"Obama, Barack",6,000030
+COMANCHE,Powell Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+COMANCHE,Powell Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+COMANCHE,Powell Township,President / Vice President,,Republican,"Romney, Mitt",33,000030
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Barnett, Andre",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Bush, Kent W",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Christensen, Will",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Goode, Virgil",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Stein, Jill E",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,Democratic,"Obama, Barack",28,120020
+COMANCHE,Protection Township H115,President / Vice President,,Libertarian,"Johnson, Gary",9,120020
+COMANCHE,Protection Township H115,President / Vice President,,Reform,"Baldwin, Chuck",1,120020
+COMANCHE,Protection Township H115,President / Vice President,,Republican,"Romney, Mitt",244,120020
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Barnett, Andre",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Bush, Kent W",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Christensen, Will",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Goode, Virgil",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Stein, Jill E",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,Democratic,"Obama, Barack",6,120030
+COMANCHE,Protection Township H116,President / Vice President,,Libertarian,"Johnson, Gary",1,120030
+COMANCHE,Protection Township H116,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,Republican,"Romney, Mitt",50,120030
+COMANCHE,Avilla Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000010
+COMANCHE,Avilla Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000010
+COMANCHE,Avilla Township,United States House of Representatives,4,Republican,"Pompeo, Mike",42,000010
+COMANCHE,Coldwater Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",85,000020
+COMANCHE,Coldwater Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",19,000020
+COMANCHE,Coldwater Township,United States House of Representatives,4,Republican,"Pompeo, Mike",392,000020
+COMANCHE,Powell Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",7,000030
+COMANCHE,Powell Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000030
+COMANCHE,Powell Township,United States House of Representatives,4,Republican,"Pompeo, Mike",41,000030
+COMANCHE,Protection Township H115,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",33,120020
+COMANCHE,Protection Township H115,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",14,120020
+COMANCHE,Protection Township H115,United States House of Representatives,4,Republican,"Pompeo, Mike",226,120020
+COMANCHE,Protection Township H116,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",5,120030
+COMANCHE,Protection Township H116,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,120030
+COMANCHE,Protection Township H116,United States House of Representatives,4,Republican,"Pompeo, Mike",49,120030

--- a/2012/20121106__ks__general__cowley__precinct.csv
+++ b/2012/20121106__ks__general__cowley__precinct.csv
@@ -1,0 +1,1787 @@
+county,precinct,office,district,party,candidate,votes,vtd
+COWLEY,Arkansas City Ward 1 A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",158,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",7,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,Kansas House of Representatives,80,Republican,"Kelley, Kasha",1,00001C
+COWLEY,Arkansas City Ward 1 B,Kansas House of Representatives,80,Republican,"Kelley, Kasha",133,000020
+COWLEY,Arkansas City Ward 1 C,Kansas House of Representatives,80,Republican,"Kelley, Kasha",242,000030
+COWLEY,Arkansas City Ward 1 D,Kansas House of Representatives,80,Republican,"Kelley, Kasha",205,000040
+COWLEY,Arkansas City Ward 2 A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",242,000050
+COWLEY,Arkansas City Ward 2 B - 1,Kansas House of Representatives,80,Republican,"Kelley, Kasha",119,00006A
+COWLEY,Arkansas City Ward 2 B - 2,Kansas House of Representatives,80,Republican,"Kelley, Kasha",77,00006B
+COWLEY,Arkansas City Ward 2 C,Kansas House of Representatives,80,Republican,"Kelley, Kasha",32,000070
+COWLEY,Arkansas City Ward 2 D,Kansas House of Representatives,80,Republican,"Kelley, Kasha",32,000080
+COWLEY,Arkansas City Ward 3 A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",65,000090
+COWLEY,Arkansas City Ward 3 B,Kansas House of Representatives,80,Republican,"Kelley, Kasha",87,000100
+COWLEY,Arkansas City Ward 3 C,Kansas House of Representatives,80,Republican,"Kelley, Kasha",73,000110
+COWLEY,Arkansas City Ward 4 A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",223,000120
+COWLEY,Arkansas City Ward 4 B,Kansas House of Representatives,80,Republican,"Kelley, Kasha",502,00013A
+COWLEY,Arkansas City Ward 4 C,Kansas House of Representatives,80,Republican,"Kelley, Kasha",206,000140
+COWLEY,Arkansas City Ward 4 D,Kansas House of Representatives,80,Republican,"Kelley, Kasha",392,000150
+COWLEY,Beaver Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",53,000170
+COWLEY,Beaver Township,Kansas House of Representatives,79,Republican,"Alley, Larry",52,000170
+COWLEY,Cedar Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",3,000180
+COWLEY,Cedar Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",17,000180
+COWLEY,Dexter Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",54,000190
+COWLEY,Dexter Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",131,000190
+COWLEY,East Bolton,Kansas House of Representatives,80,Republican,"Kelley, Kasha",277,000200
+COWLEY,East Creswell,Kansas House of Representatives,80,Republican,"Kelley, Kasha",538,000210
+COWLEY,Fairview Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",60,000220
+COWLEY,Fairview Township,Kansas House of Representatives,79,Republican,"Alley, Larry",65,000220
+COWLEY,Grant Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",7,000230
+COWLEY,Grant Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",24,000230
+COWLEY,Harvey Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",21,000240
+COWLEY,Harvey Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",21,000240
+COWLEY,Liberty Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",24,000250
+COWLEY,Liberty Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",50,000250
+COWLEY,Maple Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",119,000260
+COWLEY,Maple Township,Kansas House of Representatives,79,Republican,"Alley, Larry",214,000260
+COWLEY,Ninnescah Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",201,000270
+COWLEY,Ninnescah Township,Kansas House of Representatives,79,Republican,"Alley, Larry",242,000270
+COWLEY,Omnia Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",59,000280
+COWLEY,Omnia Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",76,000280
+COWLEY,Otter Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",5,000290
+COWLEY,Otter Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",14,000290
+COWLEY,Pleasant Valley Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",216,000300
+COWLEY,Pleasant Valley Township,Kansas House of Representatives,79,Republican,"Alley, Larry",191,000300
+COWLEY,Richland Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",37,000310
+COWLEY,Richland Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",64,000310
+COWLEY,Rock Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",39,000320
+COWLEY,Rock Township,Kansas House of Representatives,79,Republican,"Alley, Larry",49,000320
+COWLEY,Salem Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",70,000330
+COWLEY,Salem Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",72,000330
+COWLEY,Sheridan Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",33,000340
+COWLEY,Sheridan Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",47,000340
+COWLEY,Silver Creek Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",138,000350
+COWLEY,Silver Creek Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",142,000350
+COWLEY,Silverdale Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",50,000360
+COWLEY,Silverdale Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",94,000360
+COWLEY,Spring Creek Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",7,000370
+COWLEY,Spring Creek Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",22,000370
+COWLEY,Tisdale Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",67,000380
+COWLEY,Tisdale Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",101,000380
+COWLEY,Vernon Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",83,000390
+COWLEY,Vernon Township,Kansas House of Representatives,79,Republican,"Alley, Larry",154,000390
+COWLEY,Walnut Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",181,000400
+COWLEY,Walnut Township,Kansas House of Representatives,79,Republican,"Alley, Larry",170,000400
+COWLEY,West Bolton,Kansas House of Representatives,80,Republican,"Kelley, Kasha",278,00041A
+COWLEY,West Bolton Enclave A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,00041B
+COWLEY,West Creswell,Kansas House of Representatives,80,Republican,"Kelley, Kasha",248,00042A
+COWLEY,Windsor Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",40,000430
+COWLEY,Windsor Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",54,000430
+COWLEY,Winfield Ward 1 East,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",235,000440
+COWLEY,Winfield Ward 1 East,Kansas House of Representatives,79,Republican,"Alley, Larry",129,000440
+COWLEY,Winfield Ward 1 West,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",95,000450
+COWLEY,Winfield Ward 1 West,Kansas House of Representatives,79,Republican,"Alley, Larry",96,000450
+COWLEY,Winfield Ward 2 Central,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",148,000460
+COWLEY,Winfield Ward 2 Central,Kansas House of Representatives,79,Republican,"Alley, Larry",90,000460
+COWLEY,Winfield Ward 2 East,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",175,000470
+COWLEY,Winfield Ward 2 East,Kansas House of Representatives,79,Republican,"Alley, Larry",115,000470
+COWLEY,Winfield Ward 2 South,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",217,000480
+COWLEY,Winfield Ward 2 South,Kansas House of Representatives,79,Republican,"Alley, Larry",181,000480
+COWLEY,Winfield Ward 2 West,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",138,000490
+COWLEY,Winfield Ward 2 West,Kansas House of Representatives,79,Republican,"Alley, Larry",102,000490
+COWLEY,Winfield Ward 3,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",226,000500
+COWLEY,Winfield Ward 3,Kansas House of Representatives,79,Republican,"Alley, Larry",134,000500
+COWLEY,Winfield Ward 3 South,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",46,00051A
+COWLEY,Winfield Ward 3 South,Kansas House of Representatives,79,Republican,"Alley, Larry",69,00051A
+COWLEY,Winfield Ward 8,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",19,00051B
+COWLEY,Winfield Ward 8,Kansas House of Representatives,79,Republican,"Alley, Larry",21,00051B
+COWLEY,Winfield Ward 4,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",61,000520
+COWLEY,Winfield Ward 4,Kansas House of Representatives,79,Republican,"Alley, Larry",51,000520
+COWLEY,Winfield Ward 5 East,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",339,00053A
+COWLEY,Winfield Ward 5 East,Kansas House of Representatives,79,Republican,"Alley, Larry",201,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,00053B
+COWLEY,Winfield Ward 5 West,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",120,000540
+COWLEY,Winfield Ward 5 West,Kansas House of Representatives,79,Republican,"Alley, Larry",78,000540
+COWLEY,Winfield Ward 6,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",295,000550
+COWLEY,Winfield Ward 6,Kansas House of Representatives,79,Republican,"Alley, Larry",209,000550
+COWLEY,Winfield Ward 6 A,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",92,000560
+COWLEY,Winfield Ward 6 A,Kansas House of Representatives,79,Republican,"Alley, Larry",103,000560
+COWLEY,Winfield Ward 7,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",196,000570
+COWLEY,Winfield Ward 7,Kansas House of Representatives,79,Republican,"Alley, Larry",104,000570
+COWLEY,Arkansas City Ward 5,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",0,900010
+COWLEY,Arkansas City Ward 5,Kansas House of Representatives,79,Republican,"Alley, Larry",0,900010
+COWLEY,West Creswell Enclave A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,900020
+COWLEY,West Creswell Enclave B,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,900030
+COWLEY,West Creswell Enclave C,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,900060
+COWLEY,Winfield Ward 9,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",0,900070
+COWLEY,Winfield Ward 9,Kansas House of Representatives,79,Republican,"Alley, Larry",0,900070
+COWLEY,Arkansas City Ward 1 A,Kansas Senate,32,Republican,"Abrams, Steve E",150,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,Kansas Senate,32,Republican,"Abrams, Steve E",7,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,Kansas Senate,32,Republican,"Abrams, Steve E",1,00001C
+COWLEY,Arkansas City Ward 1 B,Kansas Senate,32,Republican,"Abrams, Steve E",124,000020
+COWLEY,Arkansas City Ward 1 C,Kansas Senate,32,Republican,"Abrams, Steve E",235,000030
+COWLEY,Arkansas City Ward 1 D,Kansas Senate,32,Republican,"Abrams, Steve E",201,000040
+COWLEY,Arkansas City Ward 2 A,Kansas Senate,32,Republican,"Abrams, Steve E",239,000050
+COWLEY,Arkansas City Ward 2 B - 1,Kansas Senate,32,Republican,"Abrams, Steve E",119,00006A
+COWLEY,Arkansas City Ward 2 B - 2,Kansas Senate,32,Republican,"Abrams, Steve E",75,00006B
+COWLEY,Arkansas City Ward 2 C,Kansas Senate,32,Republican,"Abrams, Steve E",30,000070
+COWLEY,Arkansas City Ward 2 D,Kansas Senate,32,Republican,"Abrams, Steve E",30,000080
+COWLEY,Arkansas City Ward 3 A,Kansas Senate,32,Republican,"Abrams, Steve E",58,000090
+COWLEY,Arkansas City Ward 3 B,Kansas Senate,32,Republican,"Abrams, Steve E",86,000100
+COWLEY,Arkansas City Ward 3 C,Kansas Senate,32,Republican,"Abrams, Steve E",75,000110
+COWLEY,Arkansas City Ward 4 A,Kansas Senate,32,Republican,"Abrams, Steve E",215,000120
+COWLEY,Arkansas City Ward 4 B,Kansas Senate,32,Republican,"Abrams, Steve E",492,00013A
+COWLEY,Arkansas City Ward 4 C,Kansas Senate,32,Republican,"Abrams, Steve E",195,000140
+COWLEY,Arkansas City Ward 4 D,Kansas Senate,32,Republican,"Abrams, Steve E",391,000150
+COWLEY,Beaver Township,Kansas Senate,32,Republican,"Abrams, Steve E",83,000170
+COWLEY,Cedar Township,Kansas Senate,14,Democratic,"Fuson, Eden",1,000180
+COWLEY,Cedar Township,Kansas Senate,14,Republican,"Knox, Forrest J.",19,000180
+COWLEY,Dexter Township,Kansas Senate,14,Democratic,"Fuson, Eden",37,000190
+COWLEY,Dexter Township,Kansas Senate,14,Republican,"Knox, Forrest J.",150,000190
+COWLEY,East Bolton,Kansas Senate,32,Republican,"Abrams, Steve E",272,000200
+COWLEY,East Creswell,Kansas Senate,32,Republican,"Abrams, Steve E",534,000210
+COWLEY,Fairview Township,Kansas Senate,14,Democratic,"Fuson, Eden",38,000220
+COWLEY,Fairview Township,Kansas Senate,14,Republican,"Knox, Forrest J.",82,000220
+COWLEY,Grant Township,Kansas Senate,14,Democratic,"Fuson, Eden",4,000230
+COWLEY,Grant Township,Kansas Senate,14,Republican,"Knox, Forrest J.",27,000230
+COWLEY,Harvey Township,Kansas Senate,14,Democratic,"Fuson, Eden",13,000240
+COWLEY,Harvey Township,Kansas Senate,14,Republican,"Knox, Forrest J.",28,000240
+COWLEY,Liberty Township,Kansas Senate,14,Democratic,"Fuson, Eden",13,000250
+COWLEY,Liberty Township,Kansas Senate,14,Republican,"Knox, Forrest J.",61,000250
+COWLEY,Maple Township,Kansas Senate,14,Democratic,"Fuson, Eden",88,000260
+COWLEY,Maple Township,Kansas Senate,14,Republican,"Knox, Forrest J.",243,000260
+COWLEY,Ninnescah Township,Kansas Senate,14,Democratic,"Fuson, Eden",109,000270
+COWLEY,Ninnescah Township,Kansas Senate,14,Republican,"Knox, Forrest J.",323,000270
+COWLEY,Omnia Township,Kansas Senate,14,Democratic,"Fuson, Eden",31,000280
+COWLEY,Omnia Township,Kansas Senate,14,Republican,"Knox, Forrest J.",104,000280
+COWLEY,Otter Township,Kansas Senate,14,Democratic,"Fuson, Eden",2,000290
+COWLEY,Otter Township,Kansas Senate,14,Republican,"Knox, Forrest J.",16,000290
+COWLEY,Pleasant Valley Township,Kansas Senate,32,Republican,"Abrams, Steve E",340,000300
+COWLEY,Richland Township,Kansas Senate,14,Democratic,"Fuson, Eden",27,000310
+COWLEY,Richland Township,Kansas Senate,14,Republican,"Knox, Forrest J.",72,000310
+COWLEY,Rock Township,Kansas Senate,14,Democratic,"Fuson, Eden",19,000320
+COWLEY,Rock Township,Kansas Senate,14,Republican,"Knox, Forrest J.",67,000320
+COWLEY,Salem Township,Kansas Senate,14,Democratic,"Fuson, Eden",42,000330
+COWLEY,Salem Township,Kansas Senate,14,Republican,"Knox, Forrest J.",100,000330
+COWLEY,Sheridan Township,Kansas Senate,14,Democratic,"Fuson, Eden",21,000340
+COWLEY,Sheridan Township,Kansas Senate,14,Republican,"Knox, Forrest J.",58,000340
+COWLEY,Silver Creek Township,Kansas Senate,14,Democratic,"Fuson, Eden",49,000350
+COWLEY,Silver Creek Township,Kansas Senate,14,Republican,"Knox, Forrest J.",226,000350
+COWLEY,Silverdale Township,Kansas Senate,14,Democratic,"Fuson, Eden",41,000360
+COWLEY,Silverdale Township,Kansas Senate,14,Republican,"Knox, Forrest J.",105,000360
+COWLEY,Spring Creek Township,Kansas Senate,14,Democratic,"Fuson, Eden",5,000370
+COWLEY,Spring Creek Township,Kansas Senate,14,Republican,"Knox, Forrest J.",24,000370
+COWLEY,Tisdale Township,Kansas Senate,14,Democratic,"Fuson, Eden",38,000380
+COWLEY,Tisdale Township,Kansas Senate,14,Republican,"Knox, Forrest J.",132,000380
+COWLEY,Vernon Township,Kansas Senate,32,Republican,"Abrams, Steve E",200,000390
+COWLEY,Walnut Township,Kansas Senate,32,Republican,"Abrams, Steve E",272,000400
+COWLEY,West Bolton,Kansas Senate,32,Republican,"Abrams, Steve E",274,00041A
+COWLEY,West Bolton Enclave A,Kansas Senate,32,Republican,"Abrams, Steve E",0,00041B
+COWLEY,West Creswell,Kansas Senate,32,Republican,"Abrams, Steve E",242,00042A
+COWLEY,Windsor Township,Kansas Senate,14,Democratic,"Fuson, Eden",21,000430
+COWLEY,Windsor Township,Kansas Senate,14,Republican,"Knox, Forrest J.",73,000430
+COWLEY,Winfield Ward 1 East,Kansas Senate,32,Republican,"Abrams, Steve E",248,000440
+COWLEY,Winfield Ward 1 West,Kansas Senate,32,Republican,"Abrams, Steve E",151,000450
+COWLEY,Winfield Ward 2 Central,Kansas Senate,32,Republican,"Abrams, Steve E",171,000460
+COWLEY,Winfield Ward 2 East,Kansas Senate,32,Republican,"Abrams, Steve E",209,000470
+COWLEY,Winfield Ward 2 South,Kansas Senate,32,Republican,"Abrams, Steve E",304,000480
+COWLEY,Winfield Ward 2 West,Kansas Senate,32,Republican,"Abrams, Steve E",185,000490
+COWLEY,Winfield Ward 3,Kansas Senate,32,Republican,"Abrams, Steve E",269,000500
+COWLEY,Winfield Ward 3 South,Kansas Senate,32,Republican,"Abrams, Steve E",96,00051A
+COWLEY,Winfield Ward 8,Kansas Senate,32,Republican,"Abrams, Steve E",30,00051B
+COWLEY,Winfield Ward 4,Kansas Senate,32,Republican,"Abrams, Steve E",87,000520
+COWLEY,Winfield Ward 5 East,Kansas Senate,32,Republican,"Abrams, Steve E",380,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,Kansas Senate,14,Democratic,"Fuson, Eden",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,Kansas Senate,14,Republican,"Knox, Forrest J.",0,00053B
+COWLEY,Winfield Ward 5 West,Kansas Senate,32,Republican,"Abrams, Steve E",157,000540
+COWLEY,Winfield Ward 6,Kansas Senate,32,Republican,"Abrams, Steve E",387,000550
+COWLEY,Winfield Ward 6 A,Kansas Senate,32,Republican,"Abrams, Steve E",145,000560
+COWLEY,Winfield Ward 7,Kansas Senate,32,Republican,"Abrams, Steve E",207,000570
+COWLEY,Arkansas City Ward 5,Kansas Senate,32,Republican,"Abrams, Steve E",0,900010
+COWLEY,West Creswell Enclave A,Kansas Senate,32,Republican,"Abrams, Steve E",0,900020
+COWLEY,West Creswell Enclave B,Kansas Senate,32,Republican,"Abrams, Steve E",0,900030
+COWLEY,West Creswell Enclave C,Kansas Senate,32,Republican,"Abrams, Steve E",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,Kansas Senate,32,Republican,"Abrams, Steve E",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,Kansas Senate,32,Republican,"Abrams, Steve E",0,900060
+COWLEY,Winfield Ward 9,Kansas Senate,32,Republican,"Abrams, Steve E",0,900070
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Ayers, Avery L",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Barnett, Andre",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Barr, Roseanne C",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Bush, Kent W",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Christensen, Will",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Duncan, Richard A",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Goode, Virgil",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Hoefling, Tom",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Knill, Dennis J",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Reed, Jill A.",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Rogers, Rick L",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Stein, Jill E",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Thorne, Kevin M",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Warner, Gerald L.",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,Democratic,"Obama, Barack",89,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,Libertarian,"Johnson, Gary",2,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,Reform,"Baldwin, Chuck",1,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,Republican,"Romney, Mitt",106,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,Democratic,"Obama, Barack",2,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,Republican,"Romney, Mitt",7,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Christensen, Will",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,Republican,"Romney, Mitt",1,00001C
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Barnett, Andre",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Bush, Kent W",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Christensen, Will",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Goode, Virgil",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Stein, Jill E",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,Democratic,"Obama, Barack",57,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,Republican,"Romney, Mitt",100,000020
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Barnett, Andre",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Bush, Kent W",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Christensen, Will",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Goode, Virgil",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Stein, Jill E",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,Democratic,"Obama, Barack",91,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,Libertarian,"Johnson, Gary",6,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,Republican,"Romney, Mitt",183,000030
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Barnett, Andre",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Bush, Kent W",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Christensen, Will",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Goode, Virgil",1,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Stein, Jill E",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,Democratic,"Obama, Barack",95,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,Libertarian,"Johnson, Gary",4,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,Republican,"Romney, Mitt",151,000040
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Barnett, Andre",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Bush, Kent W",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Christensen, Will",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Goode, Virgil",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Stein, Jill E",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,Democratic,"Obama, Barack",91,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,Libertarian,"Johnson, Gary",6,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,Reform,"Baldwin, Chuck",1,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,Republican,"Romney, Mitt",200,000050
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Ayers, Avery L",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Barnett, Andre",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Bush, Kent W",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Christensen, Will",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Duncan, Richard A",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Goode, Virgil",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Knill, Dennis J",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Reed, Jill A.",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Rogers, Rick L",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Stein, Jill E",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,Democratic,"Obama, Barack",48,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,Libertarian,"Johnson, Gary",2,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,Reform,"Baldwin, Chuck",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,Republican,"Romney, Mitt",86,00006A
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Ayers, Avery L",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Barnett, Andre",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Bush, Kent W",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Christensen, Will",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Duncan, Richard A",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Goode, Virgil",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Knill, Dennis J",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Reed, Jill A.",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Rogers, Rick L",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Stein, Jill E",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,Democratic,"Obama, Barack",34,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,Libertarian,"Johnson, Gary",1,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,Reform,"Baldwin, Chuck",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,Republican,"Romney, Mitt",60,00006B
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Barnett, Andre",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Bush, Kent W",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Christensen, Will",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Goode, Virgil",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Stein, Jill E",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,Democratic,"Obama, Barack",15,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,Republican,"Romney, Mitt",23,000070
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Barnett, Andre",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Bush, Kent W",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Christensen, Will",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Goode, Virgil",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Stein, Jill E",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,Democratic,"Obama, Barack",18,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,Republican,"Romney, Mitt",27,000080
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Barnett, Andre",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Bush, Kent W",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Christensen, Will",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Goode, Virgil",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Stein, Jill E",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,Democratic,"Obama, Barack",30,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,Libertarian,"Johnson, Gary",2,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,Republican,"Romney, Mitt",41,000090
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Barnett, Andre",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Bush, Kent W",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Christensen, Will",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Goode, Virgil",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Stein, Jill E",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,Democratic,"Obama, Barack",42,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,Libertarian,"Johnson, Gary",3,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,Republican,"Romney, Mitt",56,000100
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Barnett, Andre",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Bush, Kent W",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Christensen, Will",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Goode, Virgil",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Stein, Jill E",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,Democratic,"Obama, Barack",36,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,Libertarian,"Johnson, Gary",6,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,Reform,"Baldwin, Chuck",3,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,Republican,"Romney, Mitt",41,000110
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Barnett, Andre",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Bush, Kent W",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Christensen, Will",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Goode, Virgil",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Stein, Jill E",1,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,Democratic,"Obama, Barack",127,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,Libertarian,"Johnson, Gary",14,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,Reform,"Baldwin, Chuck",3,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,Republican,"Romney, Mitt",137,000120
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Ayers, Avery L",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Barnett, Andre",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Barr, Roseanne C",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Bush, Kent W",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Christensen, Will",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Duncan, Richard A",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Goode, Virgil",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Knill, Dennis J",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Reed, Jill A.",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Rogers, Rick L",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Stein, Jill E",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Thorne, Kevin M",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Warner, Gerald L.",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,Democratic,"Obama, Barack",251,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,Libertarian,"Johnson, Gary",17,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,Reform,"Baldwin, Chuck",4,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,Republican,"Romney, Mitt",328,00013A
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Barnett, Andre",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Bush, Kent W",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Christensen, Will",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Goode, Virgil",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Stein, Jill E",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,Democratic,"Obama, Barack",119,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,Libertarian,"Johnson, Gary",4,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,Republican,"Romney, Mitt",131,000140
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Barnett, Andre",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Bush, Kent W",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Christensen, Will",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Goode, Virgil",1,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Stein, Jill E",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,Democratic,"Obama, Barack",215,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,Libertarian,"Johnson, Gary",12,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,Reform,"Baldwin, Chuck",3,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,Republican,"Romney, Mitt",248,000150
+COWLEY,Beaver Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+COWLEY,Beaver Township,President / Vice President,,Democratic,"Obama, Barack",32,000170
+COWLEY,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000170
+COWLEY,Beaver Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000170
+COWLEY,Beaver Township,President / Vice President,,Republican,"Romney, Mitt",71,000170
+COWLEY,Cedar Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+COWLEY,Cedar Township,President / Vice President,,Democratic,"Obama, Barack",1,000180
+COWLEY,Cedar Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+COWLEY,Cedar Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+COWLEY,Cedar Township,President / Vice President,,Republican,"Romney, Mitt",19,000180
+COWLEY,Dexter Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+COWLEY,Dexter Township,President / Vice President,,Democratic,"Obama, Barack",40,000190
+COWLEY,Dexter Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000190
+COWLEY,Dexter Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000190
+COWLEY,Dexter Township,President / Vice President,,Republican,"Romney, Mitt",150,000190
+COWLEY,East Bolton,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Barnett, Andre",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Bush, Kent W",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Christensen, Will",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Goode, Virgil",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Stein, Jill E",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+COWLEY,East Bolton,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+COWLEY,East Bolton,President / Vice President,,Democratic,"Obama, Barack",90,000200
+COWLEY,East Bolton,President / Vice President,,Libertarian,"Johnson, Gary",5,000200
+COWLEY,East Bolton,President / Vice President,,Reform,"Baldwin, Chuck",7,000200
+COWLEY,East Bolton,President / Vice President,,Republican,"Romney, Mitt",207,000200
+COWLEY,East Creswell,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Barnett, Andre",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Bush, Kent W",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Christensen, Will",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Goode, Virgil",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Stein, Jill E",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+COWLEY,East Creswell,President / Vice President,,Democratic,"Obama, Barack",188,000210
+COWLEY,East Creswell,President / Vice President,,Libertarian,"Johnson, Gary",7,000210
+COWLEY,East Creswell,President / Vice President,,Reform,"Baldwin, Chuck",3,000210
+COWLEY,East Creswell,President / Vice President,,Republican,"Romney, Mitt",426,000210
+COWLEY,Fairview Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+COWLEY,Fairview Township,President / Vice President,,Democratic,"Obama, Barack",32,000220
+COWLEY,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000220
+COWLEY,Fairview Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+COWLEY,Fairview Township,President / Vice President,,Republican,"Romney, Mitt",91,000220
+COWLEY,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+COWLEY,Grant Township,President / Vice President,,Democratic,"Obama, Barack",2,000230
+COWLEY,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+COWLEY,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000230
+COWLEY,Grant Township,President / Vice President,,Republican,"Romney, Mitt",27,000230
+COWLEY,Harvey Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+COWLEY,Harvey Township,President / Vice President,,Democratic,"Obama, Barack",11,000240
+COWLEY,Harvey Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+COWLEY,Harvey Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000240
+COWLEY,Harvey Township,President / Vice President,,Republican,"Romney, Mitt",32,000240
+COWLEY,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+COWLEY,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",12,000250
+COWLEY,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+COWLEY,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000250
+COWLEY,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",64,000250
+COWLEY,Maple Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Barnett, Andre",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Bush, Kent W",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Christensen, Will",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Goode, Virgil",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Stein, Jill E",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+COWLEY,Maple Township,President / Vice President,,Democratic,"Obama, Barack",80,000260
+COWLEY,Maple Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000260
+COWLEY,Maple Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000260
+COWLEY,Maple Township,President / Vice President,,Republican,"Romney, Mitt",240,000260
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Barnett, Andre",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Bush, Kent W",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Christensen, Will",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Goode, Virgil",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Stein, Jill E",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,Democratic,"Obama, Barack",129,000270
+COWLEY,Ninnescah Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000270
+COWLEY,Ninnescah Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000270
+COWLEY,Ninnescah Township,President / Vice President,,Republican,"Romney, Mitt",309,000270
+COWLEY,Omnia Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Barnett, Andre",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Bush, Kent W",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Christensen, Will",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Goode, Virgil",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Stein, Jill E",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+COWLEY,Omnia Township,President / Vice President,,Democratic,"Obama, Barack",28,000280
+COWLEY,Omnia Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000280
+COWLEY,Omnia Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000280
+COWLEY,Omnia Township,President / Vice President,,Republican,"Romney, Mitt",106,000280
+COWLEY,Otter Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Barnett, Andre",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Bush, Kent W",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Christensen, Will",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Goode, Virgil",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Stein, Jill E",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+COWLEY,Otter Township,President / Vice President,,Democratic,"Obama, Barack",2,000290
+COWLEY,Otter Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000290
+COWLEY,Otter Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000290
+COWLEY,Otter Township,President / Vice President,,Republican,"Romney, Mitt",19,000290
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,Democratic,"Obama, Barack",122,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,Republican,"Romney, Mitt",288,000300
+COWLEY,Richland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Barnett, Andre",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Bush, Kent W",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Christensen, Will",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Goode, Virgil",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Stein, Jill E",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+COWLEY,Richland Township,President / Vice President,,Democratic,"Obama, Barack",23,000310
+COWLEY,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000310
+COWLEY,Richland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000310
+COWLEY,Richland Township,President / Vice President,,Republican,"Romney, Mitt",77,000310
+COWLEY,Rock Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Barnett, Andre",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Bush, Kent W",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Christensen, Will",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Goode, Virgil",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Stein, Jill E",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+COWLEY,Rock Township,President / Vice President,,Democratic,"Obama, Barack",20,000320
+COWLEY,Rock Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000320
+COWLEY,Rock Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000320
+COWLEY,Rock Township,President / Vice President,,Republican,"Romney, Mitt",70,000320
+COWLEY,Salem Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Ayers, Avery L",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Barnett, Andre",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Bush, Kent W",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Christensen, Will",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Duncan, Richard A",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Goode, Virgil",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Knill, Dennis J",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Reed, Jill A.",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Rogers, Rick L",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Stein, Jill E",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000330
+COWLEY,Salem Township,President / Vice President,,Democratic,"Obama, Barack",36,000330
+COWLEY,Salem Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000330
+COWLEY,Salem Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000330
+COWLEY,Salem Township,President / Vice President,,Republican,"Romney, Mitt",107,000330
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Barnett, Andre",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Bush, Kent W",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Christensen, Will",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Goode, Virgil",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Stein, Jill E",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000340
+COWLEY,Sheridan Township,President / Vice President,,Democratic,"Obama, Barack",18,000340
+COWLEY,Sheridan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000340
+COWLEY,Sheridan Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000340
+COWLEY,Sheridan Township,President / Vice President,,Republican,"Romney, Mitt",61,000340
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,Democratic,"Obama, Barack",61,000350
+COWLEY,Silver Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000350
+COWLEY,Silver Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000350
+COWLEY,Silver Creek Township,President / Vice President,,Republican,"Romney, Mitt",218,000350
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Ayers, Avery L",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Barnett, Andre",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Bush, Kent W",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Christensen, Will",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Duncan, Richard A",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Goode, Virgil",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Knill, Dennis J",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Reed, Jill A.",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Rogers, Rick L",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Stein, Jill E",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000360
+COWLEY,Silverdale Township,President / Vice President,,Democratic,"Obama, Barack",43,000360
+COWLEY,Silverdale Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000360
+COWLEY,Silverdale Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000360
+COWLEY,Silverdale Township,President / Vice President,,Republican,"Romney, Mitt",93,000360
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,Democratic,"Obama, Barack",3,000370
+COWLEY,Spring Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000370
+COWLEY,Spring Creek Township,President / Vice President,,Republican,"Romney, Mitt",25,000370
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Ayers, Avery L",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Barnett, Andre",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Bush, Kent W",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Christensen, Will",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Duncan, Richard A",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Goode, Virgil",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Knill, Dennis J",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Reed, Jill A.",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Rogers, Rick L",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Stein, Jill E",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000380
+COWLEY,Tisdale Township,President / Vice President,,Democratic,"Obama, Barack",39,000380
+COWLEY,Tisdale Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000380
+COWLEY,Tisdale Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000380
+COWLEY,Tisdale Township,President / Vice President,,Republican,"Romney, Mitt",134,000380
+COWLEY,Vernon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Barnett, Andre",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Bush, Kent W",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Christensen, Will",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Goode, Virgil",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Stein, Jill E",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000390
+COWLEY,Vernon Township,President / Vice President,,Democratic,"Obama, Barack",56,000390
+COWLEY,Vernon Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000390
+COWLEY,Vernon Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000390
+COWLEY,Vernon Township,President / Vice President,,Republican,"Romney, Mitt",178,000390
+COWLEY,Walnut Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Ayers, Avery L",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Barnett, Andre",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Bush, Kent W",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Christensen, Will",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Duncan, Richard A",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Goode, Virgil",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Knill, Dennis J",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Reed, Jill A.",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Rogers, Rick L",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Stein, Jill E",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000400
+COWLEY,Walnut Township,President / Vice President,,Democratic,"Obama, Barack",98,000400
+COWLEY,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000400
+COWLEY,Walnut Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000400
+COWLEY,Walnut Township,President / Vice President,,Republican,"Romney, Mitt",250,000400
+COWLEY,West Bolton,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Ayers, Avery L",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Barnett, Andre",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Barr, Roseanne C",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Bush, Kent W",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Christensen, Will",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Duncan, Richard A",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Goode, Virgil",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Hoefling, Tom",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Knill, Dennis J",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Reed, Jill A.",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Rogers, Rick L",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Stein, Jill E",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Thorne, Kevin M",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00041A
+COWLEY,West Bolton,President / Vice President,,write - in,"Warner, Gerald L.",0,00041A
+COWLEY,West Bolton,President / Vice President,,Democratic,"Obama, Barack",63,00041A
+COWLEY,West Bolton,President / Vice President,,Libertarian,"Johnson, Gary",8,00041A
+COWLEY,West Bolton,President / Vice President,,Reform,"Baldwin, Chuck",3,00041A
+COWLEY,West Bolton,President / Vice President,,Republican,"Romney, Mitt",237,00041A
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Barnett, Andre",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Bush, Kent W",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Christensen, Will",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Goode, Virgil",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Stein, Jill E",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,Democratic,"Obama, Barack",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,Republican,"Romney, Mitt",0,00041B
+COWLEY,West Creswell,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Ayers, Avery L",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Barnett, Andre",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Barr, Roseanne C",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Bush, Kent W",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Christensen, Will",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Duncan, Richard A",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Goode, Virgil",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Hoefling, Tom",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Knill, Dennis J",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Reed, Jill A.",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Rogers, Rick L",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Stein, Jill E",1,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Thorne, Kevin M",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Warner, Gerald L.",0,00042A
+COWLEY,West Creswell,President / Vice President,,Democratic,"Obama, Barack",85,00042A
+COWLEY,West Creswell,President / Vice President,,Libertarian,"Johnson, Gary",6,00042A
+COWLEY,West Creswell,President / Vice President,,Reform,"Baldwin, Chuck",3,00042A
+COWLEY,West Creswell,President / Vice President,,Republican,"Romney, Mitt",188,00042A
+COWLEY,Windsor Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Ayers, Avery L",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Barnett, Andre",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Bush, Kent W",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Christensen, Will",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Duncan, Richard A",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Goode, Virgil",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Hoefling, Tom",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Knill, Dennis J",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Reed, Jill A.",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Rogers, Rick L",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Stein, Jill E",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000430
+COWLEY,Windsor Township,President / Vice President,,Democratic,"Obama, Barack",24,000430
+COWLEY,Windsor Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000430
+COWLEY,Windsor Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000430
+COWLEY,Windsor Township,President / Vice President,,Republican,"Romney, Mitt",68,000430
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Ayers, Avery L",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Barnett, Andre",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Barr, Roseanne C",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Bush, Kent W",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Christensen, Will",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Duncan, Richard A",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Goode, Virgil",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Hoefling, Tom",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Knill, Dennis J",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Reed, Jill A.",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Rogers, Rick L",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Stein, Jill E",1,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Thorne, Kevin M",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Warner, Gerald L.",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,Democratic,"Obama, Barack",161,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,Libertarian,"Johnson, Gary",7,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,Reform,"Baldwin, Chuck",1,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,Republican,"Romney, Mitt",198,000440
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Ayers, Avery L",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Barnett, Andre",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Barr, Roseanne C",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Bush, Kent W",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Christensen, Will",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Duncan, Richard A",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Goode, Virgil",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Knill, Dennis J",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Reed, Jill A.",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Rogers, Rick L",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Stein, Jill E",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Thorne, Kevin M",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Warner, Gerald L.",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,Democratic,"Obama, Barack",61,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,Libertarian,"Johnson, Gary",1,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,Reform,"Baldwin, Chuck",2,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,Republican,"Romney, Mitt",125,000450
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Ayers, Avery L",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Barnett, Andre",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Barr, Roseanne C",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Bush, Kent W",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Christensen, Will",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Duncan, Richard A",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Goode, Virgil",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Hoefling, Tom",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Knill, Dennis J",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Reed, Jill A.",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Rogers, Rick L",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Stein, Jill E",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Thorne, Kevin M",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Warner, Gerald L.",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,Democratic,"Obama, Barack",107,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,Libertarian,"Johnson, Gary",4,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,Reform,"Baldwin, Chuck",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,Republican,"Romney, Mitt",127,000460
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Ayers, Avery L",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Barnett, Andre",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Barr, Roseanne C",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Bush, Kent W",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Christensen, Will",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Duncan, Richard A",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Goode, Virgil",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Hoefling, Tom",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Knill, Dennis J",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Reed, Jill A.",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Rogers, Rick L",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Stein, Jill E",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Thorne, Kevin M",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Warner, Gerald L.",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,Democratic,"Obama, Barack",113,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,Libertarian,"Johnson, Gary",4,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,Reform,"Baldwin, Chuck",2,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,Republican,"Romney, Mitt",175,000470
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Ayers, Avery L",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Barnett, Andre",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Barr, Roseanne C",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Bush, Kent W",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Christensen, Will",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Duncan, Richard A",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Goode, Virgil",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Hoefling, Tom",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Knill, Dennis J",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Reed, Jill A.",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Rogers, Rick L",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Stein, Jill E",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Thorne, Kevin M",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Warner, Gerald L.",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,Democratic,"Obama, Barack",136,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,Libertarian,"Johnson, Gary",3,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,Reform,"Baldwin, Chuck",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,Republican,"Romney, Mitt",261,000480
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Ayers, Avery L",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Barnett, Andre",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Barr, Roseanne C",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Bush, Kent W",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Christensen, Will",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Duncan, Richard A",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Goode, Virgil",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Hoefling, Tom",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Knill, Dennis J",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Reed, Jill A.",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Rogers, Rick L",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Stein, Jill E",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Thorne, Kevin M",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Warner, Gerald L.",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,Democratic,"Obama, Barack",94,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,Libertarian,"Johnson, Gary",3,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,Reform,"Baldwin, Chuck",2,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,Republican,"Romney, Mitt",144,000490
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,Democratic,"Obama, Barack",164,000500
+COWLEY,Winfield Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",9,000500
+COWLEY,Winfield Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",2,000500
+COWLEY,Winfield Ward 3,President / Vice President,,Republican,"Romney, Mitt",183,000500
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Ayers, Avery L",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Barnett, Andre",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Barr, Roseanne C",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Bush, Kent W",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Christensen, Will",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Duncan, Richard A",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Goode, Virgil",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Hoefling, Tom",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Knill, Dennis J",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Reed, Jill A.",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Rogers, Rick L",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Stein, Jill E",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Thorne, Kevin M",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Warner, Gerald L.",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,Democratic,"Obama, Barack",25,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,Libertarian,"Johnson, Gary",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,Reform,"Baldwin, Chuck",1,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,Republican,"Romney, Mitt",89,00051A
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Ayers, Avery L",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Barnett, Andre",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Barr, Roseanne C",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Bush, Kent W",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Christensen, Will",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Duncan, Richard A",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Goode, Virgil",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Hoefling, Tom",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Knill, Dennis J",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Reed, Jill A.",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Rogers, Rick L",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Stein, Jill E",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Thorne, Kevin M",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Warner, Gerald L.",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,Democratic,"Obama, Barack",10,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,Libertarian,"Johnson, Gary",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,Reform,"Baldwin, Chuck",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,Republican,"Romney, Mitt",30,00051B
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,Democratic,"Obama, Barack",41,000520
+COWLEY,Winfield Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",2,000520
+COWLEY,Winfield Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",1,000520
+COWLEY,Winfield Ward 4,President / Vice President,,Republican,"Romney, Mitt",67,000520
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Ayers, Avery L",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Barnett, Andre",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Barr, Roseanne C",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Bush, Kent W",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Christensen, Will",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Duncan, Richard A",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Goode, Virgil",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Hoefling, Tom",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Knill, Dennis J",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Reed, Jill A.",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Rogers, Rick L",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Stein, Jill E",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Thorne, Kevin M",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Warner, Gerald L.",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,Democratic,"Obama, Barack",263,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,Libertarian,"Johnson, Gary",5,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,Reform,"Baldwin, Chuck",2,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,Republican,"Romney, Mitt",273,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Ayers, Avery L",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Barnett, Andre",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Barr, Roseanne C",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Bush, Kent W",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Christensen, Will",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Duncan, Richard A",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Goode, Virgil",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Hoefling, Tom",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Knill, Dennis J",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Reed, Jill A.",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Rogers, Rick L",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Stein, Jill E",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Thorne, Kevin M",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Warner, Gerald L.",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,Democratic,"Obama, Barack",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,Libertarian,"Johnson, Gary",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,Reform,"Baldwin, Chuck",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,Republican,"Romney, Mitt",0,00053B
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Ayers, Avery L",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Barnett, Andre",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Barr, Roseanne C",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Bush, Kent W",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Christensen, Will",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Duncan, Richard A",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Goode, Virgil",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Hoefling, Tom",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Knill, Dennis J",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Reed, Jill A.",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Rogers, Rick L",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Stein, Jill E",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Thorne, Kevin M",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Warner, Gerald L.",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,Democratic,"Obama, Barack",89,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,Libertarian,"Johnson, Gary",4,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,Reform,"Baldwin, Chuck",1,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,Republican,"Romney, Mitt",105,000540
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Ayers, Avery L",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Barnett, Andre",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Barr, Roseanne C",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Bush, Kent W",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Christensen, Will",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Duncan, Richard A",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Goode, Virgil",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Hoefling, Tom",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Knill, Dennis J",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Reed, Jill A.",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Rogers, Rick L",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Stein, Jill E",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Thorne, Kevin M",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Warner, Gerald L.",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,Democratic,"Obama, Barack",186,000550
+COWLEY,Winfield Ward 6,President / Vice President,,Libertarian,"Johnson, Gary",10,000550
+COWLEY,Winfield Ward 6,President / Vice President,,Reform,"Baldwin, Chuck",1,000550
+COWLEY,Winfield Ward 6,President / Vice President,,Republican,"Romney, Mitt",310,000550
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Ayers, Avery L",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Barnett, Andre",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Barr, Roseanne C",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Bush, Kent W",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Christensen, Will",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Duncan, Richard A",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Goode, Virgil",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Hoefling, Tom",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Knill, Dennis J",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Reed, Jill A.",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Rogers, Rick L",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Stein, Jill E",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Thorne, Kevin M",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Warner, Gerald L.",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,Democratic,"Obama, Barack",63,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,Libertarian,"Johnson, Gary",3,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,Reform,"Baldwin, Chuck",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,Republican,"Romney, Mitt",129,000560
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Ayers, Avery L",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Barnett, Andre",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Barr, Roseanne C",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Bush, Kent W",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Christensen, Will",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Duncan, Richard A",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Goode, Virgil",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Hoefling, Tom",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Knill, Dennis J",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Reed, Jill A.",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Rogers, Rick L",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Stein, Jill E",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Thorne, Kevin M",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Warner, Gerald L.",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,Democratic,"Obama, Barack",108,000570
+COWLEY,Winfield Ward 7,President / Vice President,,Libertarian,"Johnson, Gary",5,000570
+COWLEY,Winfield Ward 7,President / Vice President,,Reform,"Baldwin, Chuck",1,000570
+COWLEY,Winfield Ward 7,President / Vice President,,Republican,"Romney, Mitt",184,000570
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Barnett, Andre",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Bush, Kent W",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Christensen, Will",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Goode, Virgil",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Stein, Jill E",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,Democratic,"Obama, Barack",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,Republican,"Romney, Mitt",0,900010
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Barnett, Andre",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Bush, Kent W",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Christensen, Will",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Goode, Virgil",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Stein, Jill E",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,Democratic,"Obama, Barack",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,Republican,"Romney, Mitt",0,900020
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Barnett, Andre",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Bush, Kent W",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Christensen, Will",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Goode, Virgil",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Stein, Jill E",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,Democratic,"Obama, Barack",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,Republican,"Romney, Mitt",0,900030
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Barnett, Andre",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Bush, Kent W",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Christensen, Will",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Goode, Virgil",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Stein, Jill E",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,Democratic,"Obama, Barack",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,Republican,"Romney, Mitt",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Christensen, Will",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Christensen, Will",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,900060
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Ayers, Avery L",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Barnett, Andre",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Barr, Roseanne C",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Bush, Kent W",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Christensen, Will",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Duncan, Richard A",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Goode, Virgil",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Hoefling, Tom",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Knill, Dennis J",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Reed, Jill A.",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Rogers, Rick L",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Stein, Jill E",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Thorne, Kevin M",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Warner, Gerald L.",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,Democratic,"Obama, Barack",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,Libertarian,"Johnson, Gary",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,Reform,"Baldwin, Chuck",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,Republican,"Romney, Mitt",0,900070
+COWLEY,Arkansas City Ward 1 A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",68,00001A
+COWLEY,Arkansas City Ward 1 A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",11,00001A
+COWLEY,Arkansas City Ward 1 A,United States House of Representatives,4,Republican,"Pompeo, Mike",117,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",3,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,United States House of Representatives,4,Republican,"Pompeo, Mike",6,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,United States House of Representatives,4,Republican,"Pompeo, Mike",1,00001C
+COWLEY,Arkansas City Ward 1 B,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",53,000020
+COWLEY,Arkansas City Ward 1 B,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000020
+COWLEY,Arkansas City Ward 1 B,United States House of Representatives,4,Republican,"Pompeo, Mike",97,000020
+COWLEY,Arkansas City Ward 1 C,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",88,000030
+COWLEY,Arkansas City Ward 1 C,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",19,000030
+COWLEY,Arkansas City Ward 1 C,United States House of Representatives,4,Republican,"Pompeo, Mike",169,000030
+COWLEY,Arkansas City Ward 1 D,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",89,000040
+COWLEY,Arkansas City Ward 1 D,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",12,000040
+COWLEY,Arkansas City Ward 1 D,United States House of Representatives,4,Republican,"Pompeo, Mike",148,000040
+COWLEY,Arkansas City Ward 2 A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",84,000050
+COWLEY,Arkansas City Ward 2 A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",15,000050
+COWLEY,Arkansas City Ward 2 A,United States House of Representatives,4,Republican,"Pompeo, Mike",196,000050
+COWLEY,Arkansas City Ward 2 B - 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",51,00006A
+COWLEY,Arkansas City Ward 2 B - 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",7,00006A
+COWLEY,Arkansas City Ward 2 B - 1,United States House of Representatives,4,Republican,"Pompeo, Mike",76,00006A
+COWLEY,Arkansas City Ward 2 B - 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",34,00006B
+COWLEY,Arkansas City Ward 2 B - 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,00006B
+COWLEY,Arkansas City Ward 2 B - 2,United States House of Representatives,4,Republican,"Pompeo, Mike",61,00006B
+COWLEY,Arkansas City Ward 2 C,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",11,000070
+COWLEY,Arkansas City Ward 2 C,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000070
+COWLEY,Arkansas City Ward 2 C,United States House of Representatives,4,Republican,"Pompeo, Mike",23,000070
+COWLEY,Arkansas City Ward 2 D,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",20,000080
+COWLEY,Arkansas City Ward 2 D,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,000080
+COWLEY,Arkansas City Ward 2 D,United States House of Representatives,4,Republican,"Pompeo, Mike",19,000080
+COWLEY,Arkansas City Ward 3 A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",26,000090
+COWLEY,Arkansas City Ward 3 A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",7,000090
+COWLEY,Arkansas City Ward 3 A,United States House of Representatives,4,Republican,"Pompeo, Mike",43,000090
+COWLEY,Arkansas City Ward 3 B,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",44,000100
+COWLEY,Arkansas City Ward 3 B,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000100
+COWLEY,Arkansas City Ward 3 B,United States House of Representatives,4,Republican,"Pompeo, Mike",52,000100
+COWLEY,Arkansas City Ward 3 C,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",30,000110
+COWLEY,Arkansas City Ward 3 C,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000110
+COWLEY,Arkansas City Ward 3 C,United States House of Representatives,4,Republican,"Pompeo, Mike",49,000110
+COWLEY,Arkansas City Ward 4 A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",116,000120
+COWLEY,Arkansas City Ward 4 A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",20,000120
+COWLEY,Arkansas City Ward 4 A,United States House of Representatives,4,Republican,"Pompeo, Mike",139,000120
+COWLEY,Arkansas City Ward 4 B,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",227,00013A
+COWLEY,Arkansas City Ward 4 B,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",43,00013A
+COWLEY,Arkansas City Ward 4 B,United States House of Representatives,4,Republican,"Pompeo, Mike",326,00013A
+COWLEY,Arkansas City Ward 4 C,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",101,000140
+COWLEY,Arkansas City Ward 4 C,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000140
+COWLEY,Arkansas City Ward 4 C,United States House of Representatives,4,Republican,"Pompeo, Mike",145,000140
+COWLEY,Arkansas City Ward 4 D,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",193,000150
+COWLEY,Arkansas City Ward 4 D,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",19,000150
+COWLEY,Arkansas City Ward 4 D,United States House of Representatives,4,Republican,"Pompeo, Mike",260,000150
+COWLEY,Beaver Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",26,000170
+COWLEY,Beaver Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000170
+COWLEY,Beaver Township,United States House of Representatives,4,Republican,"Pompeo, Mike",69,000170
+COWLEY,Cedar Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",1,000180
+COWLEY,Cedar Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000180
+COWLEY,Cedar Township,United States House of Representatives,4,Republican,"Pompeo, Mike",18,000180
+COWLEY,Dexter Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",31,000190
+COWLEY,Dexter Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",11,000190
+COWLEY,Dexter Township,United States House of Representatives,4,Republican,"Pompeo, Mike",148,000190
+COWLEY,East Bolton,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",101,000200
+COWLEY,East Bolton,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",19,000200
+COWLEY,East Bolton,United States House of Representatives,4,Republican,"Pompeo, Mike",190,000200
+COWLEY,East Creswell,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",165,000210
+COWLEY,East Creswell,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",33,000210
+COWLEY,East Creswell,United States House of Representatives,4,Republican,"Pompeo, Mike",423,000210
+COWLEY,Fairview Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",29,000220
+COWLEY,Fairview Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,000220
+COWLEY,Fairview Township,United States House of Representatives,4,Republican,"Pompeo, Mike",94,000220
+COWLEY,Grant Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",6,000230
+COWLEY,Grant Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000230
+COWLEY,Grant Township,United States House of Representatives,4,Republican,"Pompeo, Mike",25,000230
+COWLEY,Harvey Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",10,000240
+COWLEY,Harvey Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000240
+COWLEY,Harvey Township,United States House of Representatives,4,Republican,"Pompeo, Mike",31,000240
+COWLEY,Liberty Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",12,000250
+COWLEY,Liberty Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000250
+COWLEY,Liberty Township,United States House of Representatives,4,Republican,"Pompeo, Mike",63,000250
+COWLEY,Maple Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",79,000260
+COWLEY,Maple Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",19,000260
+COWLEY,Maple Township,United States House of Representatives,4,Republican,"Pompeo, Mike",235,000260
+COWLEY,Ninnescah Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",102,000270
+COWLEY,Ninnescah Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",31,000270
+COWLEY,Ninnescah Township,United States House of Representatives,4,Republican,"Pompeo, Mike",306,000270
+COWLEY,Omnia Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",24,000280
+COWLEY,Omnia Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000280
+COWLEY,Omnia Township,United States House of Representatives,4,Republican,"Pompeo, Mike",106,000280
+COWLEY,Otter Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000290
+COWLEY,Otter Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000290
+COWLEY,Otter Township,United States House of Representatives,4,Republican,"Pompeo, Mike",16,000290
+COWLEY,Pleasant Valley Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",117,000300
+COWLEY,Pleasant Valley Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",16,000300
+COWLEY,Pleasant Valley Township,United States House of Representatives,4,Republican,"Pompeo, Mike",275,000300
+COWLEY,Richland Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",23,000310
+COWLEY,Richland Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,000310
+COWLEY,Richland Township,United States House of Representatives,4,Republican,"Pompeo, Mike",73,000310
+COWLEY,Rock Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",16,000320
+COWLEY,Rock Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,000320
+COWLEY,Rock Township,United States House of Representatives,4,Republican,"Pompeo, Mike",70,000320
+COWLEY,Salem Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",27,000330
+COWLEY,Salem Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",10,000330
+COWLEY,Salem Township,United States House of Representatives,4,Republican,"Pompeo, Mike",104,000330
+COWLEY,Sheridan Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",17,000340
+COWLEY,Sheridan Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000340
+COWLEY,Sheridan Township,United States House of Representatives,4,Republican,"Pompeo, Mike",60,000340
+COWLEY,Silver Creek Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",52,000350
+COWLEY,Silver Creek Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",11,000350
+COWLEY,Silver Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",216,000350
+COWLEY,Silverdale Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",38,000360
+COWLEY,Silverdale Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",15,000360
+COWLEY,Silverdale Township,United States House of Representatives,4,Republican,"Pompeo, Mike",93,000360
+COWLEY,Spring Creek Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000370
+COWLEY,Spring Creek Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000370
+COWLEY,Spring Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",26,000370
+COWLEY,Tisdale Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",38,000380
+COWLEY,Tisdale Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,000380
+COWLEY,Tisdale Township,United States House of Representatives,4,Republican,"Pompeo, Mike",134,000380
+COWLEY,Vernon Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",48,000390
+COWLEY,Vernon Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",13,000390
+COWLEY,Vernon Township,United States House of Representatives,4,Republican,"Pompeo, Mike",177,000390
+COWLEY,Walnut Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",81,000400
+COWLEY,Walnut Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",18,000400
+COWLEY,Walnut Township,United States House of Representatives,4,Republican,"Pompeo, Mike",246,000400
+COWLEY,West Bolton,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",67,00041A
+COWLEY,West Bolton,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",23,00041A
+COWLEY,West Bolton,United States House of Representatives,4,Republican,"Pompeo, Mike",223,00041A
+COWLEY,West Bolton Enclave A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,00041B
+COWLEY,West Bolton Enclave A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,00041B
+COWLEY,West Bolton Enclave A,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00041B
+COWLEY,West Creswell,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",82,00042A
+COWLEY,West Creswell,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",16,00042A
+COWLEY,West Creswell,United States House of Representatives,4,Republican,"Pompeo, Mike",183,00042A
+COWLEY,Windsor Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",22,000430
+COWLEY,Windsor Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,000430
+COWLEY,Windsor Township,United States House of Representatives,4,Republican,"Pompeo, Mike",67,000430
+COWLEY,Winfield Ward 1 East,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",141,000440
+COWLEY,Winfield Ward 1 East,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",23,000440
+COWLEY,Winfield Ward 1 East,United States House of Representatives,4,Republican,"Pompeo, Mike",196,000440
+COWLEY,Winfield Ward 1 West,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",54,000450
+COWLEY,Winfield Ward 1 West,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000450
+COWLEY,Winfield Ward 1 West,United States House of Representatives,4,Republican,"Pompeo, Mike",128,000450
+COWLEY,Winfield Ward 2 Central,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",93,000460
+COWLEY,Winfield Ward 2 Central,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",12,000460
+COWLEY,Winfield Ward 2 Central,United States House of Representatives,4,Republican,"Pompeo, Mike",127,000460
+COWLEY,Winfield Ward 2 East,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",104,000470
+COWLEY,Winfield Ward 2 East,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",15,000470
+COWLEY,Winfield Ward 2 East,United States House of Representatives,4,Republican,"Pompeo, Mike",164,000470
+COWLEY,Winfield Ward 2 South,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",122,000480
+COWLEY,Winfield Ward 2 South,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",12,000480
+COWLEY,Winfield Ward 2 South,United States House of Representatives,4,Republican,"Pompeo, Mike",258,000480
+COWLEY,Winfield Ward 2 West,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",78,000490
+COWLEY,Winfield Ward 2 West,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",13,000490
+COWLEY,Winfield Ward 2 West,United States House of Representatives,4,Republican,"Pompeo, Mike",149,000490
+COWLEY,Winfield Ward 3,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",140,000500
+COWLEY,Winfield Ward 3,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",21,000500
+COWLEY,Winfield Ward 3,United States House of Representatives,4,Republican,"Pompeo, Mike",187,000500
+COWLEY,Winfield Ward 3 South,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",20,00051A
+COWLEY,Winfield Ward 3 South,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,00051A
+COWLEY,Winfield Ward 3 South,United States House of Representatives,4,Republican,"Pompeo, Mike",91,00051A
+COWLEY,Winfield Ward 8,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",9,00051B
+COWLEY,Winfield Ward 8,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,00051B
+COWLEY,Winfield Ward 8,United States House of Representatives,4,Republican,"Pompeo, Mike",29,00051B
+COWLEY,Winfield Ward 4,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",39,000520
+COWLEY,Winfield Ward 4,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000520
+COWLEY,Winfield Ward 4,United States House of Representatives,4,Republican,"Pompeo, Mike",64,000520
+COWLEY,Winfield Ward 5 East,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",209,00053A
+COWLEY,Winfield Ward 5 East,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",22,00053A
+COWLEY,Winfield Ward 5 East,United States House of Representatives,4,Republican,"Pompeo, Mike",291,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00053B
+COWLEY,Winfield Ward 5 West,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",77,000540
+COWLEY,Winfield Ward 5 West,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",13,000540
+COWLEY,Winfield Ward 5 West,United States House of Representatives,4,Republican,"Pompeo, Mike",106,000540
+COWLEY,Winfield Ward 6,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",142,000550
+COWLEY,Winfield Ward 6,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",34,000550
+COWLEY,Winfield Ward 6,United States House of Representatives,4,Republican,"Pompeo, Mike",320,000550
+COWLEY,Winfield Ward 6 A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",48,000560
+COWLEY,Winfield Ward 6 A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000560
+COWLEY,Winfield Ward 6 A,United States House of Representatives,4,Republican,"Pompeo, Mike",138,000560
+COWLEY,Winfield Ward 7,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",95,000570
+COWLEY,Winfield Ward 7,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",9,000570
+COWLEY,Winfield Ward 7,United States House of Representatives,4,Republican,"Pompeo, Mike",187,000570
+COWLEY,Arkansas City Ward 5,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900010
+COWLEY,Arkansas City Ward 5,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900010
+COWLEY,Arkansas City Ward 5,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900010
+COWLEY,West Creswell Enclave A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900020
+COWLEY,West Creswell Enclave A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900020
+COWLEY,West Creswell Enclave A,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900020
+COWLEY,West Creswell Enclave B,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900030
+COWLEY,West Creswell Enclave B,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900030
+COWLEY,West Creswell Enclave B,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900030
+COWLEY,West Creswell Enclave C,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900040
+COWLEY,West Creswell Enclave C,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900040
+COWLEY,West Creswell Enclave C,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900060
+COWLEY,Winfield Ward 9,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900070
+COWLEY,Winfield Ward 9,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900070
+COWLEY,Winfield Ward 9,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900070

--- a/2012/20121106__ks__general__crawford__precinct.csv
+++ b/2012/20121106__ks__general__crawford__precinct.csv
@@ -1,0 +1,1587 @@
+county,precinct,office,district,party,candidate,votes,vtd
+CRAWFORD,Lincoln - Arcadia,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",35,000A41
+CRAWFORD,Lincoln - Arcadia,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",5,000A41
+CRAWFORD,Lincoln - Arcadia,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",17,000A41
+CRAWFORD,Osage - McCune,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",96,000A51
+CRAWFORD,Osage - McCune,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",3,000A51
+CRAWFORD,Osage - McCune,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",103,000A51
+CRAWFORD,Cherokee - Sheridan,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",87,000A62
+CRAWFORD,Cherokee - Sheridan,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",3,000A62
+CRAWFORD,Cherokee - Sheridan,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",65,000A62
+CRAWFORD,Walnut - Helper,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",20,000A82
+CRAWFORD,Walnut - Helper,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",1,000A82
+CRAWFORD,Walnut - Helper,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",8,000A82
+CRAWFORD,Walnut Township,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",14,000A83
+CRAWFORD,Walnut Township,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",0,000A83
+CRAWFORD,Walnut Township,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",2,000A83
+CRAWFORD,Arcadia,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",88,000010
+CRAWFORD,Arcadia,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",15,000010
+CRAWFORD,Arcadia,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",34,000010
+CRAWFORD,Baker,Kansas House of Representatives,3,Democratic,"Menghini, Julie",216,000020
+CRAWFORD,Baker,Kansas House of Representatives,3,Republican,"Hucke, Michelle",262,000020
+CRAWFORD,Beulah,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",75,000030
+CRAWFORD,Beulah,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",2,000030
+CRAWFORD,Beulah,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",48,000030
+CRAWFORD,Sheridan - Cherokee City,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",32,000033
+CRAWFORD,Sheridan - Cherokee City,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",0,000033
+CRAWFORD,Sheridan - Cherokee City,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",24,000033
+CRAWFORD,Brazilton,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",29,000040
+CRAWFORD,Brazilton,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",0,000040
+CRAWFORD,Brazilton,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",13,000040
+CRAWFORD,Capaldo,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",133,000050
+CRAWFORD,Capaldo,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",13,000050
+CRAWFORD,Capaldo,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",83,000050
+CRAWFORD,Cherokee,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",130,000060
+CRAWFORD,Cherokee,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",7,000060
+CRAWFORD,Cherokee,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",109,000060
+CRAWFORD,Chicopee,Kansas House of Representatives,3,Democratic,"Menghini, Julie",125,000070
+CRAWFORD,Chicopee,Kansas House of Representatives,3,Republican,"Hucke, Michelle",132,000070
+CRAWFORD,Crawford,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",102,000080
+CRAWFORD,Crawford,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",7,000080
+CRAWFORD,Crawford,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",91,000080
+CRAWFORD,Crowe,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",63,000090
+CRAWFORD,Crowe,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",1,000090
+CRAWFORD,Crowe,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",42,000090
+CRAWFORD,Frontenac Ward 1,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",310,000110
+CRAWFORD,Frontenac Ward 1,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",7,000110
+CRAWFORD,Frontenac Ward 1,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",94,000110
+CRAWFORD,Frontenac Ward 2,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",411,00012A
+CRAWFORD,Frontenac Ward 2,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",11,00012A
+CRAWFORD,Frontenac Ward 2,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",198,00012A
+CRAWFORD,Frontenac Ward 3,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",172,00013A
+CRAWFORD,Frontenac Ward 3,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",4,00013A
+CRAWFORD,Frontenac Ward 3,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",62,00013A
+CRAWFORD,Frontenac Ward 4,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",147,00014A
+CRAWFORD,Frontenac Ward 4,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",6,00014A
+CRAWFORD,Frontenac Ward 4,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",41,00014A
+CRAWFORD,Girard Ward 1,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",69,000150
+CRAWFORD,Girard Ward 1,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",5,000150
+CRAWFORD,Girard Ward 1,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",44,000150
+CRAWFORD,Girard Ward 2,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",233,00016A
+CRAWFORD,Girard Ward 2,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",12,00016A
+CRAWFORD,Girard Ward 2,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",141,00016A
+CRAWFORD,Girard Ward 3,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",129,00017A
+CRAWFORD,Girard Ward 3,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",7,00017A
+CRAWFORD,Girard Ward 3,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",83,00017A
+CRAWFORD,Girard Ward 4,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",182,000180
+CRAWFORD,Girard Ward 4,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",8,000180
+CRAWFORD,Girard Ward 4,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",146,000180
+CRAWFORD,Grant,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",74,000190
+CRAWFORD,Grant,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",3,000190
+CRAWFORD,Grant,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",58,000190
+CRAWFORD,Hepler,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",30,000200
+CRAWFORD,Hepler,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",2,000200
+CRAWFORD,Hepler,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",16,000200
+CRAWFORD,Lincoln,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",82,000210
+CRAWFORD,Lincoln,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",8,000210
+CRAWFORD,Lincoln,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",75,000210
+CRAWFORD,Lone Star,Kansas House of Representatives,3,Democratic,"Menghini, Julie",259,00022A
+CRAWFORD,Lone Star,Kansas House of Representatives,3,Republican,"Hucke, Michelle",300,00022A
+CRAWFORD,McCune,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",118,000230
+CRAWFORD,McCune,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",6,000230
+CRAWFORD,McCune,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",49,000230
+CRAWFORD,Mulberry Ward 1,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",44,000240
+CRAWFORD,Mulberry Ward 1,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",3,000240
+CRAWFORD,Mulberry Ward 1,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",24,000240
+CRAWFORD,Mulberry Ward 2,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",53,000250
+CRAWFORD,Mulberry Ward 2,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",5,000250
+CRAWFORD,Mulberry Ward 2,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",28,000250
+CRAWFORD,North Arma,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",240,000260
+CRAWFORD,North Arma,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",6,000260
+CRAWFORD,North Arma,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",126,000260
+CRAWFORD,Opolis,Kansas House of Representatives,3,Democratic,"Menghini, Julie",80,000270
+CRAWFORD,Opolis,Kansas House of Representatives,3,Republican,"Hucke, Michelle",93,000270
+CRAWFORD,Parkview,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",144,000280
+CRAWFORD,Parkview,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",4,000280
+CRAWFORD,Parkview,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",71,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Kansas House of Representatives,3,Democratic,"Menghini, Julie",200,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Kansas House of Representatives,3,Republican,"Hucke, Michelle",146,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Kansas House of Representatives,3,Democratic,"Menghini, Julie",337,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Kansas House of Representatives,3,Republican,"Hucke, Michelle",266,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Kansas House of Representatives,3,Democratic,"Menghini, Julie",617,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Kansas House of Representatives,3,Republican,"Hucke, Michelle",566,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Kansas House of Representatives,3,Democratic,"Menghini, Julie",132,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Kansas House of Representatives,3,Republican,"Hucke, Michelle",98,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Kansas House of Representatives,3,Democratic,"Menghini, Julie",171,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Kansas House of Representatives,3,Republican,"Hucke, Michelle",107,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Kansas House of Representatives,3,Democratic,"Menghini, Julie",205,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Kansas House of Representatives,3,Republican,"Hucke, Michelle",165,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Kansas House of Representatives,3,Democratic,"Menghini, Julie",170,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Kansas House of Representatives,3,Republican,"Hucke, Michelle",138,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Kansas House of Representatives,3,Democratic,"Menghini, Julie",215,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Kansas House of Representatives,3,Republican,"Hucke, Michelle",204,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Kansas House of Representatives,3,Democratic,"Menghini, Julie",192,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Kansas House of Representatives,3,Republican,"Hucke, Michelle",156,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Kansas House of Representatives,3,Democratic,"Menghini, Julie",215,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Kansas House of Representatives,3,Republican,"Hucke, Michelle",170,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Kansas House of Representatives,3,Democratic,"Menghini, Julie",85,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Kansas House of Representatives,3,Republican,"Hucke, Michelle",43,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Kansas House of Representatives,3,Democratic,"Menghini, Julie",186,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Kansas House of Representatives,3,Republican,"Hucke, Michelle",105,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Kansas House of Representatives,3,Democratic,"Menghini, Julie",286,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Kansas House of Representatives,3,Republican,"Hucke, Michelle",188,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Kansas House of Representatives,3,Democratic,"Menghini, Julie",161,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Kansas House of Representatives,3,Republican,"Hucke, Michelle",118,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Kansas House of Representatives,3,Democratic,"Menghini, Julie",346,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Kansas House of Representatives,3,Republican,"Hucke, Michelle",317,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Kansas House of Representatives,3,Democratic,"Menghini, Julie",43,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Kansas House of Representatives,3,Republican,"Hucke, Michelle",48,00044A
+CRAWFORD,Raymond,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",181,000450
+CRAWFORD,Raymond,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",6,000450
+CRAWFORD,Raymond,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",151,000450
+CRAWFORD,Sheridan,Kansas House of Representatives,3,Democratic,"Menghini, Julie",37,000460
+CRAWFORD,Sheridan,Kansas House of Representatives,3,Republican,"Hucke, Michelle",26,000460
+CRAWFORD,Sherman,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",157,000470
+CRAWFORD,Sherman,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",8,000470
+CRAWFORD,Sherman,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",120,000470
+CRAWFORD,Smelter,Kansas House of Representatives,3,Democratic,"Menghini, Julie",134,000480
+CRAWFORD,Smelter,Kansas House of Representatives,3,Republican,"Hucke, Michelle",147,000480
+CRAWFORD,South Arma,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",254,000490
+CRAWFORD,South Arma,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",9,000490
+CRAWFORD,South Arma,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",151,000490
+CRAWFORD,Walnut,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",30,000500
+CRAWFORD,Walnut,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",1,000500
+CRAWFORD,Walnut,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",27,000500
+CRAWFORD,Franklin,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",110,700100
+CRAWFORD,Franklin,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",4,700100
+CRAWFORD,Franklin,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",58,700100
+CRAWFORD,Lincoln - Arcadia,Kansas Senate,13,Democratic,"Garman, Gene",26,000A41
+CRAWFORD,Lincoln - Arcadia,Kansas Senate,13,Republican,"LaTurner, Jacob",28,000A41
+CRAWFORD,Osage - McCune,Kansas Senate,13,Democratic,"Garman, Gene",63,000A51
+CRAWFORD,Osage - McCune,Kansas Senate,13,Republican,"LaTurner, Jacob",137,000A51
+CRAWFORD,Cherokee - Sheridan,Kansas Senate,13,Democratic,"Garman, Gene",54,000A62
+CRAWFORD,Cherokee - Sheridan,Kansas Senate,13,Republican,"LaTurner, Jacob",98,000A62
+CRAWFORD,Walnut - Helper,Kansas Senate,13,Democratic,"Garman, Gene",10,000A82
+CRAWFORD,Walnut - Helper,Kansas Senate,13,Republican,"LaTurner, Jacob",18,000A82
+CRAWFORD,Walnut Township,Kansas Senate,13,Democratic,"Garman, Gene",4,000A83
+CRAWFORD,Walnut Township,Kansas Senate,13,Republican,"LaTurner, Jacob",11,000A83
+CRAWFORD,Arcadia,Kansas Senate,13,Democratic,"Garman, Gene",82,000010
+CRAWFORD,Arcadia,Kansas Senate,13,Republican,"LaTurner, Jacob",50,000010
+CRAWFORD,Baker,Kansas Senate,13,Democratic,"Garman, Gene",172,000020
+CRAWFORD,Baker,Kansas Senate,13,Republican,"LaTurner, Jacob",293,000020
+CRAWFORD,Beulah,Kansas Senate,13,Democratic,"Garman, Gene",44,000030
+CRAWFORD,Beulah,Kansas Senate,13,Republican,"LaTurner, Jacob",77,000030
+CRAWFORD,Sheridan - Cherokee City,Kansas Senate,13,Democratic,"Garman, Gene",14,000033
+CRAWFORD,Sheridan - Cherokee City,Kansas Senate,13,Republican,"LaTurner, Jacob",40,000033
+CRAWFORD,Brazilton,Kansas Senate,13,Democratic,"Garman, Gene",11,000040
+CRAWFORD,Brazilton,Kansas Senate,13,Republican,"LaTurner, Jacob",28,000040
+CRAWFORD,Capaldo,Kansas Senate,13,Democratic,"Garman, Gene",100,000050
+CRAWFORD,Capaldo,Kansas Senate,13,Republican,"LaTurner, Jacob",114,000050
+CRAWFORD,Cherokee,Kansas Senate,13,Democratic,"Garman, Gene",102,000060
+CRAWFORD,Cherokee,Kansas Senate,13,Republican,"LaTurner, Jacob",136,000060
+CRAWFORD,Chicopee,Kansas Senate,13,Democratic,"Garman, Gene",97,000070
+CRAWFORD,Chicopee,Kansas Senate,13,Republican,"LaTurner, Jacob",153,000070
+CRAWFORD,Crawford,Kansas Senate,13,Democratic,"Garman, Gene",44,000080
+CRAWFORD,Crawford,Kansas Senate,13,Republican,"LaTurner, Jacob",154,000080
+CRAWFORD,Crowe,Kansas Senate,13,Democratic,"Garman, Gene",50,000090
+CRAWFORD,Crowe,Kansas Senate,13,Republican,"LaTurner, Jacob",52,000090
+CRAWFORD,Frontenac Ward 1,Kansas Senate,13,Democratic,"Garman, Gene",228,000110
+CRAWFORD,Frontenac Ward 1,Kansas Senate,13,Republican,"LaTurner, Jacob",171,000110
+CRAWFORD,Frontenac Ward 2,Kansas Senate,13,Democratic,"Garman, Gene",316,00012A
+CRAWFORD,Frontenac Ward 2,Kansas Senate,13,Republican,"LaTurner, Jacob",292,00012A
+CRAWFORD,Frontenac Ward 3,Kansas Senate,13,Democratic,"Garman, Gene",122,00013A
+CRAWFORD,Frontenac Ward 3,Kansas Senate,13,Republican,"LaTurner, Jacob",103,00013A
+CRAWFORD,Frontenac Ward 4,Kansas Senate,13,Democratic,"Garman, Gene",110,00014A
+CRAWFORD,Frontenac Ward 4,Kansas Senate,13,Republican,"LaTurner, Jacob",74,00014A
+CRAWFORD,Girard Ward 1,Kansas Senate,13,Democratic,"Garman, Gene",46,000150
+CRAWFORD,Girard Ward 1,Kansas Senate,13,Republican,"LaTurner, Jacob",69,000150
+CRAWFORD,Girard Ward 2,Kansas Senate,13,Democratic,"Garman, Gene",155,00016A
+CRAWFORD,Girard Ward 2,Kansas Senate,13,Republican,"LaTurner, Jacob",219,00016A
+CRAWFORD,Girard Ward 3,Kansas Senate,13,Democratic,"Garman, Gene",105,00017A
+CRAWFORD,Girard Ward 3,Kansas Senate,13,Republican,"LaTurner, Jacob",114,00017A
+CRAWFORD,Girard Ward 4,Kansas Senate,13,Democratic,"Garman, Gene",144,000180
+CRAWFORD,Girard Ward 4,Kansas Senate,13,Republican,"LaTurner, Jacob",180,000180
+CRAWFORD,Grant,Kansas Senate,13,Democratic,"Garman, Gene",32,000190
+CRAWFORD,Grant,Kansas Senate,13,Republican,"LaTurner, Jacob",99,000190
+CRAWFORD,Hepler,Kansas Senate,13,Democratic,"Garman, Gene",15,000200
+CRAWFORD,Hepler,Kansas Senate,13,Republican,"LaTurner, Jacob",32,000200
+CRAWFORD,Lincoln,Kansas Senate,13,Democratic,"Garman, Gene",67,000210
+CRAWFORD,Lincoln,Kansas Senate,13,Republican,"LaTurner, Jacob",92,000210
+CRAWFORD,Lone Star,Kansas Senate,13,Democratic,"Garman, Gene",218,00022A
+CRAWFORD,Lone Star,Kansas Senate,13,Republican,"LaTurner, Jacob",329,00022A
+CRAWFORD,McCune,Kansas Senate,13,Democratic,"Garman, Gene",78,000230
+CRAWFORD,McCune,Kansas Senate,13,Republican,"LaTurner, Jacob",91,000230
+CRAWFORD,Mulberry Ward 1,Kansas Senate,13,Democratic,"Garman, Gene",40,000240
+CRAWFORD,Mulberry Ward 1,Kansas Senate,13,Republican,"LaTurner, Jacob",32,000240
+CRAWFORD,Mulberry Ward 2,Kansas Senate,13,Democratic,"Garman, Gene",49,000250
+CRAWFORD,Mulberry Ward 2,Kansas Senate,13,Republican,"LaTurner, Jacob",35,000250
+CRAWFORD,North Arma,Kansas Senate,13,Democratic,"Garman, Gene",193,000260
+CRAWFORD,North Arma,Kansas Senate,13,Republican,"LaTurner, Jacob",168,000260
+CRAWFORD,Opolis,Kansas Senate,13,Democratic,"Garman, Gene",74,000270
+CRAWFORD,Opolis,Kansas Senate,13,Republican,"LaTurner, Jacob",97,000270
+CRAWFORD,Parkview,Kansas Senate,13,Democratic,"Garman, Gene",104,000280
+CRAWFORD,Parkview,Kansas Senate,13,Republican,"LaTurner, Jacob",111,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Kansas Senate,13,Democratic,"Garman, Gene",167,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Kansas Senate,13,Republican,"LaTurner, Jacob",169,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Kansas Senate,13,Democratic,"Garman, Gene",297,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Kansas Senate,13,Republican,"LaTurner, Jacob",290,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Kansas Senate,13,Democratic,"Garman, Gene",513,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Kansas Senate,13,Republican,"LaTurner, Jacob",635,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Kansas Senate,13,Democratic,"Garman, Gene",107,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Kansas Senate,13,Republican,"LaTurner, Jacob",115,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Kansas Senate,13,Democratic,"Garman, Gene",138,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Kansas Senate,13,Republican,"LaTurner, Jacob",130,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Kansas Senate,13,Democratic,"Garman, Gene",188,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Kansas Senate,13,Republican,"LaTurner, Jacob",175,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Kansas Senate,13,Democratic,"Garman, Gene",148,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Kansas Senate,13,Republican,"LaTurner, Jacob",157,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Kansas Senate,13,Democratic,"Garman, Gene",171,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Kansas Senate,13,Republican,"LaTurner, Jacob",239,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Kansas Senate,13,Democratic,"Garman, Gene",174,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Kansas Senate,13,Republican,"LaTurner, Jacob",167,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Kansas Senate,13,Democratic,"Garman, Gene",185,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Kansas Senate,13,Republican,"LaTurner, Jacob",191,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Kansas Senate,13,Democratic,"Garman, Gene",74,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Kansas Senate,13,Republican,"LaTurner, Jacob",52,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Kansas Senate,13,Democratic,"Garman, Gene",150,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Kansas Senate,13,Republican,"LaTurner, Jacob",132,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Kansas Senate,13,Democratic,"Garman, Gene",242,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Kansas Senate,13,Republican,"LaTurner, Jacob",227,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Kansas Senate,13,Democratic,"Garman, Gene",154,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Kansas Senate,13,Republican,"LaTurner, Jacob",123,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Kansas Senate,13,Democratic,"Garman, Gene",293,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Kansas Senate,13,Republican,"LaTurner, Jacob",355,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Kansas Senate,13,Democratic,"Garman, Gene",27,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Kansas Senate,13,Republican,"LaTurner, Jacob",65,00044A
+CRAWFORD,Raymond,Kansas Senate,13,Democratic,"Garman, Gene",109,000450
+CRAWFORD,Raymond,Kansas Senate,13,Republican,"LaTurner, Jacob",226,000450
+CRAWFORD,Sheridan,Kansas Senate,13,Democratic,"Garman, Gene",28,000460
+CRAWFORD,Sheridan,Kansas Senate,13,Republican,"LaTurner, Jacob",33,000460
+CRAWFORD,Sherman,Kansas Senate,13,Democratic,"Garman, Gene",100,000470
+CRAWFORD,Sherman,Kansas Senate,13,Republican,"LaTurner, Jacob",178,000470
+CRAWFORD,Smelter,Kansas Senate,13,Democratic,"Garman, Gene",105,000480
+CRAWFORD,Smelter,Kansas Senate,13,Republican,"LaTurner, Jacob",175,000480
+CRAWFORD,South Arma,Kansas Senate,13,Democratic,"Garman, Gene",215,000490
+CRAWFORD,South Arma,Kansas Senate,13,Republican,"LaTurner, Jacob",190,000490
+CRAWFORD,Walnut,Kansas Senate,13,Democratic,"Garman, Gene",18,000500
+CRAWFORD,Walnut,Kansas Senate,13,Republican,"LaTurner, Jacob",41,000500
+CRAWFORD,Franklin,Kansas Senate,13,Democratic,"Garman, Gene",81,700100
+CRAWFORD,Franklin,Kansas Senate,13,Republican,"LaTurner, Jacob",86,700100
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Ayers, Avery L",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Barnett, Andre",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Barr, Roseanne C",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Bush, Kent W",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Christensen, Will",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Duncan, Richard A",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Goode, Virgil",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Hoefling, Tom",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Knill, Dennis J",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Reed, Jill A.",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Rogers, Rick L",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Stein, Jill E",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Thorne, Kevin M",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Warner, Gerald L.",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,Democratic,"Obama, Barack",20,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,Libertarian,"Johnson, Gary",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,Reform,"Baldwin, Chuck",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,Republican,"Romney, Mitt",35,000A41
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Ayers, Avery L",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Barnett, Andre",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Barr, Roseanne C",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Bush, Kent W",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Christensen, Will",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Duncan, Richard A",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Goode, Virgil",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Hoefling, Tom",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Knill, Dennis J",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Reed, Jill A.",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Rogers, Rick L",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Stein, Jill E",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Thorne, Kevin M",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Warner, Gerald L.",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,Democratic,"Obama, Barack",65,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,Libertarian,"Johnson, Gary",3,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,Reform,"Baldwin, Chuck",1,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,Republican,"Romney, Mitt",132,000A51
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Ayers, Avery L",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Barnett, Andre",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Barr, Roseanne C",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Bush, Kent W",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Christensen, Will",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Duncan, Richard A",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Goode, Virgil",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Hoefling, Tom",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Knill, Dennis J",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Reed, Jill A.",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Rogers, Rick L",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Stein, Jill E",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Thorne, Kevin M",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Warner, Gerald L.",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,Democratic,"Obama, Barack",51,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,Libertarian,"Johnson, Gary",5,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,Reform,"Baldwin, Chuck",1,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,Republican,"Romney, Mitt",93,000A62
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Ayers, Avery L",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Barnett, Andre",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Barr, Roseanne C",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Bush, Kent W",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Christensen, Will",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Duncan, Richard A",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Goode, Virgil",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Hoefling, Tom",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Knill, Dennis J",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Reed, Jill A.",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Rogers, Rick L",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Stein, Jill E",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Thorne, Kevin M",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Warner, Gerald L.",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,Democratic,"Obama, Barack",11,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,Libertarian,"Johnson, Gary",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,Reform,"Baldwin, Chuck",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,Republican,"Romney, Mitt",19,000A82
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Ayers, Avery L",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Barnett, Andre",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Bush, Kent W",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Christensen, Will",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Duncan, Richard A",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Goode, Virgil",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Knill, Dennis J",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Reed, Jill A.",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Rogers, Rick L",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Stein, Jill E",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,Democratic,"Obama, Barack",4,000A83
+CRAWFORD,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,Republican,"Romney, Mitt",12,000A83
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",2,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Barnett, Andre",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Barr, Roseanne C",1,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Bush, Kent W",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Christensen, Will",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Goode, Virgil",7,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Stein, Jill E",10,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+CRAWFORD,Arcadia,President / Vice President,,Democratic,"Obama, Barack",84,000010
+CRAWFORD,Arcadia,President / Vice President,,Libertarian,"Johnson, Gary",6,000010
+CRAWFORD,Arcadia,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+CRAWFORD,Arcadia,President / Vice President,,Republican,"Romney, Mitt",46,000010
+CRAWFORD,Baker,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Barnett, Andre",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Bush, Kent W",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Christensen, Will",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Goode, Virgil",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Stein, Jill E",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+CRAWFORD,Baker,President / Vice President,,Democratic,"Obama, Barack",169,000020
+CRAWFORD,Baker,President / Vice President,,Libertarian,"Johnson, Gary",8,000020
+CRAWFORD,Baker,President / Vice President,,Reform,"Baldwin, Chuck",2,000020
+CRAWFORD,Baker,President / Vice President,,Republican,"Romney, Mitt",302,000020
+CRAWFORD,Beulah,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Barnett, Andre",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Bush, Kent W",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Christensen, Will",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Goode, Virgil",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Stein, Jill E",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+CRAWFORD,Beulah,President / Vice President,,Democratic,"Obama, Barack",45,000030
+CRAWFORD,Beulah,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+CRAWFORD,Beulah,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+CRAWFORD,Beulah,President / Vice President,,Republican,"Romney, Mitt",77,000030
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Ayers, Avery L",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Barnett, Andre",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Barr, Roseanne C",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Bush, Kent W",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Christensen, Will",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Duncan, Richard A",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Goode, Virgil",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Hoefling, Tom",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Knill, Dennis J",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Reed, Jill A.",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Rogers, Rick L",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Stein, Jill E",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Thorne, Kevin M",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Warner, Gerald L.",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,Democratic,"Obama, Barack",20,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,Libertarian,"Johnson, Gary",2,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,Reform,"Baldwin, Chuck",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,Republican,"Romney, Mitt",33,000033
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Barnett, Andre",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Bush, Kent W",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Christensen, Will",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Goode, Virgil",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Stein, Jill E",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+CRAWFORD,Brazilton,President / Vice President,,Democratic,"Obama, Barack",11,000040
+CRAWFORD,Brazilton,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+CRAWFORD,Brazilton,President / Vice President,,Reform,"Baldwin, Chuck",2,000040
+CRAWFORD,Brazilton,President / Vice President,,Republican,"Romney, Mitt",30,000040
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Barnett, Andre",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Bush, Kent W",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Christensen, Will",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Goode, Virgil",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Stein, Jill E",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+CRAWFORD,Capaldo,President / Vice President,,Democratic,"Obama, Barack",100,000050
+CRAWFORD,Capaldo,President / Vice President,,Libertarian,"Johnson, Gary",8,000050
+CRAWFORD,Capaldo,President / Vice President,,Reform,"Baldwin, Chuck",2,000050
+CRAWFORD,Capaldo,President / Vice President,,Republican,"Romney, Mitt",120,000050
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Barnett, Andre",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Bush, Kent W",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Christensen, Will",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Goode, Virgil",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Stein, Jill E",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+CRAWFORD,Cherokee,President / Vice President,,Democratic,"Obama, Barack",104,000060
+CRAWFORD,Cherokee,President / Vice President,,Libertarian,"Johnson, Gary",10,000060
+CRAWFORD,Cherokee,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+CRAWFORD,Cherokee,President / Vice President,,Republican,"Romney, Mitt",131,000060
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Barnett, Andre",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Bush, Kent W",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Christensen, Will",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Goode, Virgil",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Stein, Jill E",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+CRAWFORD,Chicopee,President / Vice President,,Democratic,"Obama, Barack",101,000070
+CRAWFORD,Chicopee,President / Vice President,,Libertarian,"Johnson, Gary",3,000070
+CRAWFORD,Chicopee,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+CRAWFORD,Chicopee,President / Vice President,,Republican,"Romney, Mitt",153,000070
+CRAWFORD,Crawford,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Barnett, Andre",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Bush, Kent W",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Christensen, Will",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Goode, Virgil",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Stein, Jill E",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+CRAWFORD,Crawford,President / Vice President,,Democratic,"Obama, Barack",51,000080
+CRAWFORD,Crawford,President / Vice President,,Libertarian,"Johnson, Gary",3,000080
+CRAWFORD,Crawford,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+CRAWFORD,Crawford,President / Vice President,,Republican,"Romney, Mitt",155,000080
+CRAWFORD,Crowe,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Barnett, Andre",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Bush, Kent W",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Christensen, Will",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Goode, Virgil",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Stein, Jill E",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+CRAWFORD,Crowe,President / Vice President,,Democratic,"Obama, Barack",40,000090
+CRAWFORD,Crowe,President / Vice President,,Libertarian,"Johnson, Gary",4,000090
+CRAWFORD,Crowe,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+CRAWFORD,Crowe,President / Vice President,,Republican,"Romney, Mitt",60,000090
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,Democratic,"Obama, Barack",222,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,Republican,"Romney, Mitt",182,000110
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,Democratic,"Obama, Barack",323,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",8,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",6,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,Republican,"Romney, Mitt",289,00012A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,Democratic,"Obama, Barack",128,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",6,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",2,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,Republican,"Romney, Mitt",105,00013A
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Ayers, Avery L",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Barnett, Andre",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Barr, Roseanne C",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Bush, Kent W",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Christensen, Will",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Duncan, Richard A",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Goode, Virgil",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Hoefling, Tom",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Knill, Dennis J",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Reed, Jill A.",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Rogers, Rick L",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Stein, Jill E",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Thorne, Kevin M",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Warner, Gerald L.",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,Democratic,"Obama, Barack",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,Libertarian,"Johnson, Gary",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,Reform,"Baldwin, Chuck",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,Republican,"Romney, Mitt",0,00013B
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Christensen, Will",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,Democratic,"Obama, Barack",111,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",5,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",1,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,Republican,"Romney, Mitt",78,00014A
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,Democratic,"Obama, Barack",53,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",3,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,Republican,"Romney, Mitt",59,000150
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,Democratic,"Obama, Barack",170,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",8,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",2,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,Republican,"Romney, Mitt",209,00016A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,Democratic,"Obama, Barack",109,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",6,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,Republican,"Romney, Mitt",106,00017A
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Ayers, Avery L",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Barnett, Andre",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Barr, Roseanne C",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Bush, Kent W",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Christensen, Will",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Duncan, Richard A",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Goode, Virgil",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Hoefling, Tom",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Knill, Dennis J",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Reed, Jill A.",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Rogers, Rick L",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Stein, Jill E",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Thorne, Kevin M",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Warner, Gerald L.",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,Democratic,"Obama, Barack",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,Libertarian,"Johnson, Gary",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,Reform,"Baldwin, Chuck",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,Republican,"Romney, Mitt",0,00017B
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,Democratic,"Obama, Barack",141,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",9,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",7,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,Republican,"Romney, Mitt",177,000180
+CRAWFORD,Grant,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Barnett, Andre",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Bush, Kent W",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Christensen, Will",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Goode, Virgil",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Stein, Jill E",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+CRAWFORD,Grant,President / Vice President,,Democratic,"Obama, Barack",42,000190
+CRAWFORD,Grant,President / Vice President,,Libertarian,"Johnson, Gary",6,000190
+CRAWFORD,Grant,President / Vice President,,Reform,"Baldwin, Chuck",1,000190
+CRAWFORD,Grant,President / Vice President,,Republican,"Romney, Mitt",83,000190
+CRAWFORD,Hepler,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Barnett, Andre",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Bush, Kent W",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Christensen, Will",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Goode, Virgil",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Stein, Jill E",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+CRAWFORD,Hepler,President / Vice President,,Democratic,"Obama, Barack",27,000200
+CRAWFORD,Hepler,President / Vice President,,Libertarian,"Johnson, Gary",1,000200
+CRAWFORD,Hepler,President / Vice President,,Reform,"Baldwin, Chuck",1,000200
+CRAWFORD,Hepler,President / Vice President,,Republican,"Romney, Mitt",19,000200
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Barnett, Andre",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Bush, Kent W",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Christensen, Will",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Goode, Virgil",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Stein, Jill E",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+CRAWFORD,Lincoln,President / Vice President,,Democratic,"Obama, Barack",63,000210
+CRAWFORD,Lincoln,President / Vice President,,Libertarian,"Johnson, Gary",2,000210
+CRAWFORD,Lincoln,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+CRAWFORD,Lincoln,President / Vice President,,Republican,"Romney, Mitt",100,000210
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Ayers, Avery L",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Barnett, Andre",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Barr, Roseanne C",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Bush, Kent W",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Christensen, Will",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Duncan, Richard A",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Goode, Virgil",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Hoefling, Tom",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Knill, Dennis J",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Reed, Jill A.",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Rogers, Rick L",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Stein, Jill E",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Thorne, Kevin M",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Warner, Gerald L.",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,Democratic,"Obama, Barack",236,00022A
+CRAWFORD,Lone Star,President / Vice President,,Libertarian,"Johnson, Gary",15,00022A
+CRAWFORD,Lone Star,President / Vice President,,Reform,"Baldwin, Chuck",2,00022A
+CRAWFORD,Lone Star,President / Vice President,,Republican,"Romney, Mitt",308,00022A
+CRAWFORD,McCune,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Barnett, Andre",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Bush, Kent W",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Christensen, Will",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Goode, Virgil",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Stein, Jill E",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+CRAWFORD,McCune,President / Vice President,,Democratic,"Obama, Barack",91,000230
+CRAWFORD,McCune,President / Vice President,,Libertarian,"Johnson, Gary",7,000230
+CRAWFORD,McCune,President / Vice President,,Reform,"Baldwin, Chuck",2,000230
+CRAWFORD,McCune,President / Vice President,,Republican,"Romney, Mitt",69,000230
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,Democratic,"Obama, Barack",37,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,Republican,"Romney, Mitt",31,000240
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,Democratic,"Obama, Barack",43,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,Republican,"Romney, Mitt",40,000250
+CRAWFORD,North Arma,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Barnett, Andre",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Bush, Kent W",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Christensen, Will",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Goode, Virgil",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Stein, Jill E",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+CRAWFORD,North Arma,President / Vice President,,Democratic,"Obama, Barack",193,000260
+CRAWFORD,North Arma,President / Vice President,,Libertarian,"Johnson, Gary",11,000260
+CRAWFORD,North Arma,President / Vice President,,Reform,"Baldwin, Chuck",1,000260
+CRAWFORD,North Arma,President / Vice President,,Republican,"Romney, Mitt",171,000260
+CRAWFORD,Opolis,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Barnett, Andre",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Bush, Kent W",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Christensen, Will",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Goode, Virgil",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Stein, Jill E",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+CRAWFORD,Opolis,President / Vice President,,Democratic,"Obama, Barack",73,000270
+CRAWFORD,Opolis,President / Vice President,,Libertarian,"Johnson, Gary",4,000270
+CRAWFORD,Opolis,President / Vice President,,Reform,"Baldwin, Chuck",0,000270
+CRAWFORD,Opolis,President / Vice President,,Republican,"Romney, Mitt",97,000270
+CRAWFORD,Parkview,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Barnett, Andre",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Bush, Kent W",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Christensen, Will",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Goode, Virgil",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Stein, Jill E",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+CRAWFORD,Parkview,President / Vice President,,Democratic,"Obama, Barack",107,000280
+CRAWFORD,Parkview,President / Vice President,,Libertarian,"Johnson, Gary",2,000280
+CRAWFORD,Parkview,President / Vice President,,Reform,"Baldwin, Chuck",1,000280
+CRAWFORD,Parkview,President / Vice President,,Republican,"Romney, Mitt",114,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",171,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",11,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",3,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",163,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",311,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",15,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",285,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",528,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",18,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",4,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",644,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",123,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",3,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",99,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",146,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",4,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",126,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",198,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",10,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",167,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Goode, Virgil",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Stein, Jill E",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,Democratic,"Obama, Barack",142,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",5,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,Republican,"Romney, Mitt",163,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Ayers, Avery L",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Barnett, Andre",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Bush, Kent W",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Christensen, Will",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Duncan, Richard A",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Goode, Virgil",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Knill, Dennis J",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Reed, Jill A.",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Rogers, Rick L",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Stein, Jill E",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,Democratic,"Obama, Barack",177,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",9,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,Reform,"Baldwin, Chuck",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,Republican,"Romney, Mitt",236,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",178,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",7,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",154,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",186,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",10,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",193,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",75,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",1,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",47,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",163,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",118,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",246,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",17,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",215,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Goode, Virgil",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Stein, Jill E",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,Democratic,"Obama, Barack",142,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",9,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",1,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,Republican,"Romney, Mitt",126,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Ayers, Avery L",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Barnett, Andre",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Bush, Kent W",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Christensen, Will",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Duncan, Richard A",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Goode, Virgil",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Knill, Dennis J",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Reed, Jill A.",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Rogers, Rick L",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Stein, Jill E",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,Democratic,"Obama, Barack",292,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",9,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,Reform,"Baldwin, Chuck",5,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,Republican,"Romney, Mitt",359,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Ayers, Avery L",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Barnett, Andre",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Barr, Roseanne C",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Bush, Kent W",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Christensen, Will",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Duncan, Richard A",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Goode, Virgil",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Hoefling, Tom",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Knill, Dennis J",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Reed, Jill A.",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Rogers, Rick L",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Stein, Jill E",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Thorne, Kevin M",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Warner, Gerald L.",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,Democratic,"Obama, Barack",27,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,Libertarian,"Johnson, Gary",1,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,Reform,"Baldwin, Chuck",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,Republican,"Romney, Mitt",64,00044A
+CRAWFORD,Raymond,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Ayers, Avery L",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Barnett, Andre",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Barr, Roseanne C",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Bush, Kent W",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Christensen, Will",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Duncan, Richard A",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Goode, Virgil",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Knill, Dennis J",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Reed, Jill A.",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Rogers, Rick L",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Stein, Jill E",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Thorne, Kevin M",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Warner, Gerald L.",0,000450
+CRAWFORD,Raymond,President / Vice President,,Democratic,"Obama, Barack",114,000450
+CRAWFORD,Raymond,President / Vice President,,Libertarian,"Johnson, Gary",7,000450
+CRAWFORD,Raymond,President / Vice President,,Reform,"Baldwin, Chuck",1,000450
+CRAWFORD,Raymond,President / Vice President,,Republican,"Romney, Mitt",219,000450
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Ayers, Avery L",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Barnett, Andre",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Barr, Roseanne C",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Bush, Kent W",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Christensen, Will",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Duncan, Richard A",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Goode, Virgil",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Hoefling, Tom",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Knill, Dennis J",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Reed, Jill A.",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Rogers, Rick L",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Stein, Jill E",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Thorne, Kevin M",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Warner, Gerald L.",0,000460
+CRAWFORD,Sheridan,President / Vice President,,Democratic,"Obama, Barack",32,000460
+CRAWFORD,Sheridan,President / Vice President,,Libertarian,"Johnson, Gary",0,000460
+CRAWFORD,Sheridan,President / Vice President,,Reform,"Baldwin, Chuck",0,000460
+CRAWFORD,Sheridan,President / Vice President,,Republican,"Romney, Mitt",30,000460
+CRAWFORD,Sherman,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Ayers, Avery L",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Barnett, Andre",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Barr, Roseanne C",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Bush, Kent W",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Christensen, Will",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Duncan, Richard A",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Goode, Virgil",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Hoefling, Tom",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Knill, Dennis J",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Reed, Jill A.",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Rogers, Rick L",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Stein, Jill E",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Thorne, Kevin M",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Warner, Gerald L.",0,000470
+CRAWFORD,Sherman,President / Vice President,,Democratic,"Obama, Barack",106,000470
+CRAWFORD,Sherman,President / Vice President,,Libertarian,"Johnson, Gary",3,000470
+CRAWFORD,Sherman,President / Vice President,,Reform,"Baldwin, Chuck",0,000470
+CRAWFORD,Sherman,President / Vice President,,Republican,"Romney, Mitt",172,000470
+CRAWFORD,Smelter,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Ayers, Avery L",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Barnett, Andre",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Barr, Roseanne C",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Bush, Kent W",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Christensen, Will",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Duncan, Richard A",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Goode, Virgil",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Hoefling, Tom",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Knill, Dennis J",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Reed, Jill A.",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Rogers, Rick L",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Stein, Jill E",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Thorne, Kevin M",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Warner, Gerald L.",0,000480
+CRAWFORD,Smelter,President / Vice President,,Democratic,"Obama, Barack",108,000480
+CRAWFORD,Smelter,President / Vice President,,Libertarian,"Johnson, Gary",3,000480
+CRAWFORD,Smelter,President / Vice President,,Reform,"Baldwin, Chuck",1,000480
+CRAWFORD,Smelter,President / Vice President,,Republican,"Romney, Mitt",176,000480
+CRAWFORD,South Arma,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Ayers, Avery L",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Barnett, Andre",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Barr, Roseanne C",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Bush, Kent W",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Christensen, Will",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Duncan, Richard A",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Goode, Virgil",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Hoefling, Tom",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Knill, Dennis J",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Reed, Jill A.",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Rogers, Rick L",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Stein, Jill E",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Thorne, Kevin M",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Warner, Gerald L.",0,000490
+CRAWFORD,South Arma,President / Vice President,,Democratic,"Obama, Barack",213,000490
+CRAWFORD,South Arma,President / Vice President,,Libertarian,"Johnson, Gary",4,000490
+CRAWFORD,South Arma,President / Vice President,,Reform,"Baldwin, Chuck",2,000490
+CRAWFORD,South Arma,President / Vice President,,Republican,"Romney, Mitt",197,000490
+CRAWFORD,Walnut,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Ayers, Avery L",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Barnett, Andre",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Barr, Roseanne C",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Bush, Kent W",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Christensen, Will",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Duncan, Richard A",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Goode, Virgil",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Hoefling, Tom",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Knill, Dennis J",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Reed, Jill A.",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Rogers, Rick L",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Stein, Jill E",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Thorne, Kevin M",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Warner, Gerald L.",0,000500
+CRAWFORD,Walnut,President / Vice President,,Democratic,"Obama, Barack",21,000500
+CRAWFORD,Walnut,President / Vice President,,Libertarian,"Johnson, Gary",3,000500
+CRAWFORD,Walnut,President / Vice President,,Reform,"Baldwin, Chuck",0,000500
+CRAWFORD,Walnut,President / Vice President,,Republican,"Romney, Mitt",35,000500
+CRAWFORD,Franklin,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Ayers, Avery L",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Barnett, Andre",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Barr, Roseanne C",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Bush, Kent W",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Christensen, Will",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Duncan, Richard A",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Goode, Virgil",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Hoefling, Tom",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Knill, Dennis J",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Reed, Jill A.",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Rogers, Rick L",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Stein, Jill E",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Thorne, Kevin M",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Warner, Gerald L.",0,700100
+CRAWFORD,Franklin,President / Vice President,,Democratic,"Obama, Barack",82,700100
+CRAWFORD,Franklin,President / Vice President,,Libertarian,"Johnson, Gary",2,700100
+CRAWFORD,Franklin,President / Vice President,,Reform,"Baldwin, Chuck",0,700100
+CRAWFORD,Franklin,President / Vice President,,Republican,"Romney, Mitt",85,700100
+CRAWFORD,Lincoln - Arcadia,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",25,000A41
+CRAWFORD,Lincoln - Arcadia,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000A41
+CRAWFORD,Lincoln - Arcadia,United States House of Representatives,2,Republican,"Jenkins, Lynn",28,000A41
+CRAWFORD,Osage - McCune,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",49,000A51
+CRAWFORD,Osage - McCune,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000A51
+CRAWFORD,Osage - McCune,United States House of Representatives,2,Republican,"Jenkins, Lynn",150,000A51
+CRAWFORD,Cherokee - Sheridan,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",50,000A62
+CRAWFORD,Cherokee - Sheridan,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000A62
+CRAWFORD,Cherokee - Sheridan,United States House of Representatives,2,Republican,"Jenkins, Lynn",96,000A62
+CRAWFORD,Walnut - Helper,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",12,000A82
+CRAWFORD,Walnut - Helper,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000A82
+CRAWFORD,Walnut - Helper,United States House of Representatives,2,Republican,"Jenkins, Lynn",14,000A82
+CRAWFORD,Walnut Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",6,000A83
+CRAWFORD,Walnut Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000A83
+CRAWFORD,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",6,000A83
+CRAWFORD,Arcadia,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",70,000010
+CRAWFORD,Arcadia,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000010
+CRAWFORD,Arcadia,United States House of Representatives,2,Republican,"Jenkins, Lynn",52,000010
+CRAWFORD,Baker,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",158,000020
+CRAWFORD,Baker,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000020
+CRAWFORD,Baker,United States House of Representatives,2,Republican,"Jenkins, Lynn",305,000020
+CRAWFORD,Beulah,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",42,000030
+CRAWFORD,Beulah,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000030
+CRAWFORD,Beulah,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,000030
+CRAWFORD,Sheridan - Cherokee City,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",16,000033
+CRAWFORD,Sheridan - Cherokee City,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000033
+CRAWFORD,Sheridan - Cherokee City,United States House of Representatives,2,Republican,"Jenkins, Lynn",35,000033
+CRAWFORD,Brazilton,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",9,000040
+CRAWFORD,Brazilton,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000040
+CRAWFORD,Brazilton,United States House of Representatives,2,Republican,"Jenkins, Lynn",30,000040
+CRAWFORD,Capaldo,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",99,000050
+CRAWFORD,Capaldo,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000050
+CRAWFORD,Capaldo,United States House of Representatives,2,Republican,"Jenkins, Lynn",111,000050
+CRAWFORD,Cherokee,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",103,000060
+CRAWFORD,Cherokee,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,000060
+CRAWFORD,Cherokee,United States House of Representatives,2,Republican,"Jenkins, Lynn",128,000060
+CRAWFORD,Chicopee,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",92,000070
+CRAWFORD,Chicopee,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000070
+CRAWFORD,Chicopee,United States House of Representatives,2,Republican,"Jenkins, Lynn",153,000070
+CRAWFORD,Crawford,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",46,000080
+CRAWFORD,Crawford,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000080
+CRAWFORD,Crawford,United States House of Representatives,2,Republican,"Jenkins, Lynn",152,000080
+CRAWFORD,Crowe,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",49,000090
+CRAWFORD,Crowe,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000090
+CRAWFORD,Crowe,United States House of Representatives,2,Republican,"Jenkins, Lynn",55,000090
+CRAWFORD,Frontenac Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",204,000110
+CRAWFORD,Frontenac Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000110
+CRAWFORD,Frontenac Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",187,000110
+CRAWFORD,Frontenac Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",288,00012A
+CRAWFORD,Frontenac Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,00012A
+CRAWFORD,Frontenac Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",308,00012A
+CRAWFORD,Frontenac Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",121,00013A
+CRAWFORD,Frontenac Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,00013A
+CRAWFORD,Frontenac Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",110,00013A
+CRAWFORD,Frontenac Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",91,00014A
+CRAWFORD,Frontenac Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,00014A
+CRAWFORD,Frontenac Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",96,00014A
+CRAWFORD,Girard Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",47,000150
+CRAWFORD,Girard Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000150
+CRAWFORD,Girard Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",66,000150
+CRAWFORD,Girard Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",139,00016A
+CRAWFORD,Girard Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,00016A
+CRAWFORD,Girard Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",226,00016A
+CRAWFORD,Girard Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",91,00017A
+CRAWFORD,Girard Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,00017A
+CRAWFORD,Girard Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",123,00017A
+CRAWFORD,Girard Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",125,000180
+CRAWFORD,Girard Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",19,000180
+CRAWFORD,Girard Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",186,000180
+CRAWFORD,Grant,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",35,000190
+CRAWFORD,Grant,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000190
+CRAWFORD,Grant,United States House of Representatives,2,Republican,"Jenkins, Lynn",93,000190
+CRAWFORD,Hepler,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",16,000200
+CRAWFORD,Hepler,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000200
+CRAWFORD,Hepler,United States House of Representatives,2,Republican,"Jenkins, Lynn",29,000200
+CRAWFORD,Lincoln,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",57,000210
+CRAWFORD,Lincoln,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000210
+CRAWFORD,Lincoln,United States House of Representatives,2,Republican,"Jenkins, Lynn",96,000210
+CRAWFORD,Lone Star,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",203,00022A
+CRAWFORD,Lone Star,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,00022A
+CRAWFORD,Lone Star,United States House of Representatives,2,Republican,"Jenkins, Lynn",329,00022A
+CRAWFORD,McCune,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",67,000230
+CRAWFORD,McCune,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000230
+CRAWFORD,McCune,United States House of Representatives,2,Republican,"Jenkins, Lynn",90,000230
+CRAWFORD,Mulberry Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",29,000240
+CRAWFORD,Mulberry Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000240
+CRAWFORD,Mulberry Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",40,000240
+CRAWFORD,Mulberry Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",33,000250
+CRAWFORD,Mulberry Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000250
+CRAWFORD,Mulberry Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",46,000250
+CRAWFORD,North Arma,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",174,000260
+CRAWFORD,North Arma,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000260
+CRAWFORD,North Arma,United States House of Representatives,2,Republican,"Jenkins, Lynn",189,000260
+CRAWFORD,Opolis,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",59,000270
+CRAWFORD,Opolis,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000270
+CRAWFORD,Opolis,United States House of Representatives,2,Republican,"Jenkins, Lynn",106,000270
+CRAWFORD,Parkview,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",101,000280
+CRAWFORD,Parkview,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000280
+CRAWFORD,Parkview,United States House of Representatives,2,Republican,"Jenkins, Lynn",112,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",145,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",182,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",262,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",23,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",311,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",475,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",44,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",649,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",101,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",117,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",141,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",130,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",173,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",17,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",175,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",124,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",169,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",159,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States House of Representatives,2,Libertarian,"Hawver, Dennis",17,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",244,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",146,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",22,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",176,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",172,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",200,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",67,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",52,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",135,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",143,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",219,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",24,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",233,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",130,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",135,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",255,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",392,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",27,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,00044A
+CRAWFORD,Raymond,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",95,000450
+CRAWFORD,Raymond,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000450
+CRAWFORD,Raymond,United States House of Representatives,2,Republican,"Jenkins, Lynn",226,000450
+CRAWFORD,Sheridan,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",24,000460
+CRAWFORD,Sheridan,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000460
+CRAWFORD,Sheridan,United States House of Representatives,2,Republican,"Jenkins, Lynn",37,000460
+CRAWFORD,Sherman,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",90,000470
+CRAWFORD,Sherman,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000470
+CRAWFORD,Sherman,United States House of Representatives,2,Republican,"Jenkins, Lynn",181,000470
+CRAWFORD,Smelter,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",96,000480
+CRAWFORD,Smelter,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000480
+CRAWFORD,Smelter,United States House of Representatives,2,Republican,"Jenkins, Lynn",178,000480
+CRAWFORD,South Arma,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",185,000490
+CRAWFORD,South Arma,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,000490
+CRAWFORD,South Arma,United States House of Representatives,2,Republican,"Jenkins, Lynn",211,000490
+CRAWFORD,Walnut,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",11,000500
+CRAWFORD,Walnut,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000500
+CRAWFORD,Walnut,United States House of Representatives,2,Republican,"Jenkins, Lynn",44,000500
+CRAWFORD,Franklin,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",70,700100
+CRAWFORD,Franklin,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,700100
+CRAWFORD,Franklin,United States House of Representatives,2,Republican,"Jenkins, Lynn",91,700100

--- a/2012/20121106__ks__general__decatur__precinct.csv
+++ b/2012/20121106__ks__general__decatur__precinct.csv
@@ -1,0 +1,673 @@
+county,precinct,office,district,party,candidate,votes,vtd
+DECATUR,Allison Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",8,000010
+DECATUR,Altory Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",12,000020
+DECATUR,Bassettville Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",12,000030
+DECATUR,Beaver Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",28,000040
+DECATUR,Center Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",26,000050
+DECATUR,Cook Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",16,000060
+DECATUR,Custer Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",18,000070
+DECATUR,Dresden Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",50,000080
+DECATUR,Finley Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",15,000090
+DECATUR,Garfield Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",20,000100
+DECATUR,Grant Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",2,000110
+DECATUR,Harlan Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",16,000120
+DECATUR,Jennings Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",60,000130
+DECATUR,Liberty Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",26,000140
+DECATUR,Lincoln Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",72,000150
+DECATUR,Logan Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",16,000160
+DECATUR,Lyon Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",7,000170
+DECATUR,Oberlin City Precinct 1,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",354,000180
+DECATUR,Oberlin City Precinct 2,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",433,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",0,00019B
+DECATUR,Oberlin Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",46,000200
+DECATUR,Olive Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",24,000210
+DECATUR,Pleasant Valley Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",18,000220
+DECATUR,Prairie Dog Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",21,000230
+DECATUR,Roosevelt Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",9,000240
+DECATUR,Sappa Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",20,000250
+DECATUR,Sherman Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",7,000260
+DECATUR,Summit Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",13,000270
+DECATUR,Allison Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000010
+DECATUR,Allison Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",8,000010
+DECATUR,Altory Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",3,000020
+DECATUR,Altory Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",8,000020
+DECATUR,Bassettville Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",1,000030
+DECATUR,Bassettville Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",12,000030
+DECATUR,Beaver Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",8,000040
+DECATUR,Beaver Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",20,000040
+DECATUR,Center Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000050
+DECATUR,Center Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",25,000050
+DECATUR,Cook Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,000060
+DECATUR,Cook Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",16,000060
+DECATUR,Custer Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000070
+DECATUR,Custer Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",16,000070
+DECATUR,Dresden Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",16,000080
+DECATUR,Dresden Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",44,000080
+DECATUR,Finley Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",3,000090
+DECATUR,Finley Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",14,000090
+DECATUR,Garfield Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",8,000100
+DECATUR,Garfield Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",16,000100
+DECATUR,Grant Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",1,000110
+DECATUR,Grant Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",2,000110
+DECATUR,Harlan Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000120
+DECATUR,Harlan Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",13,000120
+DECATUR,Jennings Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",19,000130
+DECATUR,Jennings Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",49,000130
+DECATUR,Liberty Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",2,000140
+DECATUR,Liberty Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",23,000140
+DECATUR,Lincoln Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",17,000150
+DECATUR,Lincoln Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",61,000150
+DECATUR,Logan Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000160
+DECATUR,Logan Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",14,000160
+DECATUR,Lyon Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000170
+DECATUR,Lyon Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",4,000170
+DECATUR,Oberlin City Precinct 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",93,000180
+DECATUR,Oberlin City Precinct 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",295,000180
+DECATUR,Oberlin City Precinct 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",108,00019A
+DECATUR,Oberlin City Precinct 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",371,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,00019B
+DECATUR,Oberlin Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",11,000200
+DECATUR,Oberlin Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",42,000200
+DECATUR,Olive Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000210
+DECATUR,Olive Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",22,000210
+DECATUR,Pleasant Valley Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",5,000220
+DECATUR,Pleasant Valley Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",13,000220
+DECATUR,Prairie Dog Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,000230
+DECATUR,Prairie Dog Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",22,000230
+DECATUR,Roosevelt Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",2,000240
+DECATUR,Roosevelt Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",7,000240
+DECATUR,Sappa Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,000250
+DECATUR,Sappa Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",20,000250
+DECATUR,Sherman Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",2,000260
+DECATUR,Sherman Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",5,000260
+DECATUR,Summit Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",1,000270
+DECATUR,Summit Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",12,000270
+DECATUR,Allison Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+DECATUR,Allison Township,President / Vice President,,Democratic,"Obama, Barack",2,000010
+DECATUR,Allison Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+DECATUR,Allison Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+DECATUR,Allison Township,President / Vice President,,Republican,"Romney, Mitt",11,000010
+DECATUR,Altory Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+DECATUR,Altory Township,President / Vice President,,Democratic,"Obama, Barack",1,000020
+DECATUR,Altory Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+DECATUR,Altory Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+DECATUR,Altory Township,President / Vice President,,Republican,"Romney, Mitt",10,000020
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+DECATUR,Bassettville Township,President / Vice President,,Democratic,"Obama, Barack",0,000030
+DECATUR,Bassettville Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+DECATUR,Bassettville Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+DECATUR,Bassettville Township,President / Vice President,,Republican,"Romney, Mitt",13,000030
+DECATUR,Beaver Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+DECATUR,Beaver Township,President / Vice President,,Democratic,"Obama, Barack",6,000040
+DECATUR,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+DECATUR,Beaver Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+DECATUR,Beaver Township,President / Vice President,,Republican,"Romney, Mitt",24,000040
+DECATUR,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+DECATUR,Center Township,President / Vice President,,Democratic,"Obama, Barack",5,000050
+DECATUR,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+DECATUR,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+DECATUR,Center Township,President / Vice President,,Republican,"Romney, Mitt",23,000050
+DECATUR,Cook Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+DECATUR,Cook Township,President / Vice President,,Democratic,"Obama, Barack",0,000060
+DECATUR,Cook Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+DECATUR,Cook Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+DECATUR,Cook Township,President / Vice President,,Republican,"Romney, Mitt",16,000060
+DECATUR,Custer Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+DECATUR,Custer Township,President / Vice President,,Democratic,"Obama, Barack",0,000070
+DECATUR,Custer Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+DECATUR,Custer Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+DECATUR,Custer Township,President / Vice President,,Republican,"Romney, Mitt",21,000070
+DECATUR,Dresden Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+DECATUR,Dresden Township,President / Vice President,,Democratic,"Obama, Barack",9,000080
+DECATUR,Dresden Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+DECATUR,Dresden Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+DECATUR,Dresden Township,President / Vice President,,Republican,"Romney, Mitt",50,000080
+DECATUR,Finley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+DECATUR,Finley Township,President / Vice President,,Democratic,"Obama, Barack",3,000090
+DECATUR,Finley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+DECATUR,Finley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+DECATUR,Finley Township,President / Vice President,,Republican,"Romney, Mitt",15,000090
+DECATUR,Garfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+DECATUR,Garfield Township,President / Vice President,,Democratic,"Obama, Barack",6,000100
+DECATUR,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+DECATUR,Garfield Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+DECATUR,Garfield Township,President / Vice President,,Republican,"Romney, Mitt",18,000100
+DECATUR,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+DECATUR,Grant Township,President / Vice President,,Democratic,"Obama, Barack",0,000110
+DECATUR,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+DECATUR,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+DECATUR,Grant Township,President / Vice President,,Republican,"Romney, Mitt",4,000110
+DECATUR,Harlan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+DECATUR,Harlan Township,President / Vice President,,Democratic,"Obama, Barack",0,000120
+DECATUR,Harlan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000120
+DECATUR,Harlan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+DECATUR,Harlan Township,President / Vice President,,Republican,"Romney, Mitt",16,000120
+DECATUR,Jennings Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+DECATUR,Jennings Township,President / Vice President,,Democratic,"Obama, Barack",26,000130
+DECATUR,Jennings Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+DECATUR,Jennings Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+DECATUR,Jennings Township,President / Vice President,,Republican,"Romney, Mitt",45,000130
+DECATUR,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+DECATUR,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",2,000140
+DECATUR,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+DECATUR,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+DECATUR,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",25,000140
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+DECATUR,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",13,000150
+DECATUR,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+DECATUR,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+DECATUR,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",68,000150
+DECATUR,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+DECATUR,Logan Township,President / Vice President,,Democratic,"Obama, Barack",0,000160
+DECATUR,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+DECATUR,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+DECATUR,Logan Township,President / Vice President,,Republican,"Romney, Mitt",18,000160
+DECATUR,Lyon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+DECATUR,Lyon Township,President / Vice President,,Democratic,"Obama, Barack",4,000170
+DECATUR,Lyon Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000170
+DECATUR,Lyon Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+DECATUR,Lyon Township,President / Vice President,,Republican,"Romney, Mitt",4,000170
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,Democratic,"Obama, Barack",81,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",17,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,Republican,"Romney, Mitt",305,000180
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,Democratic,"Obama, Barack",86,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",17,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,Republican,"Romney, Mitt",384,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00019B
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+DECATUR,Oberlin Township,President / Vice President,,Democratic,"Obama, Barack",6,000200
+DECATUR,Oberlin Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+DECATUR,Oberlin Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+DECATUR,Oberlin Township,President / Vice President,,Republican,"Romney, Mitt",49,000200
+DECATUR,Olive Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+DECATUR,Olive Township,President / Vice President,,Democratic,"Obama, Barack",2,000210
+DECATUR,Olive Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+DECATUR,Olive Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+DECATUR,Olive Township,President / Vice President,,Republican,"Romney, Mitt",24,000210
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,Democratic,"Obama, Barack",6,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,Republican,"Romney, Mitt",12,000220
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,Democratic,"Obama, Barack",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,Republican,"Romney, Mitt",22,000230
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,Democratic,"Obama, Barack",4,000240
+DECATUR,Roosevelt Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,Republican,"Romney, Mitt",5,000240
+DECATUR,Sappa Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+DECATUR,Sappa Township,President / Vice President,,Democratic,"Obama, Barack",0,000250
+DECATUR,Sappa Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+DECATUR,Sappa Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+DECATUR,Sappa Township,President / Vice President,,Republican,"Romney, Mitt",20,000250
+DECATUR,Sherman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Barnett, Andre",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Bush, Kent W",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Christensen, Will",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Goode, Virgil",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Stein, Jill E",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+DECATUR,Sherman Township,President / Vice President,,Democratic,"Obama, Barack",0,000260
+DECATUR,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+DECATUR,Sherman Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000260
+DECATUR,Sherman Township,President / Vice President,,Republican,"Romney, Mitt",7,000260
+DECATUR,Summit Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Barnett, Andre",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Bush, Kent W",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Christensen, Will",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Goode, Virgil",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Stein, Jill E",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+DECATUR,Summit Township,President / Vice President,,Democratic,"Obama, Barack",4,000270
+DECATUR,Summit Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000270
+DECATUR,Summit Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000270
+DECATUR,Summit Township,President / Vice President,,Republican,"Romney, Mitt",9,000270
+DECATUR,Allison Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,000010
+DECATUR,Altory Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000020
+DECATUR,Bassettville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000030
+DECATUR,Beaver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000040
+DECATUR,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000050
+DECATUR,Cook Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000060
+DECATUR,Custer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000070
+DECATUR,Dresden Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000080
+DECATUR,Finley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000090
+DECATUR,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000100
+DECATUR,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,000110
+DECATUR,Harlan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000120
+DECATUR,Jennings Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000130
+DECATUR,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000140
+DECATUR,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",71,000150
+DECATUR,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000160
+DECATUR,Lyon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,000170
+DECATUR,Oberlin City Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",335,000180
+DECATUR,Oberlin City Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",415,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00019B
+DECATUR,Oberlin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000200
+DECATUR,Olive Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000210
+DECATUR,Pleasant Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000220
+DECATUR,Prairie Dog Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000230
+DECATUR,Roosevelt Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,000240
+DECATUR,Sappa Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000250
+DECATUR,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,000260
+DECATUR,Summit Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000270

--- a/2012/20121106__ks__general__dickinson__precinct.csv
+++ b/2012/20121106__ks__general__dickinson__precinct.csv
@@ -1,0 +1,913 @@
+county,precinct,office,district,party,candidate,votes,vtd
+DICKINSON,Abilene Ward 1,Kansas House of Representatives,70,Republican,"Barker, John E",350,000010
+DICKINSON,Abilene Ward 2,Kansas House of Representatives,70,Republican,"Barker, John E",552,00002A
+DICKINSON,Abilene Ward 2 Exclave A,Kansas House of Representatives,70,Republican,"Barker, John E",0,00002B
+DICKINSON,Abilene Ward 3,Kansas House of Representatives,70,Republican,"Barker, John E",323,000030
+DICKINSON,Abilene Ward 4 Precinct 1,Kansas House of Representatives,70,Republican,"Barker, John E",444,000040
+DICKINSON,Abilene Ward 4 Precinct 2,Kansas House of Representatives,70,Republican,"Barker, John E",595,000050
+DICKINSON,Banner Township,Kansas House of Representatives,70,Republican,"Barker, John E",49,000060
+DICKINSON,Buckeye Township,Kansas House of Representatives,70,Republican,"Barker, John E",176,000070
+DICKINSON,Center Township,Kansas House of Representatives,70,Republican,"Barker, John E",391,000080
+DICKINSON,Cheever Township,Kansas House of Representatives,70,Republican,"Barker, John E",65,000090
+DICKINSON,Flora Township,Kansas House of Representatives,70,Republican,"Barker, John E",76,000100
+DICKINSON,Fragrant Hill Township,Kansas House of Representatives,70,Republican,"Barker, John E",127,000110
+DICKINSON,Garfield Township,Kansas House of Representatives,70,Republican,"Barker, John E",79,000120
+DICKINSON,Grant Township,Kansas House of Representatives,70,Republican,"Barker, John E",424,000130
+DICKINSON,Hayes Township,Kansas House of Representatives,70,Republican,"Barker, John E",107,000140
+DICKINSON,Herington Ward 1,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",278,000150
+DICKINSON,Herington Ward 2,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",268,000160
+DICKINSON,Herington Ward 4,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",154,000170
+DICKINSON,Holland Township,Kansas House of Representatives,70,Republican,"Barker, John E",51,000180
+DICKINSON,Hope Township,Kansas House of Representatives,70,Republican,"Barker, John E",154,000190
+DICKINSON,Jefferson Township,Kansas House of Representatives,70,Republican,"Barker, John E",105,000200
+DICKINSON,Liberty Township,Kansas House of Representatives,70,Republican,"Barker, John E",128,000210
+DICKINSON,Lincoln Township,Kansas House of Representatives,70,Republican,"Barker, John E",562,000220
+DICKINSON,Logan Township,Kansas House of Representatives,70,Republican,"Barker, John E",79,000230
+DICKINSON,Newbern Township,Kansas House of Representatives,70,Republican,"Barker, John E",176,000250
+DICKINSON,Noble Township,Kansas House of Representatives,70,Republican,"Barker, John E",640,000260
+DICKINSON,Ridge Township,Kansas House of Representatives,70,Republican,"Barker, John E",58,000270
+DICKINSON,Rinehart Township,Kansas House of Representatives,70,Republican,"Barker, John E",102,000280
+DICKINSON,Sherman Township,Kansas House of Representatives,70,Republican,"Barker, John E",70,000290
+DICKINSON,Union Township,Kansas House of Representatives,70,Republican,"Barker, John E",66,000300
+DICKINSON,Wheatland Township,Kansas House of Representatives,70,Republican,"Barker, John E",61,000310
+DICKINSON,Willowdale Township,Kansas House of Representatives,70,Republican,"Barker, John E",123,000320
+DICKINSON,Lyon Township H68 A,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,12002A
+DICKINSON,Lyon Township H68,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",30,120020
+DICKINSON,Lyon Township H70,Kansas House of Representatives,70,Republican,"Barker, John E",69,120030
+DICKINSON,Abilene Ward 1 Exclave A,Kansas House of Representatives,70,Republican,"Barker, John E",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,Kansas House of Representatives,70,Republican,"Barker, John E",0,900020
+DICKINSON,Grant Township Enclave,Kansas House of Representatives,70,Republican,"Barker, John E",0,900030
+DICKINSON,Abilene Ward 1,Kansas Senate,24,Democratic,"Norlin, Janice",190,000010
+DICKINSON,Abilene Ward 1,Kansas Senate,24,Republican,"Arpke, Tom",224,000010
+DICKINSON,Abilene Ward 2,Kansas Senate,24,Democratic,"Norlin, Janice",238,00002A
+DICKINSON,Abilene Ward 2,Kansas Senate,24,Republican,"Arpke, Tom",387,00002A
+DICKINSON,Abilene Ward 2 Exclave A,Kansas Senate,24,Democratic,"Norlin, Janice",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,Kansas Senate,24,Republican,"Arpke, Tom",0,00002B
+DICKINSON,Abilene Ward 3,Kansas Senate,24,Democratic,"Norlin, Janice",160,000030
+DICKINSON,Abilene Ward 3,Kansas Senate,24,Republican,"Arpke, Tom",217,000030
+DICKINSON,Abilene Ward 4 Precinct 1,Kansas Senate,24,Democratic,"Norlin, Janice",220,000040
+DICKINSON,Abilene Ward 4 Precinct 1,Kansas Senate,24,Republican,"Arpke, Tom",301,000040
+DICKINSON,Abilene Ward 4 Precinct 2,Kansas Senate,24,Democratic,"Norlin, Janice",243,000050
+DICKINSON,Abilene Ward 4 Precinct 2,Kansas Senate,24,Republican,"Arpke, Tom",429,000050
+DICKINSON,Banner Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",11,000060
+DICKINSON,Banner Township,Kansas Senate,35,Republican,"Emler, Jay Scott",43,000060
+DICKINSON,Buckeye Township,Kansas Senate,24,Democratic,"Norlin, Janice",47,000070
+DICKINSON,Buckeye Township,Kansas Senate,24,Republican,"Arpke, Tom",154,000070
+DICKINSON,Center Township,Kansas Senate,24,Democratic,"Norlin, Janice",124,000080
+DICKINSON,Center Township,Kansas Senate,24,Republican,"Arpke, Tom",311,000080
+DICKINSON,Cheever Township,Kansas Senate,24,Democratic,"Norlin, Janice",13,000090
+DICKINSON,Cheever Township,Kansas Senate,24,Republican,"Arpke, Tom",52,000090
+DICKINSON,Flora Township,Kansas Senate,24,Democratic,"Norlin, Janice",29,000100
+DICKINSON,Flora Township,Kansas Senate,24,Republican,"Arpke, Tom",59,000100
+DICKINSON,Fragrant Hill Township,Kansas Senate,24,Democratic,"Norlin, Janice",25,000110
+DICKINSON,Fragrant Hill Township,Kansas Senate,24,Republican,"Arpke, Tom",116,000110
+DICKINSON,Garfield Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",19,000120
+DICKINSON,Garfield Township,Kansas Senate,35,Republican,"Emler, Jay Scott",67,000120
+DICKINSON,Grant Township,Kansas Senate,24,Democratic,"Norlin, Janice",135,000130
+DICKINSON,Grant Township,Kansas Senate,24,Republican,"Arpke, Tom",334,000130
+DICKINSON,Hayes Township,Kansas Senate,24,Democratic,"Norlin, Janice",23,000140
+DICKINSON,Hayes Township,Kansas Senate,24,Republican,"Arpke, Tom",89,000140
+DICKINSON,Herington Ward 1,Kansas Senate,35,Libertarian,"Bryant, Jesse",77,000150
+DICKINSON,Herington Ward 1,Kansas Senate,35,Republican,"Emler, Jay Scott",221,000150
+DICKINSON,Herington Ward 2,Kansas Senate,35,Libertarian,"Bryant, Jesse",87,000160
+DICKINSON,Herington Ward 2,Kansas Senate,35,Republican,"Emler, Jay Scott",206,000160
+DICKINSON,Herington Ward 4,Kansas Senate,35,Libertarian,"Bryant, Jesse",47,000170
+DICKINSON,Herington Ward 4,Kansas Senate,35,Republican,"Emler, Jay Scott",125,000170
+DICKINSON,Holland Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",11,000180
+DICKINSON,Holland Township,Kansas Senate,35,Republican,"Emler, Jay Scott",41,000180
+DICKINSON,Hope Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",48,000190
+DICKINSON,Hope Township,Kansas Senate,35,Republican,"Emler, Jay Scott",133,000190
+DICKINSON,Jefferson Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",15,000200
+DICKINSON,Jefferson Township,Kansas Senate,35,Republican,"Emler, Jay Scott",97,000200
+DICKINSON,Liberty Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",35,000210
+DICKINSON,Liberty Township,Kansas Senate,35,Republican,"Emler, Jay Scott",109,000210
+DICKINSON,Lincoln Township,Kansas Senate,24,Democratic,"Norlin, Janice",205,000220
+DICKINSON,Lincoln Township,Kansas Senate,24,Republican,"Arpke, Tom",421,000220
+DICKINSON,Logan Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",16,000230
+DICKINSON,Logan Township,Kansas Senate,35,Republican,"Emler, Jay Scott",68,000230
+DICKINSON,Newbern Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",37,000250
+DICKINSON,Newbern Township,Kansas Senate,35,Republican,"Emler, Jay Scott",143,000250
+DICKINSON,Noble Township,Kansas Senate,24,Democratic,"Norlin, Janice",281,000260
+DICKINSON,Noble Township,Kansas Senate,24,Republican,"Arpke, Tom",449,000260
+DICKINSON,Ridge Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",14,000270
+DICKINSON,Ridge Township,Kansas Senate,35,Republican,"Emler, Jay Scott",52,000270
+DICKINSON,Rinehart Township,Kansas Senate,24,Democratic,"Norlin, Janice",28,000280
+DICKINSON,Rinehart Township,Kansas Senate,24,Republican,"Arpke, Tom",85,000280
+DICKINSON,Sherman Township,Kansas Senate,24,Democratic,"Norlin, Janice",17,000290
+DICKINSON,Sherman Township,Kansas Senate,24,Republican,"Arpke, Tom",67,000290
+DICKINSON,Union Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",19,000300
+DICKINSON,Union Township,Kansas Senate,35,Republican,"Emler, Jay Scott",49,000300
+DICKINSON,Wheatland Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",11,000310
+DICKINSON,Wheatland Township,Kansas Senate,35,Republican,"Emler, Jay Scott",51,000310
+DICKINSON,Willowdale Township,Kansas Senate,24,Democratic,"Norlin, Janice",34,000320
+DICKINSON,Willowdale Township,Kansas Senate,24,Republican,"Arpke, Tom",97,000320
+DICKINSON,Lyon Township H68 A,Kansas Senate,35,Libertarian,"Bryant, Jesse",0,12002A
+DICKINSON,Lyon Township H68 A,Kansas Senate,35,Republican,"Emler, Jay Scott",0,12002A
+DICKINSON,Lyon Township H68,Kansas Senate,35,Libertarian,"Bryant, Jesse",6,120020
+DICKINSON,Lyon Township H68,Kansas Senate,35,Republican,"Emler, Jay Scott",27,120020
+DICKINSON,Lyon Township H70,Kansas Senate,35,Libertarian,"Bryant, Jesse",10,120030
+DICKINSON,Lyon Township H70,Kansas Senate,35,Republican,"Emler, Jay Scott",62,120030
+DICKINSON,Abilene Ward 1 Exclave A,Kansas Senate,24,Democratic,"Norlin, Janice",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,Kansas Senate,24,Republican,"Arpke, Tom",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,Kansas Senate,24,Democratic,"Norlin, Janice",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,Kansas Senate,24,Republican,"Arpke, Tom",0,900020
+DICKINSON,Grant Township Enclave,Kansas Senate,24,Democratic,"Norlin, Janice",0,900030
+DICKINSON,Grant Township Enclave,Kansas Senate,24,Republican,"Arpke, Tom",0,900030
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,Democratic,"Obama, Barack",147,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",13,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",7,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,Republican,"Romney, Mitt",258,000010
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Stein, Jill E",1,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,Democratic,"Obama, Barack",161,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",16,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,Republican,"Romney, Mitt",459,00002A
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00002B
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,Democratic,"Obama, Barack",113,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",10,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,Republican,"Romney, Mitt",260,000030
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",167,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",16,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",348,000040
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",183,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",10,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",484,000050
+DICKINSON,Banner Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+DICKINSON,Banner Township,President / Vice President,,Democratic,"Obama, Barack",7,000060
+DICKINSON,Banner Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000060
+DICKINSON,Banner Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+DICKINSON,Banner Township,President / Vice President,,Republican,"Romney, Mitt",47,000060
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,Democratic,"Obama, Barack",27,000070
+DICKINSON,Buckeye Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000070
+DICKINSON,Buckeye Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+DICKINSON,Buckeye Township,President / Vice President,,Republican,"Romney, Mitt",169,000070
+DICKINSON,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+DICKINSON,Center Township,President / Vice President,,Democratic,"Obama, Barack",89,000080
+DICKINSON,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000080
+DICKINSON,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000080
+DICKINSON,Center Township,President / Vice President,,Republican,"Romney, Mitt",337,000080
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+DICKINSON,Cheever Township,President / Vice President,,Democratic,"Obama, Barack",5,000090
+DICKINSON,Cheever Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+DICKINSON,Cheever Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+DICKINSON,Cheever Township,President / Vice President,,Republican,"Romney, Mitt",62,000090
+DICKINSON,Flora Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+DICKINSON,Flora Township,President / Vice President,,Democratic,"Obama, Barack",24,000100
+DICKINSON,Flora Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+DICKINSON,Flora Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+DICKINSON,Flora Township,President / Vice President,,Republican,"Romney, Mitt",70,000100
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,Democratic,"Obama, Barack",15,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,Republican,"Romney, Mitt",120,000110
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+DICKINSON,Garfield Township,President / Vice President,,Democratic,"Obama, Barack",18,000120
+DICKINSON,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+DICKINSON,Garfield Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+DICKINSON,Garfield Township,President / Vice President,,Republican,"Romney, Mitt",76,000120
+DICKINSON,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Stein, Jill E",1,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+DICKINSON,Grant Township,President / Vice President,,Democratic,"Obama, Barack",100,000130
+DICKINSON,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000130
+DICKINSON,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000130
+DICKINSON,Grant Township,President / Vice President,,Republican,"Romney, Mitt",363,000130
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+DICKINSON,Hayes Township,President / Vice President,,Democratic,"Obama, Barack",11,000140
+DICKINSON,Hayes Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+DICKINSON,Hayes Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+DICKINSON,Hayes Township,President / Vice President,,Republican,"Romney, Mitt",104,000140
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,Democratic,"Obama, Barack",141,000150
+DICKINSON,Herington Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",7,000150
+DICKINSON,Herington Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+DICKINSON,Herington Ward 1,President / Vice President,,Republican,"Romney, Mitt",184,000150
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,Democratic,"Obama, Barack",122,000160
+DICKINSON,Herington Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000160
+DICKINSON,Herington Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000160
+DICKINSON,Herington Ward 2,President / Vice President,,Republican,"Romney, Mitt",195,000160
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,Democratic,"Obama, Barack",48,000170
+DICKINSON,Herington Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",6,000170
+DICKINSON,Herington Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",5,000170
+DICKINSON,Herington Ward 4,President / Vice President,,Republican,"Romney, Mitt",125,000170
+DICKINSON,Holland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+DICKINSON,Holland Township,President / Vice President,,Democratic,"Obama, Barack",6,000180
+DICKINSON,Holland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+DICKINSON,Holland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+DICKINSON,Holland Township,President / Vice President,,Republican,"Romney, Mitt",50,000180
+DICKINSON,Hope Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+DICKINSON,Hope Township,President / Vice President,,Democratic,"Obama, Barack",63,000190
+DICKINSON,Hope Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000190
+DICKINSON,Hope Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+DICKINSON,Hope Township,President / Vice President,,Republican,"Romney, Mitt",126,000190
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,Democratic,"Obama, Barack",16,000200
+DICKINSON,Jefferson Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000200
+DICKINSON,Jefferson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,Republican,"Romney, Mitt",97,000200
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+DICKINSON,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",44,000210
+DICKINSON,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000210
+DICKINSON,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000210
+DICKINSON,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",100,000210
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",150,000220
+DICKINSON,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000220
+DICKINSON,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000220
+DICKINSON,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",478,000220
+DICKINSON,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+DICKINSON,Logan Township,President / Vice President,,Democratic,"Obama, Barack",21,000230
+DICKINSON,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+DICKINSON,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+DICKINSON,Logan Township,President / Vice President,,Republican,"Romney, Mitt",73,000230
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+DICKINSON,Newbern Township,President / Vice President,,Democratic,"Obama, Barack",34,000250
+DICKINSON,Newbern Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000250
+DICKINSON,Newbern Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+DICKINSON,Newbern Township,President / Vice President,,Republican,"Romney, Mitt",153,000250
+DICKINSON,Noble Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Barnett, Andre",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Bush, Kent W",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Christensen, Will",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Goode, Virgil",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Stein, Jill E",1,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+DICKINSON,Noble Township,President / Vice President,,Democratic,"Obama, Barack",191,000260
+DICKINSON,Noble Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000260
+DICKINSON,Noble Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000260
+DICKINSON,Noble Township,President / Vice President,,Republican,"Romney, Mitt",552,000260
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Barnett, Andre",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Bush, Kent W",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Christensen, Will",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Goode, Virgil",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Stein, Jill E",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+DICKINSON,Ridge Township,President / Vice President,,Democratic,"Obama, Barack",5,000270
+DICKINSON,Ridge Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000270
+DICKINSON,Ridge Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000270
+DICKINSON,Ridge Township,President / Vice President,,Republican,"Romney, Mitt",60,000270
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Barnett, Andre",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Bush, Kent W",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Christensen, Will",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Goode, Virgil",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Stein, Jill E",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,Democratic,"Obama, Barack",21,000280
+DICKINSON,Rinehart Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,Republican,"Romney, Mitt",95,000280
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Barnett, Andre",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Bush, Kent W",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Christensen, Will",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Goode, Virgil",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Stein, Jill E",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+DICKINSON,Sherman Township,President / Vice President,,Democratic,"Obama, Barack",13,000290
+DICKINSON,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000290
+DICKINSON,Sherman Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000290
+DICKINSON,Sherman Township,President / Vice President,,Republican,"Romney, Mitt",72,000290
+DICKINSON,Union Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Barnett, Andre",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Bush, Kent W",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Christensen, Will",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Goode, Virgil",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Stein, Jill E",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+DICKINSON,Union Township,President / Vice President,,Democratic,"Obama, Barack",16,000300
+DICKINSON,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000300
+DICKINSON,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000300
+DICKINSON,Union Township,President / Vice President,,Republican,"Romney, Mitt",57,000300
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Barnett, Andre",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Bush, Kent W",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Christensen, Will",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Goode, Virgil",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Stein, Jill E",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,Democratic,"Obama, Barack",5,000310
+DICKINSON,Wheatland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000310
+DICKINSON,Wheatland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,Republican,"Romney, Mitt",63,000310
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Barnett, Andre",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Bush, Kent W",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Christensen, Will",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Goode, Virgil",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Stein, Jill E",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,Democratic,"Obama, Barack",28,000320
+DICKINSON,Willowdale Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,Republican,"Romney, Mitt",109,000320
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Ayers, Avery L",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Barnett, Andre",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Bush, Kent W",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Christensen, Will",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Duncan, Richard A",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Goode, Virgil",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Hoefling, Tom",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Knill, Dennis J",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Reed, Jill A.",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Rogers, Rick L",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Stein, Jill E",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,Democratic,"Obama, Barack",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,Republican,"Romney, Mitt",1,12002A
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Barnett, Andre",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Bush, Kent W",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Christensen, Will",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Goode, Virgil",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Stein, Jill E",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,Democratic,"Obama, Barack",12,120020
+DICKINSON,Lyon Township H68,President / Vice President,,Libertarian,"Johnson, Gary",2,120020
+DICKINSON,Lyon Township H68,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,Republican,"Romney, Mitt",22,120020
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Barnett, Andre",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Bush, Kent W",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Christensen, Will",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Goode, Virgil",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Stein, Jill E",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,Democratic,"Obama, Barack",17,120030
+DICKINSON,Lyon Township H70,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,Republican,"Romney, Mitt",63,120030
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Christensen, Will",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,900020
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Barnett, Andre",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Bush, Kent W",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Christensen, Will",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Goode, Virgil",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Stein, Jill E",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,Democratic,"Obama, Barack",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,Republican,"Romney, Mitt",0,900030
+DICKINSON,Abilene Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",322,000010
+DICKINSON,Abilene Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",522,00002A
+DICKINSON,Abilene Ward 2 Exclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00002B
+DICKINSON,Abilene Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",318,000030
+DICKINSON,Abilene Ward 4 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",409,000040
+DICKINSON,Abilene Ward 4 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",533,000050
+DICKINSON,Banner Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",50,000060
+DICKINSON,Buckeye Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",178,000070
+DICKINSON,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",375,000080
+DICKINSON,Cheever Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",60,000090
+DICKINSON,Flora Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",71,000100
+DICKINSON,Fragrant Hill Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",128,000110
+DICKINSON,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",77,000120
+DICKINSON,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",406,000130
+DICKINSON,Hayes Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",108,000140
+DICKINSON,Herington Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",258,000150
+DICKINSON,Herington Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",265,000160
+DICKINSON,Herington Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",157,000170
+DICKINSON,Holland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000180
+DICKINSON,Hope Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",159,000190
+DICKINSON,Jefferson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",99,000200
+DICKINSON,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",126,000210
+DICKINSON,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",545,000220
+DICKINSON,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",78,000230
+DICKINSON,Newbern Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",167,000250
+DICKINSON,Noble Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",608,000260
+DICKINSON,Ridge Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",60,000270
+DICKINSON,Rinehart Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",103,000280
+DICKINSON,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",70,000290
+DICKINSON,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",63,000300
+DICKINSON,Wheatland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",63,000310
+DICKINSON,Willowdale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",118,000320
+DICKINSON,Lyon Township H68 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,12002A
+DICKINSON,Lyon Township H68,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,120020
+DICKINSON,Lyon Township H70,United States House of Representatives,1,Republican,"Huelskamp, Tim",69,120030
+DICKINSON,Abilene Ward 1 Exclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+DICKINSON,Grant Township Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900030

--- a/2012/20121106__ks__general__doniphan__precinct.csv
+++ b/2012/20121106__ks__general__doniphan__precinct.csv
@@ -1,0 +1,352 @@
+county,precinct,office,district,party,candidate,votes,vtd
+DONIPHAN,Bendena Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",98,000010
+DONIPHAN,Bendena Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",57,000010
+DONIPHAN,Blair Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",42,000020
+DONIPHAN,Blair Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",57,000020
+DONIPHAN,Burr Oak Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",26,000030
+DONIPHAN,Burr Oak Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",47,000030
+DONIPHAN,Denton Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",103,000040
+DONIPHAN,Denton Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",61,000040
+DONIPHAN,Elwood Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",184,000050
+DONIPHAN,Elwood Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",160,000050
+DONIPHAN,Highland Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",218,000060
+DONIPHAN,Highland Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",244,000060
+DONIPHAN,Leona Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",19,000070
+DONIPHAN,Leona Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",22,000070
+DONIPHAN,Marion Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",55,000080
+DONIPHAN,Marion Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",73,000080
+DONIPHAN,Severance Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",76,000090
+DONIPHAN,Severance Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",48,000090
+DONIPHAN,Troy Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",335,000100
+DONIPHAN,Troy Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",432,000100
+DONIPHAN,Wathena Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",258,000110
+DONIPHAN,Wathena Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",390,000110
+DONIPHAN,Wayne Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",47,000120
+DONIPHAN,Wayne Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",40,000120
+DONIPHAN,White Cloud Township,Kansas House of Representatives,63,Democratic,"Henry, Jerry",41,000130
+DONIPHAN,White Cloud Township,Kansas House of Representatives,63,Republican,"Bodenhausen, Stephen",56,000130
+DONIPHAN,Bendena Township,Kansas Senate,1,Democratic,"Lukert, Steve",83,000010
+DONIPHAN,Bendena Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",77,000010
+DONIPHAN,Blair Township,Kansas Senate,1,Democratic,"Lukert, Steve",34,000020
+DONIPHAN,Blair Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",70,000020
+DONIPHAN,Burr Oak Township,Kansas Senate,1,Democratic,"Lukert, Steve",31,000030
+DONIPHAN,Burr Oak Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",45,000030
+DONIPHAN,Denton Township,Kansas Senate,1,Democratic,"Lukert, Steve",81,000040
+DONIPHAN,Denton Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",82,000040
+DONIPHAN,Elwood Township,Kansas Senate,1,Democratic,"Lukert, Steve",173,000050
+DONIPHAN,Elwood Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",189,000050
+DONIPHAN,Highland Township,Kansas Senate,1,Democratic,"Lukert, Steve",248,000060
+DONIPHAN,Highland Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",248,000060
+DONIPHAN,Leona Township,Kansas Senate,1,Democratic,"Lukert, Steve",11,000070
+DONIPHAN,Leona Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",31,000070
+DONIPHAN,Marion Township,Kansas Senate,1,Democratic,"Lukert, Steve",43,000080
+DONIPHAN,Marion Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",87,000080
+DONIPHAN,Severance Township,Kansas Senate,1,Democratic,"Lukert, Steve",51,000090
+DONIPHAN,Severance Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",81,000090
+DONIPHAN,Troy Township,Kansas Senate,1,Democratic,"Lukert, Steve",365,000100
+DONIPHAN,Troy Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",448,000100
+DONIPHAN,Wathena Township,Kansas Senate,1,Democratic,"Lukert, Steve",304,000110
+DONIPHAN,Wathena Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",366,000110
+DONIPHAN,Wayne Township,Kansas Senate,1,Democratic,"Lukert, Steve",36,000120
+DONIPHAN,Wayne Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",51,000120
+DONIPHAN,White Cloud Township,Kansas Senate,1,Democratic,"Lukert, Steve",39,000130
+DONIPHAN,White Cloud Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",65,000130
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,Democratic,"Obama, Barack",27,000010
+DONIPHAN,Bendena Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000010
+DONIPHAN,Bendena Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+DONIPHAN,Bendena Township,President / Vice President,,Republican,"Romney, Mitt",125,000010
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+DONIPHAN,Blair Township,President / Vice President,,Democratic,"Obama, Barack",24,000020
+DONIPHAN,Blair Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+DONIPHAN,Blair Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000020
+DONIPHAN,Blair Township,President / Vice President,,Republican,"Romney, Mitt",70,000020
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,Democratic,"Obama, Barack",13,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,Republican,"Romney, Mitt",62,000030
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+DONIPHAN,Denton Township,President / Vice President,,Democratic,"Obama, Barack",28,000040
+DONIPHAN,Denton Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000040
+DONIPHAN,Denton Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+DONIPHAN,Denton Township,President / Vice President,,Republican,"Romney, Mitt",134,000040
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,Democratic,"Obama, Barack",189,000050
+DONIPHAN,Elwood Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000050
+DONIPHAN,Elwood Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000050
+DONIPHAN,Elwood Township,President / Vice President,,Republican,"Romney, Mitt",183,000050
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+DONIPHAN,Highland Township,President / Vice President,,Democratic,"Obama, Barack",152,000060
+DONIPHAN,Highland Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000060
+DONIPHAN,Highland Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000060
+DONIPHAN,Highland Township,President / Vice President,,Republican,"Romney, Mitt",340,000060
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+DONIPHAN,Leona Township,President / Vice President,,Democratic,"Obama, Barack",9,000070
+DONIPHAN,Leona Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+DONIPHAN,Leona Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+DONIPHAN,Leona Township,President / Vice President,,Republican,"Romney, Mitt",33,000070
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+DONIPHAN,Marion Township,President / Vice President,,Democratic,"Obama, Barack",35,000080
+DONIPHAN,Marion Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000080
+DONIPHAN,Marion Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+DONIPHAN,Marion Township,President / Vice President,,Republican,"Romney, Mitt",100,000080
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+DONIPHAN,Severance Township,President / Vice President,,Democratic,"Obama, Barack",29,000090
+DONIPHAN,Severance Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000090
+DONIPHAN,Severance Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+DONIPHAN,Severance Township,President / Vice President,,Republican,"Romney, Mitt",97,000090
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+DONIPHAN,Troy Township,President / Vice President,,Democratic,"Obama, Barack",174,000100
+DONIPHAN,Troy Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000100
+DONIPHAN,Troy Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000100
+DONIPHAN,Troy Township,President / Vice President,,Republican,"Romney, Mitt",635,000100
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,Democratic,"Obama, Barack",173,000110
+DONIPHAN,Wathena Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000110
+DONIPHAN,Wathena Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000110
+DONIPHAN,Wathena Township,President / Vice President,,Republican,"Romney, Mitt",499,000110
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,Democratic,"Obama, Barack",18,000120
+DONIPHAN,Wayne Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+DONIPHAN,Wayne Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000120
+DONIPHAN,Wayne Township,President / Vice President,,Republican,"Romney, Mitt",69,000120
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,Democratic,"Obama, Barack",31,000130
+DONIPHAN,White Cloud Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000130
+DONIPHAN,White Cloud Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000130
+DONIPHAN,White Cloud Township,President / Vice President,,Republican,"Romney, Mitt",67,000130
+DONIPHAN,Bendena Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",18,000010
+DONIPHAN,Bendena Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000010
+DONIPHAN,Bendena Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",132,000010
+DONIPHAN,Blair Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",16,000020
+DONIPHAN,Blair Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000020
+DONIPHAN,Blair Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",84,000020
+DONIPHAN,Burr Oak Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",7,000030
+DONIPHAN,Burr Oak Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000030
+DONIPHAN,Burr Oak Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",64,000030
+DONIPHAN,Denton Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",25,000040
+DONIPHAN,Denton Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000040
+DONIPHAN,Denton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",135,000040
+DONIPHAN,Elwood Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",133,000050
+DONIPHAN,Elwood Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",21,000050
+DONIPHAN,Elwood Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",203,000050
+DONIPHAN,Highland Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",106,000060
+DONIPHAN,Highland Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",22,000060
+DONIPHAN,Highland Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",349,000060
+DONIPHAN,Leona Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",1,000070
+DONIPHAN,Leona Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000070
+DONIPHAN,Leona Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",40,000070
+DONIPHAN,Marion Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",28,000080
+DONIPHAN,Marion Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000080
+DONIPHAN,Marion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",100,000080
+DONIPHAN,Severance Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",11,000090
+DONIPHAN,Severance Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000090
+DONIPHAN,Severance Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",107,000090
+DONIPHAN,Troy Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",121,000100
+DONIPHAN,Troy Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",41,000100
+DONIPHAN,Troy Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",644,000100
+DONIPHAN,Wathena Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",113,000110
+DONIPHAN,Wathena Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",25,000110
+DONIPHAN,Wathena Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",524,000110
+DONIPHAN,Wayne Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",8,000120
+DONIPHAN,Wayne Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000120
+DONIPHAN,Wayne Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",72,000120
+DONIPHAN,White Cloud Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",17,000130
+DONIPHAN,White Cloud Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000130
+DONIPHAN,White Cloud Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",80,000130

--- a/2012/20121106__ks__general__douglas__precinct.csv
+++ b/2012/20121106__ks__general__douglas__precinct.csv
@@ -1,0 +1,3301 @@
+county,precinct,office,district,party,candidate,votes,vtd
+DOUGLAS,Big Springs Township,Kansas House of Representatives,45,Republican,"Sloan, Tom",173,000010
+DOUGLAS,Central Eudora,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",235,000020
+DOUGLAS,Central Eudora,Kansas House of Representatives,42,Republican,"O'Brien, Connie",437,000020
+DOUGLAS,Clinton Township,Kansas House of Representatives,45,Republican,"Sloan, Tom",300,000030
+DOUGLAS,Lawrence Precinct 01,Kansas House of Representatives,46,Democratic,"Davis, Paul",448,00007A
+DOUGLAS,Lawrence Precinct 02,Kansas House of Representatives,46,Democratic,"Davis, Paul",495,000080
+DOUGLAS,Lawrence Precinct 03,Kansas House of Representatives,46,Democratic,"Davis, Paul",478,000090
+DOUGLAS,Lawrence Precinct 04,Kansas House of Representatives,46,Democratic,"Davis, Paul",472,00010A
+DOUGLAS,Lawrence Precinct 05,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",491,000110
+DOUGLAS,Lawrence Precinct 05,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",203,000110
+DOUGLAS,Lawrence Precinct 06,Kansas House of Representatives,45,Republican,"Sloan, Tom",536,00012A
+DOUGLAS,Lawrence Precinct 07,Kansas House of Representatives,46,Democratic,"Davis, Paul",281,000130
+DOUGLAS,Lawrence Precinct 08,Kansas House of Representatives,46,Democratic,"Davis, Paul",395,000140
+DOUGLAS,Lawrence Precinct 09,Kansas House of Representatives,46,Democratic,"Davis, Paul",331,000150
+DOUGLAS,Lawrence Precinct 10,Kansas House of Representatives,46,Democratic,"Davis, Paul",312,000160
+DOUGLAS,Lawrence Precinct 11,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",412,000170
+DOUGLAS,Lawrence Precinct 11,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",107,000170
+DOUGLAS,Lawrence Precinct 12,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",662,000180
+DOUGLAS,Lawrence Precinct 12,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",187,000180
+DOUGLAS,Lawrence Precinct 13,Kansas House of Representatives,45,Republican,"Sloan, Tom",516,000190
+DOUGLAS,Lawrence Precinct 14,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",954,000200
+DOUGLAS,Lawrence Precinct 14,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",373,000200
+DOUGLAS,Lawrence Precinct 15,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",725,000210
+DOUGLAS,Lawrence Precinct 15,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",175,000210
+DOUGLAS,Lawrence Precinct 16,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",521,000220
+DOUGLAS,Lawrence Precinct 16,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",205,000220
+DOUGLAS,Lawrence Precinct 17,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",447,000230
+DOUGLAS,Lawrence Precinct 17,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",231,000230
+DOUGLAS,Lawrence Precinct 18,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",790,000240
+DOUGLAS,Lawrence Precinct 18,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",412,000240
+DOUGLAS,Lawrence Precinct 19,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",578,000250
+DOUGLAS,Lawrence Precinct 19,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",349,000250
+DOUGLAS,Lawrence Precinct 20,Kansas House of Representatives,45,Republican,"Sloan, Tom",868,000260
+DOUGLAS,Lawrence Precinct 21,Kansas House of Representatives,46,Democratic,"Davis, Paul",366,000270
+DOUGLAS,Lawrence Precinct 22,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",640,000280
+DOUGLAS,Lawrence Precinct 22,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",237,000280
+DOUGLAS,Lawrence Precinct 23,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",413,000290
+DOUGLAS,Lawrence Precinct 23,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",130,000290
+DOUGLAS,Lawrence Precinct 24,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",327,000300
+DOUGLAS,Lawrence Precinct 24,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",158,000300
+DOUGLAS,Lawrence Precinct 25,Kansas House of Representatives,46,Democratic,"Davis, Paul",396,000310
+DOUGLAS,Lawrence Precinct 26,Kansas House of Representatives,46,Democratic,"Davis, Paul",477,000320
+DOUGLAS,Lawrence Precinct 27,Kansas House of Representatives,10,Democratic,"Wilson, John",448,000330
+DOUGLAS,Lawrence Precinct 27,Kansas House of Representatives,10,Republican,"Anderson, Erica",109,000330
+DOUGLAS,Lawrence Precinct 28,Kansas House of Representatives,10,Democratic,"Wilson, John",304,000340
+DOUGLAS,Lawrence Precinct 28,Kansas House of Representatives,10,Republican,"Anderson, Erica",52,000340
+DOUGLAS,Lawrence Precinct 29,Kansas House of Representatives,10,Democratic,"Wilson, John",408,000350
+DOUGLAS,Lawrence Precinct 29,Kansas House of Representatives,10,Republican,"Anderson, Erica",108,000350
+DOUGLAS,Lawrence Precinct 31,Kansas House of Representatives,10,Democratic,"Wilson, John",554,000370
+DOUGLAS,Lawrence Precinct 31,Kansas House of Representatives,10,Republican,"Anderson, Erica",207,000370
+DOUGLAS,Lawrence Precinct 32,Kansas House of Representatives,10,Democratic,"Wilson, John",339,000380
+DOUGLAS,Lawrence Precinct 32,Kansas House of Representatives,10,Republican,"Anderson, Erica",126,000380
+DOUGLAS,Lawrence Precinct 33,Kansas House of Representatives,46,Democratic,"Davis, Paul",581,000400
+DOUGLAS,Lawrence Precinct 38,Kansas House of Representatives,10,Democratic,"Wilson, John",559,000450
+DOUGLAS,Lawrence Precinct 38,Kansas House of Representatives,10,Republican,"Anderson, Erica",248,000450
+DOUGLAS,Lawrence Precinct 39,Kansas House of Representatives,46,Democratic,"Davis, Paul",535,000460
+DOUGLAS,Lawrence Precinct 40,Kansas House of Representatives,46,Democratic,"Davis, Paul",529,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave B,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave C,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,Kansas House of Representatives,45,Republican,"Sloan, Tom",360,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,Kansas House of Representatives,45,Republican,"Sloan, Tom",347,00050C
+DOUGLAS,Lawrence Precinct 45,Kansas House of Representatives,45,Republican,"Sloan, Tom",1392,00052A
+DOUGLAS,Lawrence Precinct 49,Kansas House of Representatives,45,Republican,"Sloan, Tom",682,000560
+DOUGLAS,North Eudora Precinct 52,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",191,000600
+DOUGLAS,North Eudora Precinct 52,Kansas House of Representatives,42,Republican,"O'Brien, Connie",258,000600
+DOUGLAS,Northeast Baldwin Precinct 61,Kansas House of Representatives,10,Democratic,"Wilson, John",409,000620
+DOUGLAS,Northeast Baldwin Precinct 61,Kansas House of Representatives,10,Republican,"Anderson, Erica",532,000620
+DOUGLAS,Northwest Baldwin Precinct 60,Kansas House of Representatives,10,Democratic,"Wilson, John",324,000630
+DOUGLAS,Northwest Baldwin Precinct 60,Kansas House of Representatives,10,Republican,"Anderson, Erica",410,000630
+DOUGLAS,South Baldwin Precinct 62,Kansas House of Representatives,10,Democratic,"Wilson, John",366,000640
+DOUGLAS,South Baldwin Precinct 62,Kansas House of Representatives,10,Republican,"Anderson, Erica",572,000640
+DOUGLAS,Vinland Precinct 63,Kansas House of Representatives,10,Democratic,"Wilson, John",278,000660
+DOUGLAS,Vinland Precinct 63,Kansas House of Representatives,10,Republican,"Anderson, Erica",345,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Kansas House of Representatives,10,Republican,"Anderson, Erica",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Kansas House of Representatives,46,Democratic,"Davis, Paul",0,120030
+DOUGLAS,Grant Township S2 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",23,120040
+DOUGLAS,Grant Township S3 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",100,120050
+DOUGLAS,Grant Township S3 H46,Kansas House of Representatives,46,Democratic,"Davis, Paul",35,120060
+DOUGLAS,Kawaka Township S19,Kansas House of Representatives,45,Republican,"Sloan, Tom",671,120070
+DOUGLAS,Kawaka Township S2,Kansas House of Representatives,45,Republican,"Sloan, Tom",48,120080
+DOUGLAS,Lawrence Precinct 30 S2,Kansas House of Representatives,10,Democratic,"Wilson, John",127,120090
+DOUGLAS,Lawrence Precinct 30 S2,Kansas House of Representatives,10,Republican,"Anderson, Erica",41,120090
+DOUGLAS,Lawrence Precinct 30 S3,Kansas House of Representatives,10,Democratic,"Wilson, John",262,120100
+DOUGLAS,Lawrence Precinct 30 S3,Kansas House of Representatives,10,Republican,"Anderson, Erica",68,120100
+DOUGLAS,Lawrence Precinct 34 S2,Kansas House of Representatives,10,Democratic,"Wilson, John",337,120110
+DOUGLAS,Lawrence Precinct 34 S2,Kansas House of Representatives,10,Republican,"Anderson, Erica",74,120110
+DOUGLAS,Lawrence Precinct 34 S3,Kansas House of Representatives,10,Democratic,"Wilson, John",77,120120
+DOUGLAS,Lawrence Precinct 34 S3,Kansas House of Representatives,10,Republican,"Anderson, Erica",6,120120
+DOUGLAS,Lawrence Precinct 35 S2,Kansas House of Representatives,46,Democratic,"Davis, Paul",533,120130
+DOUGLAS,Lawrence Precinct 35 S3,Kansas House of Representatives,46,Democratic,"Davis, Paul",29,120140
+DOUGLAS,Lawrence Precinct 36 S2,Kansas House of Representatives,46,Democratic,"Davis, Paul",467,120150
+DOUGLAS,Lawrence Precinct 36 S3,Kansas House of Representatives,46,Democratic,"Davis, Paul",411,120160
+DOUGLAS,Lawrence Precinct 37 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",665,120170
+DOUGLAS,Lawrence Precinct 37 H10,Kansas House of Representatives,10,Republican,"Anderson, Erica",314,120170
+DOUGLAS,Lawrence Precinct 37 H46,Kansas House of Representatives,46,Democratic,"Davis, Paul",46,120180
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Kansas House of Representatives,10,Republican,"Anderson, Erica",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,Kansas House of Representatives,46,Democratic,"Davis, Paul",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,Kansas House of Representatives,46,Democratic,"Davis, Paul",0,120200
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,Kansas House of Representatives,46,Democratic,"Davis, Paul",9,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",1,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,Kansas House of Representatives,46,Democratic,"Davis, Paul",951,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",229,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Kansas House of Representatives,46,Democratic,"Davis, Paul",234,120260
+DOUGLAS,Lawrence Precinct 44 H44,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",80,120270
+DOUGLAS,Lawrence Precinct 44 H44,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",42,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",376,120280
+DOUGLAS,Lawrence Precinct 46 S19,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,Kansas House of Representatives,45,Republican,"Sloan, Tom",940,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,Kansas House of Representatives,45,Republican,"Sloan, Tom",105,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,Kansas House of Representatives,45,Republican,"Sloan, Tom",401,120320
+DOUGLAS,Marion Township Precinct 59 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",211,120330
+DOUGLAS,Marion Township Precinct 59 H54,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",114,120340
+DOUGLAS,Marion Township Precinct 59 H54,Kansas House of Representatives,54,Republican,"Corbet, Ken",89,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",155,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,Kansas House of Representatives,46,Democratic,"Davis, Paul",1,120360
+DOUGLAS,South Eudora Precinct 53 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",174,120370
+DOUGLAS,South Eudora Precinct 53 H10,Kansas House of Representatives,10,Republican,"Anderson, Erica",299,120370
+DOUGLAS,South Eudora Precinct 53 H42,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",159,120380
+DOUGLAS,South Eudora Precinct 53 H42,Kansas House of Representatives,42,Republican,"O'Brien, Connie",346,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",140,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Kansas House of Representatives,10,Republican,"Anderson, Erica",135,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",138,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",95,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Kansas House of Representatives,10,Republican,"Anderson, Erica",111,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,120420
+DOUGLAS,Willow Springs Township S19 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",222,120430
+DOUGLAS,Willow Springs Township S19 H54,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",124,120440
+DOUGLAS,Willow Springs Township S19 H54,Kansas House of Representatives,54,Republican,"Corbet, Ken",197,120440
+DOUGLAS,Willow Springs Township S3 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",71,120450
+DOUGLAS,Willow Springs Township S3 H54,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",43,120460
+DOUGLAS,Willow Springs Township S3 H54,Kansas House of Representatives,54,Republican,"Corbet, Ken",32,120460
+DOUGLAS,East Wakarusa H10 Precinct 65,Kansas House of Representatives,10,Democratic,"Wilson, John",181,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,Kansas House of Representatives,10,Republican,"Anderson, Erica",178,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,400010
+DOUGLAS,Lawrence Precinct 47,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",267,400030
+DOUGLAS,Lawrence Precinct 47,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",156,400030
+DOUGLAS,Lawrence Precinct 48,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",658,400040
+DOUGLAS,Lawrence Precinct 48,Kansas House of Representatives,44,Republican,"Bengtson, Patrick",280,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,Kansas House of Representatives,42,Republican,"O'Brien, Connie",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",364,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,Kansas House of Representatives,42,Republican,"O'Brien, Connie",639,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,Kansas House of Representatives,42,Republican,"O'Brien, Connie",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,400110
+DOUGLAS,Lawrence Precinct 68,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900010
+DOUGLAS,Lawrence Precinct 69,Kansas House of Representatives,10,Democratic,"Wilson, John",0,900020
+DOUGLAS,Lawrence Precinct 69,Kansas House of Representatives,10,Republican,"Anderson, Erica",0,900020
+DOUGLAS,Lawrence Precinct 70,Kansas House of Representatives,45,Republican,"Sloan, Tom",11,900040
+DOUGLAS,Lawrence Precinct 71,Kansas House of Representatives,45,Republican,"Sloan, Tom",599,900050
+DOUGLAS,Lawrence Precinct 72,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900060
+DOUGLAS,Lawrence Precinct 73,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900070
+DOUGLAS,Lawrence Precinct 74,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Kansas House of Representatives,10,Democratic,"Wilson, John",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Kansas House of Representatives,10,Republican,"Anderson, Erica",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Kansas House of Representatives,10,Democratic,"Wilson, John",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Kansas House of Representatives,10,Republican,"Anderson, Erica",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Kansas House of Representatives,46,Democratic,"Davis, Paul",32,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Kansas House of Representatives,46,Democratic,"Davis, Paul",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Kansas House of Representatives,46,Democratic,"Davis, Paul",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,Kansas House of Representatives,46,Democratic,"Davis, Paul",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,Kansas House of Representatives,10,Democratic,"Wilson, John",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,Kansas House of Representatives,10,Republican,"Anderson, Erica",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900170
+DOUGLAS,Big Springs Township,Kansas Senate,19,Democratic,"Hensley, Anthony",105,000010
+DOUGLAS,Big Springs Township,Kansas Senate,19,Republican,"Moore, Casey W.",104,000010
+DOUGLAS,Central Eudora,Kansas Senate,3,Democratic,"Holland, Tom",313,000020
+DOUGLAS,Central Eudora,Kansas Senate,3,Republican,"Brown, Anthony R.",381,000020
+DOUGLAS,Clinton Township,Kansas Senate,19,Democratic,"Hensley, Anthony",165,000030
+DOUGLAS,Clinton Township,Kansas Senate,19,Republican,"Moore, Casey W.",204,000030
+DOUGLAS,Lawrence Precinct 01,Kansas Senate,2,Democratic,"Francisco, Marci",415,00007A
+DOUGLAS,Lawrence Precinct 01,Kansas Senate,2,Republican,"Ellis, Ronald B.",77,00007A
+DOUGLAS,Lawrence Precinct 02,Kansas Senate,2,Democratic,"Francisco, Marci",495,000080
+DOUGLAS,Lawrence Precinct 02,Kansas Senate,2,Republican,"Ellis, Ronald B.",61,000080
+DOUGLAS,Lawrence Precinct 03,Kansas Senate,2,Democratic,"Francisco, Marci",480,000090
+DOUGLAS,Lawrence Precinct 03,Kansas Senate,2,Republican,"Ellis, Ronald B.",65,000090
+DOUGLAS,Lawrence Precinct 04,Kansas Senate,2,Democratic,"Francisco, Marci",452,00010A
+DOUGLAS,Lawrence Precinct 04,Kansas Senate,2,Republican,"Ellis, Ronald B.",98,00010A
+DOUGLAS,Lawrence Precinct 05,Kansas Senate,2,Democratic,"Francisco, Marci",474,000110
+DOUGLAS,Lawrence Precinct 05,Kansas Senate,2,Republican,"Ellis, Ronald B.",219,000110
+DOUGLAS,Lawrence Precinct 06,Kansas Senate,2,Democratic,"Francisco, Marci",482,00012A
+DOUGLAS,Lawrence Precinct 06,Kansas Senate,2,Republican,"Ellis, Ronald B.",212,00012A
+DOUGLAS,Lawrence Precinct 07,Kansas Senate,2,Democratic,"Francisco, Marci",258,000130
+DOUGLAS,Lawrence Precinct 07,Kansas Senate,2,Republican,"Ellis, Ronald B.",50,000130
+DOUGLAS,Lawrence Precinct 08,Kansas Senate,2,Democratic,"Francisco, Marci",361,000140
+DOUGLAS,Lawrence Precinct 08,Kansas Senate,2,Republican,"Ellis, Ronald B.",63,000140
+DOUGLAS,Lawrence Precinct 09,Kansas Senate,2,Democratic,"Francisco, Marci",296,000150
+DOUGLAS,Lawrence Precinct 09,Kansas Senate,2,Republican,"Ellis, Ronald B.",84,000150
+DOUGLAS,Lawrence Precinct 10,Kansas Senate,2,Democratic,"Francisco, Marci",275,000160
+DOUGLAS,Lawrence Precinct 10,Kansas Senate,2,Republican,"Ellis, Ronald B.",87,000160
+DOUGLAS,Lawrence Precinct 11,Kansas Senate,2,Democratic,"Francisco, Marci",417,000170
+DOUGLAS,Lawrence Precinct 11,Kansas Senate,2,Republican,"Ellis, Ronald B.",107,000170
+DOUGLAS,Lawrence Precinct 12,Kansas Senate,2,Democratic,"Francisco, Marci",668,000180
+DOUGLAS,Lawrence Precinct 12,Kansas Senate,2,Republican,"Ellis, Ronald B.",191,000180
+DOUGLAS,Lawrence Precinct 13,Kansas Senate,2,Democratic,"Francisco, Marci",538,000190
+DOUGLAS,Lawrence Precinct 13,Kansas Senate,2,Republican,"Ellis, Ronald B.",192,000190
+DOUGLAS,Lawrence Precinct 14,Kansas Senate,3,Democratic,"Holland, Tom",942,000200
+DOUGLAS,Lawrence Precinct 14,Kansas Senate,3,Republican,"Brown, Anthony R.",396,000200
+DOUGLAS,Lawrence Precinct 15,Kansas Senate,2,Democratic,"Francisco, Marci",747,000210
+DOUGLAS,Lawrence Precinct 15,Kansas Senate,2,Republican,"Ellis, Ronald B.",178,000210
+DOUGLAS,Lawrence Precinct 16,Kansas Senate,2,Democratic,"Francisco, Marci",513,000220
+DOUGLAS,Lawrence Precinct 16,Kansas Senate,2,Republican,"Ellis, Ronald B.",215,000220
+DOUGLAS,Lawrence Precinct 17,Kansas Senate,3,Democratic,"Holland, Tom",451,000230
+DOUGLAS,Lawrence Precinct 17,Kansas Senate,3,Republican,"Brown, Anthony R.",233,000230
+DOUGLAS,Lawrence Precinct 18,Kansas Senate,2,Democratic,"Francisco, Marci",797,000240
+DOUGLAS,Lawrence Precinct 18,Kansas Senate,2,Republican,"Ellis, Ronald B.",417,000240
+DOUGLAS,Lawrence Precinct 19,Kansas Senate,2,Democratic,"Francisco, Marci",550,000250
+DOUGLAS,Lawrence Precinct 19,Kansas Senate,2,Republican,"Ellis, Ronald B.",379,000250
+DOUGLAS,Lawrence Precinct 20,Kansas Senate,2,Democratic,"Francisco, Marci",821,000260
+DOUGLAS,Lawrence Precinct 20,Kansas Senate,2,Republican,"Ellis, Ronald B.",336,000260
+DOUGLAS,Lawrence Precinct 21,Kansas Senate,2,Democratic,"Francisco, Marci",324,000270
+DOUGLAS,Lawrence Precinct 21,Kansas Senate,2,Republican,"Ellis, Ronald B.",99,000270
+DOUGLAS,Lawrence Precinct 22,Kansas Senate,3,Democratic,"Holland, Tom",641,000280
+DOUGLAS,Lawrence Precinct 22,Kansas Senate,3,Republican,"Brown, Anthony R.",251,000280
+DOUGLAS,Lawrence Precinct 23,Kansas Senate,2,Democratic,"Francisco, Marci",415,000290
+DOUGLAS,Lawrence Precinct 23,Kansas Senate,2,Republican,"Ellis, Ronald B.",132,000290
+DOUGLAS,Lawrence Precinct 24,Kansas Senate,2,Democratic,"Francisco, Marci",312,000300
+DOUGLAS,Lawrence Precinct 24,Kansas Senate,2,Republican,"Ellis, Ronald B.",170,000300
+DOUGLAS,Lawrence Precinct 25,Kansas Senate,2,Democratic,"Francisco, Marci",354,000310
+DOUGLAS,Lawrence Precinct 25,Kansas Senate,2,Republican,"Ellis, Ronald B.",95,000310
+DOUGLAS,Lawrence Precinct 26,Kansas Senate,2,Democratic,"Francisco, Marci",460,000320
+DOUGLAS,Lawrence Precinct 26,Kansas Senate,2,Republican,"Ellis, Ronald B.",77,000320
+DOUGLAS,Lawrence Precinct 27,Kansas Senate,2,Democratic,"Francisco, Marci",464,000330
+DOUGLAS,Lawrence Precinct 27,Kansas Senate,2,Republican,"Ellis, Ronald B.",105,000330
+DOUGLAS,Lawrence Precinct 28,Kansas Senate,2,Democratic,"Francisco, Marci",312,000340
+DOUGLAS,Lawrence Precinct 28,Kansas Senate,2,Republican,"Ellis, Ronald B.",51,000340
+DOUGLAS,Lawrence Precinct 29,Kansas Senate,3,Democratic,"Holland, Tom",423,000350
+DOUGLAS,Lawrence Precinct 29,Kansas Senate,3,Republican,"Brown, Anthony R.",109,000350
+DOUGLAS,Lawrence Precinct 31,Kansas Senate,3,Democratic,"Holland, Tom",593,000370
+DOUGLAS,Lawrence Precinct 31,Kansas Senate,3,Republican,"Brown, Anthony R.",184,000370
+DOUGLAS,Lawrence Precinct 32,Kansas Senate,3,Democratic,"Holland, Tom",348,000380
+DOUGLAS,Lawrence Precinct 32,Kansas Senate,3,Republican,"Brown, Anthony R.",119,000380
+DOUGLAS,Lawrence Precinct 33,Kansas Senate,2,Democratic,"Francisco, Marci",566,000400
+DOUGLAS,Lawrence Precinct 33,Kansas Senate,2,Republican,"Ellis, Ronald B.",83,000400
+DOUGLAS,Lawrence Precinct 38,Kansas Senate,3,Democratic,"Holland, Tom",557,000450
+DOUGLAS,Lawrence Precinct 38,Kansas Senate,3,Republican,"Brown, Anthony R.",270,000450
+DOUGLAS,Lawrence Precinct 39,Kansas Senate,2,Democratic,"Francisco, Marci",545,000460
+DOUGLAS,Lawrence Precinct 39,Kansas Senate,2,Republican,"Ellis, Ronald B.",26,000460
+DOUGLAS,Lawrence Precinct 40,Kansas Senate,2,Democratic,"Francisco, Marci",524,000470
+DOUGLAS,Lawrence Precinct 40,Kansas Senate,2,Republican,"Ellis, Ronald B.",30,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,Kansas Senate,3,Democratic,"Holland, Tom",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,Kansas Senate,3,Republican,"Brown, Anthony R.",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave B,Kansas Senate,3,Democratic,"Holland, Tom",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,Kansas Senate,3,Republican,"Brown, Anthony R.",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave C,Kansas Senate,3,Democratic,"Holland, Tom",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,Kansas Senate,3,Republican,"Brown, Anthony R.",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,Kansas Senate,2,Democratic,"Francisco, Marci",317,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,Kansas Senate,2,Republican,"Ellis, Ronald B.",148,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,Kansas Senate,2,Democratic,"Francisco, Marci",298,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,Kansas Senate,2,Republican,"Ellis, Ronald B.",156,00050C
+DOUGLAS,Lawrence Precinct 45,Kansas Senate,2,Democratic,"Francisco, Marci",1047,00052A
+DOUGLAS,Lawrence Precinct 45,Kansas Senate,2,Republican,"Ellis, Ronald B.",698,00052A
+DOUGLAS,Lawrence Precinct 49,Kansas Senate,2,Democratic,"Francisco, Marci",498,000560
+DOUGLAS,Lawrence Precinct 49,Kansas Senate,2,Republican,"Ellis, Ronald B.",341,000560
+DOUGLAS,North Eudora Precinct 52,Kansas Senate,3,Democratic,"Holland, Tom",232,000600
+DOUGLAS,North Eudora Precinct 52,Kansas Senate,3,Republican,"Brown, Anthony R.",230,000600
+DOUGLAS,Northeast Baldwin Precinct 61,Kansas Senate,3,Democratic,"Holland, Tom",557,000620
+DOUGLAS,Northeast Baldwin Precinct 61,Kansas Senate,3,Republican,"Brown, Anthony R.",407,000620
+DOUGLAS,Northwest Baldwin Precinct 60,Kansas Senate,3,Democratic,"Holland, Tom",454,000630
+DOUGLAS,Northwest Baldwin Precinct 60,Kansas Senate,3,Republican,"Brown, Anthony R.",299,000630
+DOUGLAS,South Baldwin Precinct 62,Kansas Senate,3,Democratic,"Holland, Tom",509,000640
+DOUGLAS,South Baldwin Precinct 62,Kansas Senate,3,Republican,"Brown, Anthony R.",449,000640
+DOUGLAS,Vinland Precinct 63,Kansas Senate,3,Democratic,"Holland, Tom",344,000660
+DOUGLAS,Vinland Precinct 63,Kansas Senate,3,Republican,"Brown, Anthony R.",291,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Kansas Senate,3,Democratic,"Holland, Tom",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Kansas Senate,3,Republican,"Brown, Anthony R.",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Kansas Senate,3,Democratic,"Holland, Tom",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Kansas Senate,3,Republican,"Brown, Anthony R.",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Kansas Senate,3,Democratic,"Holland, Tom",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Kansas Senate,3,Republican,"Brown, Anthony R.",0,120030
+DOUGLAS,Grant Township S2 H45,Kansas Senate,2,Democratic,"Francisco, Marci",24,120040
+DOUGLAS,Grant Township S2 H45,Kansas Senate,2,Republican,"Ellis, Ronald B.",8,120040
+DOUGLAS,Grant Township S3 H45,Kansas Senate,3,Democratic,"Holland, Tom",77,120050
+DOUGLAS,Grant Township S3 H45,Kansas Senate,3,Republican,"Brown, Anthony R.",55,120050
+DOUGLAS,Grant Township S3 H46,Kansas Senate,3,Democratic,"Holland, Tom",31,120060
+DOUGLAS,Grant Township S3 H46,Kansas Senate,3,Republican,"Brown, Anthony R.",10,120060
+DOUGLAS,Kawaka Township S19,Kansas Senate,19,Democratic,"Hensley, Anthony",408,120070
+DOUGLAS,Kawaka Township S19,Kansas Senate,19,Republican,"Moore, Casey W.",380,120070
+DOUGLAS,Kawaka Township S2,Kansas Senate,2,Democratic,"Francisco, Marci",38,120080
+DOUGLAS,Kawaka Township S2,Kansas Senate,2,Republican,"Ellis, Ronald B.",17,120080
+DOUGLAS,Lawrence Precinct 30 S2,Kansas Senate,2,Democratic,"Francisco, Marci",130,120090
+DOUGLAS,Lawrence Precinct 30 S2,Kansas Senate,2,Republican,"Ellis, Ronald B.",44,120090
+DOUGLAS,Lawrence Precinct 30 S3,Kansas Senate,3,Democratic,"Holland, Tom",262,120100
+DOUGLAS,Lawrence Precinct 30 S3,Kansas Senate,3,Republican,"Brown, Anthony R.",74,120100
+DOUGLAS,Lawrence Precinct 34 S2,Kansas Senate,2,Democratic,"Francisco, Marci",348,120110
+DOUGLAS,Lawrence Precinct 34 S2,Kansas Senate,2,Republican,"Ellis, Ronald B.",74,120110
+DOUGLAS,Lawrence Precinct 34 S3,Kansas Senate,3,Democratic,"Holland, Tom",76,120120
+DOUGLAS,Lawrence Precinct 34 S3,Kansas Senate,3,Republican,"Brown, Anthony R.",7,120120
+DOUGLAS,Lawrence Precinct 35 S2,Kansas Senate,2,Democratic,"Francisco, Marci",492,120130
+DOUGLAS,Lawrence Precinct 35 S2,Kansas Senate,2,Republican,"Ellis, Ronald B.",108,120130
+DOUGLAS,Lawrence Precinct 35 S3,Kansas Senate,3,Democratic,"Holland, Tom",33,120140
+DOUGLAS,Lawrence Precinct 35 S3,Kansas Senate,3,Republican,"Brown, Anthony R.",6,120140
+DOUGLAS,Lawrence Precinct 36 S2,Kansas Senate,2,Democratic,"Francisco, Marci",402,120150
+DOUGLAS,Lawrence Precinct 36 S2,Kansas Senate,2,Republican,"Ellis, Ronald B.",128,120150
+DOUGLAS,Lawrence Precinct 36 S3,Kansas Senate,3,Democratic,"Holland, Tom",353,120160
+DOUGLAS,Lawrence Precinct 36 S3,Kansas Senate,3,Republican,"Brown, Anthony R.",124,120160
+DOUGLAS,Lawrence Precinct 37 H10,Kansas Senate,3,Democratic,"Holland, Tom",703,120170
+DOUGLAS,Lawrence Precinct 37 H10,Kansas Senate,3,Republican,"Brown, Anthony R.",299,120170
+DOUGLAS,Lawrence Precinct 37 H46,Kansas Senate,3,Democratic,"Holland, Tom",37,120180
+DOUGLAS,Lawrence Precinct 37 H46,Kansas Senate,3,Republican,"Brown, Anthony R.",15,120180
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Kansas Senate,3,Democratic,"Holland, Tom",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Kansas Senate,3,Republican,"Brown, Anthony R.",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,Kansas Senate,3,Democratic,"Holland, Tom",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,Kansas Senate,3,Republican,"Brown, Anthony R.",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,Kansas Senate,3,Democratic,"Holland, Tom",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,Kansas Senate,3,Republican,"Brown, Anthony R.",0,120200
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Kansas Senate,2,Democratic,"Francisco, Marci",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Kansas Senate,2,Republican,"Ellis, Ronald B.",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,Kansas Senate,2,Democratic,"Francisco, Marci",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,Kansas Senate,2,Republican,"Ellis, Ronald B.",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,Kansas Senate,2,Democratic,"Francisco, Marci",10,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,Kansas Senate,2,Republican,"Ellis, Ronald B.",2,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,Kansas Senate,3,Democratic,"Holland, Tom",1,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,Kansas Senate,3,Republican,"Brown, Anthony R.",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,Kansas Senate,3,Democratic,"Holland, Tom",838,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,Kansas Senate,3,Republican,"Brown, Anthony R.",230,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Kansas Senate,2,Democratic,"Francisco, Marci",213,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Kansas Senate,2,Republican,"Ellis, Ronald B.",90,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Kansas Senate,2,Democratic,"Francisco, Marci",220,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Kansas Senate,2,Republican,"Ellis, Ronald B.",50,120260
+DOUGLAS,Lawrence Precinct 44 H44,Kansas Senate,2,Democratic,"Francisco, Marci",80,120270
+DOUGLAS,Lawrence Precinct 44 H44,Kansas Senate,2,Republican,"Ellis, Ronald B.",42,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,Kansas Senate,2,Democratic,"Francisco, Marci",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,Kansas Senate,2,Republican,"Ellis, Ronald B.",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,Kansas Senate,2,Democratic,"Francisco, Marci",312,120280
+DOUGLAS,Lawrence Precinct 44 H45,Kansas Senate,2,Republican,"Ellis, Ronald B.",164,120280
+DOUGLAS,Lawrence Precinct 46 S19,Kansas Senate,19,Democratic,"Hensley, Anthony",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,Kansas Senate,19,Republican,"Moore, Casey W.",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,Kansas Senate,3,Democratic,"Holland, Tom",895,120300
+DOUGLAS,Lawrence Precinct 46 S3,Kansas Senate,3,Republican,"Brown, Anthony R.",392,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,Kansas Senate,19,Democratic,"Hensley, Anthony",60,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,Kansas Senate,19,Republican,"Moore, Casey W.",70,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,Kansas Senate,2,Democratic,"Francisco, Marci",265,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,Kansas Senate,2,Republican,"Ellis, Ronald B.",228,120320
+DOUGLAS,Marion Township Precinct 59 H45,Kansas Senate,19,Democratic,"Hensley, Anthony",135,120330
+DOUGLAS,Marion Township Precinct 59 H45,Kansas Senate,19,Republican,"Moore, Casey W.",123,120330
+DOUGLAS,Marion Township Precinct 59 H54,Kansas Senate,19,Democratic,"Hensley, Anthony",95,120340
+DOUGLAS,Marion Township Precinct 59 H54,Kansas Senate,19,Republican,"Moore, Casey W.",109,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,Kansas Senate,2,Democratic,"Francisco, Marci",153,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,Kansas Senate,2,Republican,"Ellis, Ronald B.",60,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,Kansas Senate,2,Democratic,"Francisco, Marci",1,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,Kansas Senate,2,Republican,"Ellis, Ronald B.",0,120360
+DOUGLAS,South Eudora Precinct 53 H10,Kansas Senate,3,Democratic,"Holland, Tom",200,120370
+DOUGLAS,South Eudora Precinct 53 H10,Kansas Senate,3,Republican,"Brown, Anthony R.",292,120370
+DOUGLAS,South Eudora Precinct 53 H42,Kansas Senate,3,Democratic,"Holland, Tom",206,120380
+DOUGLAS,South Eudora Precinct 53 H42,Kansas Senate,3,Republican,"Brown, Anthony R.",317,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Kansas Senate,19,Democratic,"Hensley, Anthony",137,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Kansas Senate,19,Republican,"Moore, Casey W.",142,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas Senate,3,Democratic,"Holland, Tom",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas Senate,3,Republican,"Brown, Anthony R.",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas Senate,19,Democratic,"Hensley, Anthony",74,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas Senate,19,Republican,"Moore, Casey W.",86,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Kansas Senate,3,Democratic,"Holland, Tom",100,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Kansas Senate,3,Republican,"Brown, Anthony R.",111,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Kansas Senate,3,Democratic,"Holland, Tom",2,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Kansas Senate,3,Republican,"Brown, Anthony R.",0,120420
+DOUGLAS,Willow Springs Township S19 H45,Kansas Senate,19,Democratic,"Hensley, Anthony",153,120430
+DOUGLAS,Willow Springs Township S19 H45,Kansas Senate,19,Republican,"Moore, Casey W.",123,120430
+DOUGLAS,Willow Springs Township S19 H54,Kansas Senate,19,Democratic,"Hensley, Anthony",113,120440
+DOUGLAS,Willow Springs Township S19 H54,Kansas Senate,19,Republican,"Moore, Casey W.",206,120440
+DOUGLAS,Willow Springs Township S3 H45,Kansas Senate,3,Democratic,"Holland, Tom",51,120450
+DOUGLAS,Willow Springs Township S3 H45,Kansas Senate,3,Republican,"Brown, Anthony R.",43,120450
+DOUGLAS,Willow Springs Township S3 H54,Kansas Senate,3,Democratic,"Holland, Tom",49,120460
+DOUGLAS,Willow Springs Township S3 H54,Kansas Senate,3,Republican,"Brown, Anthony R.",25,120460
+DOUGLAS,East Wakarusa H10 Precinct 65,Kansas Senate,3,Democratic,"Holland, Tom",203,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,Kansas Senate,3,Republican,"Brown, Anthony R.",163,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,Kansas Senate,2,Democratic,"Francisco, Marci",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,Kansas Senate,2,Republican,"Ellis, Ronald B.",0,400010
+DOUGLAS,Lawrence Precinct 47,Kansas Senate,2,Democratic,"Francisco, Marci",263,400030
+DOUGLAS,Lawrence Precinct 47,Kansas Senate,2,Republican,"Ellis, Ronald B.",161,400030
+DOUGLAS,Lawrence Precinct 48,Kansas Senate,2,Democratic,"Francisco, Marci",646,400040
+DOUGLAS,Lawrence Precinct 48,Kansas Senate,2,Republican,"Ellis, Ronald B.",296,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,Kansas Senate,3,Democratic,"Holland, Tom",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,Kansas Senate,3,Republican,"Brown, Anthony R.",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,Kansas Senate,2,Democratic,"Francisco, Marci",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,Kansas Senate,2,Republican,"Ellis, Ronald B.",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,Kansas Senate,3,Democratic,"Holland, Tom",444,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,Kansas Senate,3,Republican,"Brown, Anthony R.",576,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,Kansas Senate,3,Democratic,"Holland, Tom",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,Kansas Senate,3,Republican,"Brown, Anthony R.",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Kansas Senate,19,Democratic,"Hensley, Anthony",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Kansas Senate,19,Republican,"Moore, Casey W.",0,400110
+DOUGLAS,Lawrence Precinct 68,Kansas Senate,19,Democratic,"Hensley, Anthony",0,900010
+DOUGLAS,Lawrence Precinct 68,Kansas Senate,19,Republican,"Moore, Casey W.",0,900010
+DOUGLAS,Lawrence Precinct 69,Kansas Senate,3,Democratic,"Holland, Tom",0,900020
+DOUGLAS,Lawrence Precinct 69,Kansas Senate,3,Republican,"Brown, Anthony R.",0,900020
+DOUGLAS,Lawrence Precinct 70,Kansas Senate,2,Democratic,"Francisco, Marci",8,900040
+DOUGLAS,Lawrence Precinct 70,Kansas Senate,2,Republican,"Ellis, Ronald B.",7,900040
+DOUGLAS,Lawrence Precinct 71,Kansas Senate,2,Democratic,"Francisco, Marci",521,900050
+DOUGLAS,Lawrence Precinct 71,Kansas Senate,2,Republican,"Ellis, Ronald B.",257,900050
+DOUGLAS,Lawrence Precinct 72,Kansas Senate,2,Democratic,"Francisco, Marci",0,900060
+DOUGLAS,Lawrence Precinct 72,Kansas Senate,2,Republican,"Ellis, Ronald B.",0,900060
+DOUGLAS,Lawrence Precinct 73,Kansas Senate,2,Democratic,"Francisco, Marci",0,900070
+DOUGLAS,Lawrence Precinct 73,Kansas Senate,2,Republican,"Ellis, Ronald B.",0,900070
+DOUGLAS,Lawrence Precinct 74,Kansas Senate,2,Democratic,"Francisco, Marci",0,900080
+DOUGLAS,Lawrence Precinct 74,Kansas Senate,2,Republican,"Ellis, Ronald B.",0,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,Kansas Senate,2,Democratic,"Francisco, Marci",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,Kansas Senate,2,Republican,"Ellis, Ronald B.",0,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Kansas Senate,3,Democratic,"Holland, Tom",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Kansas Senate,3,Republican,"Brown, Anthony R.",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Kansas Senate,3,Democratic,"Holland, Tom",32,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Kansas Senate,3,Republican,"Brown, Anthony R.",16,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Kansas Senate,2,Democratic,"Francisco, Marci",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Kansas Senate,2,Republican,"Ellis, Ronald B.",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Kansas Senate,3,Democratic,"Holland, Tom",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Kansas Senate,3,Republican,"Brown, Anthony R.",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Kansas Senate,3,Democratic,"Holland, Tom",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Kansas Senate,3,Republican,"Brown, Anthony R.",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,Kansas Senate,2,Democratic,"Francisco, Marci",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,Kansas Senate,2,Republican,"Ellis, Ronald B.",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,Kansas Senate,3,Democratic,"Holland, Tom",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,Kansas Senate,3,Republican,"Brown, Anthony R.",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,Kansas Senate,2,Democratic,"Francisco, Marci",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,Kansas Senate,2,Republican,"Ellis, Ronald B.",0,900170
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,Democratic,"Obama, Barack",91,000010
+DOUGLAS,Big Springs Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000010
+DOUGLAS,Big Springs Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,Republican,"Romney, Mitt",111,000010
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Barnett, Andre",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Bush, Kent W",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Christensen, Will",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Goode, Virgil",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Stein, Jill E",1,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,Democratic,"Obama, Barack",292,000020
+DOUGLAS,Central Eudora,President / Vice President,,Libertarian,"Johnson, Gary",19,000020
+DOUGLAS,Central Eudora,President / Vice President,,Reform,"Baldwin, Chuck",2,000020
+DOUGLAS,Central Eudora,President / Vice President,,Republican,"Romney, Mitt",390,000020
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,Democratic,"Obama, Barack",150,000030
+DOUGLAS,Clinton Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+DOUGLAS,Clinton Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,Republican,"Romney, Mitt",226,000030
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Stein, Jill E",6,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,Democratic,"Obama, Barack",394,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",16,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",3,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,Republican,"Romney, Mitt",88,00007A
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Stein, Jill E",6,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,Democratic,"Obama, Barack",468,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",19,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",4,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,Republican,"Romney, Mitt",77,000080
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Stein, Jill E",4,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,Democratic,"Obama, Barack",460,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",12,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,Republican,"Romney, Mitt",82,000090
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",1,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Stein, Jill E",8,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,Democratic,"Obama, Barack",425,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",27,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",1,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,Republican,"Romney, Mitt",107,00010A
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Goode, Virgil",1,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,Democratic,"Obama, Barack",430,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",19,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",3,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,Republican,"Romney, Mitt",258,000110
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Ayers, Avery L",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Barnett, Andre",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Barr, Roseanne C",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Bush, Kent W",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Christensen, Will",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Duncan, Richard A",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Goode, Virgil",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Knill, Dennis J",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Reed, Jill A.",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Rogers, Rick L",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Stein, Jill E",2,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Thorne, Kevin M",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Warner, Gerald L.",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,Democratic,"Obama, Barack",425,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",12,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,Reform,"Baldwin, Chuck",2,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,Republican,"Romney, Mitt",268,00012A
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Barnett, Andre",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Bush, Kent W",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Christensen, Will",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Goode, Virgil",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Stein, Jill E",1,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,Democratic,"Obama, Barack",243,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",13,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,Republican,"Romney, Mitt",56,000130
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Barnett, Andre",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Bush, Kent W",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Christensen, Will",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Goode, Virgil",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Stein, Jill E",4,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,Democratic,"Obama, Barack",370,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",11,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,Republican,"Romney, Mitt",77,000140
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Barnett, Andre",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Bush, Kent W",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Christensen, Will",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Goode, Virgil",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Stein, Jill E",1,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,Democratic,"Obama, Barack",290,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",13,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,Republican,"Romney, Mitt",95,000150
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Barnett, Andre",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Bush, Kent W",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Christensen, Will",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Goode, Virgil",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Stein, Jill E",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,Democratic,"Obama, Barack",293,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",8,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,Reform,"Baldwin, Chuck",1,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,Republican,"Romney, Mitt",105,000160
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Barnett, Andre",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Bush, Kent W",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Christensen, Will",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Goode, Virgil",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Stein, Jill E",1,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,Democratic,"Obama, Barack",384,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",7,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,Reform,"Baldwin, Chuck",2,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,Republican,"Romney, Mitt",142,000170
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Barnett, Andre",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Bush, Kent W",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Christensen, Will",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Goode, Virgil",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Stein, Jill E",3,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,Democratic,"Obama, Barack",614,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,Libertarian,"Johnson, Gary",27,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,Republican,"Romney, Mitt",218,000180
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Barnett, Andre",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Bush, Kent W",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Christensen, Will",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Goode, Virgil",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Stein, Jill E",3,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,Democratic,"Obama, Barack",471,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,Libertarian,"Johnson, Gary",16,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,Reform,"Baldwin, Chuck",1,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,Republican,"Romney, Mitt",251,000190
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Barnett, Andre",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Bush, Kent W",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Christensen, Will",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Goode, Virgil",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Stein, Jill E",3,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,Democratic,"Obama, Barack",912,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,Libertarian,"Johnson, Gary",36,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,Reform,"Baldwin, Chuck",3,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,Republican,"Romney, Mitt",419,000200
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Barnett, Andre",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Barr, Roseanne C",1,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Bush, Kent W",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Christensen, Will",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Goode, Virgil",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Stein, Jill E",11,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,Democratic,"Obama, Barack",687,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,Libertarian,"Johnson, Gary",30,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,Republican,"Romney, Mitt",226,000210
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Barnett, Andre",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Bush, Kent W",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Christensen, Will",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Goode, Virgil",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Stein, Jill E",1,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,Democratic,"Obama, Barack",490,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,Libertarian,"Johnson, Gary",11,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,Reform,"Baldwin, Chuck",2,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,Republican,"Romney, Mitt",246,000220
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Barnett, Andre",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Barr, Roseanne C",1,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Bush, Kent W",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Christensen, Will",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Goode, Virgil",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Stein, Jill E",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,Democratic,"Obama, Barack",412,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,Libertarian,"Johnson, Gary",15,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,Reform,"Baldwin, Chuck",1,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,Republican,"Romney, Mitt",263,000230
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Barnett, Andre",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Bush, Kent W",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Christensen, Will",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Goode, Virgil",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Stein, Jill E",1,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,Democratic,"Obama, Barack",707,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,Libertarian,"Johnson, Gary",17,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,Reform,"Baldwin, Chuck",2,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,Republican,"Romney, Mitt",513,000240
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Barnett, Andre",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Bush, Kent W",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Christensen, Will",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Goode, Virgil",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Stein, Jill E",1,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,Democratic,"Obama, Barack",474,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,Libertarian,"Johnson, Gary",16,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,Reform,"Baldwin, Chuck",1,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,Republican,"Romney, Mitt",464,000250
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Barnett, Andre",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Bush, Kent W",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Christensen, Will",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Goode, Virgil",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Stein, Jill E",1,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,Democratic,"Obama, Barack",754,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,Libertarian,"Johnson, Gary",22,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,Reform,"Baldwin, Chuck",1,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,Republican,"Romney, Mitt",407,000260
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Barnett, Andre",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Bush, Kent W",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Christensen, Will",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Goode, Virgil",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Stein, Jill E",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,Democratic,"Obama, Barack",313,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,Libertarian,"Johnson, Gary",8,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,Reform,"Baldwin, Chuck",1,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,Republican,"Romney, Mitt",120,000270
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Barnett, Andre",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Bush, Kent W",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Christensen, Will",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Goode, Virgil",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Stein, Jill E",2,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,Democratic,"Obama, Barack",596,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,Libertarian,"Johnson, Gary",20,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,Reform,"Baldwin, Chuck",4,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,Republican,"Romney, Mitt",304,000280
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Barnett, Andre",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Bush, Kent W",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Christensen, Will",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Goode, Virgil",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Stein, Jill E",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,Democratic,"Obama, Barack",383,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,Libertarian,"Johnson, Gary",16,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,Reform,"Baldwin, Chuck",1,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,Republican,"Romney, Mitt",153,000290
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Barnett, Andre",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Bush, Kent W",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Christensen, Will",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Goode, Virgil",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Stein, Jill E",1,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,Democratic,"Obama, Barack",280,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,Libertarian,"Johnson, Gary",7,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,Reform,"Baldwin, Chuck",1,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,Republican,"Romney, Mitt",212,000300
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Barnett, Andre",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Bush, Kent W",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Christensen, Will",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Goode, Virgil",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Stein, Jill E",6,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,Democratic,"Obama, Barack",351,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,Libertarian,"Johnson, Gary",15,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,Reform,"Baldwin, Chuck",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,Republican,"Romney, Mitt",105,000310
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Barnett, Andre",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Bush, Kent W",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Christensen, Will",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Goode, Virgil",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Stein, Jill E",3,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,Democratic,"Obama, Barack",448,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,Libertarian,"Johnson, Gary",10,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,Reform,"Baldwin, Chuck",1,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,Republican,"Romney, Mitt",89,000320
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Ayers, Avery L",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Barnett, Andre",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Barr, Roseanne C",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Bush, Kent W",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Christensen, Will",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Duncan, Richard A",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Goode, Virgil",1,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Knill, Dennis J",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Reed, Jill A.",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Rogers, Rick L",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Stein, Jill E",5,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Thorne, Kevin M",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Warner, Gerald L.",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,Democratic,"Obama, Barack",436,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,Libertarian,"Johnson, Gary",22,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,Reform,"Baldwin, Chuck",1,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,Republican,"Romney, Mitt",112,000330
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",2,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Ayers, Avery L",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Barnett, Andre",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Barr, Roseanne C",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Bush, Kent W",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Christensen, Will",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Duncan, Richard A",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Goode, Virgil",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Knill, Dennis J",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Reed, Jill A.",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Rogers, Rick L",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Stein, Jill E",2,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Thorne, Kevin M",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Warner, Gerald L.",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,Democratic,"Obama, Barack",293,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,Libertarian,"Johnson, Gary",5,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,Reform,"Baldwin, Chuck",2,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,Republican,"Romney, Mitt",67,000340
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Ayers, Avery L",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Barnett, Andre",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Barr, Roseanne C",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Bush, Kent W",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Christensen, Will",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Duncan, Richard A",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Goode, Virgil",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Knill, Dennis J",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Reed, Jill A.",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Rogers, Rick L",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Stein, Jill E",2,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Thorne, Kevin M",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Warner, Gerald L.",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,Democratic,"Obama, Barack",413,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,Libertarian,"Johnson, Gary",13,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,Reform,"Baldwin, Chuck",2,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,Republican,"Romney, Mitt",118,000350
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Ayers, Avery L",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Barnett, Andre",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Barr, Roseanne C",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Bush, Kent W",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Christensen, Will",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Duncan, Richard A",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Goode, Virgil",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Knill, Dennis J",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Reed, Jill A.",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Rogers, Rick L",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Stein, Jill E",3,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Thorne, Kevin M",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Warner, Gerald L.",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,Democratic,"Obama, Barack",509,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,Libertarian,"Johnson, Gary",20,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,Reform,"Baldwin, Chuck",4,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,Republican,"Romney, Mitt",249,000370
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Ayers, Avery L",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Barnett, Andre",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Barr, Roseanne C",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Bush, Kent W",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Christensen, Will",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Duncan, Richard A",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Goode, Virgil",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Knill, Dennis J",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Reed, Jill A.",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Rogers, Rick L",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Stein, Jill E",3,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Thorne, Kevin M",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Warner, Gerald L.",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,Democratic,"Obama, Barack",336,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,Libertarian,"Johnson, Gary",13,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,Reform,"Baldwin, Chuck",1,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,Republican,"Romney, Mitt",131,000380
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Ayers, Avery L",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Barnett, Andre",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Barr, Roseanne C",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Bush, Kent W",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Christensen, Will",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Duncan, Richard A",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Goode, Virgil",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Knill, Dennis J",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Reed, Jill A.",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Rogers, Rick L",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Stein, Jill E",6,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Thorne, Kevin M",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Warner, Gerald L.",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,Democratic,"Obama, Barack",543,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,Libertarian,"Johnson, Gary",16,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,Reform,"Baldwin, Chuck",2,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,Republican,"Romney, Mitt",102,000400
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Ayers, Avery L",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Barnett, Andre",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Barr, Roseanne C",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Bush, Kent W",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Christensen, Will",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Duncan, Richard A",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Goode, Virgil",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Knill, Dennis J",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Reed, Jill A.",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Rogers, Rick L",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Stein, Jill E",3,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Thorne, Kevin M",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Warner, Gerald L.",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,Democratic,"Obama, Barack",525,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,Libertarian,"Johnson, Gary",31,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,Reform,"Baldwin, Chuck",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,Republican,"Romney, Mitt",285,000450
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Ayers, Avery L",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Barnett, Andre",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Barr, Roseanne C",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Bush, Kent W",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Christensen, Will",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Duncan, Richard A",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Goode, Virgil",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Hoefling, Tom",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Knill, Dennis J",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Reed, Jill A.",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Rogers, Rick L",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Stein, Jill E",7,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Thorne, Kevin M",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Warner, Gerald L.",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,Democratic,"Obama, Barack",508,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,Libertarian,"Johnson, Gary",24,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,Reform,"Baldwin, Chuck",1,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,Republican,"Romney, Mitt",39,000460
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",2,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Ayers, Avery L",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Barnett, Andre",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Barr, Roseanne C",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Bush, Kent W",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Christensen, Will",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Duncan, Richard A",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Goode, Virgil",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Hoefling, Tom",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Knill, Dennis J",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Reed, Jill A.",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Rogers, Rick L",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Stein, Jill E",6,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Thorne, Kevin M",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Warner, Gerald L.",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,Democratic,"Obama, Barack",509,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,Libertarian,"Johnson, Gary",18,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,Reform,"Baldwin, Chuck",1,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,Republican,"Romney, Mitt",35,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Christensen, Will",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Ayers, Avery L",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Barnett, Andre",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Barr, Roseanne C",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Bush, Kent W",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Christensen, Will",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Duncan, Richard A",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Goode, Virgil",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Knill, Dennis J",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Reed, Jill A.",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Rogers, Rick L",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Stein, Jill E",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Thorne, Kevin M",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Warner, Gerald L.",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,Democratic,"Obama, Barack",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,Reform,"Baldwin, Chuck",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,Republican,"Romney, Mitt",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Ayers, Avery L",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Barnett, Andre",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Bush, Kent W",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Christensen, Will",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Duncan, Richard A",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Goode, Virgil",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Hoefling, Tom",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Knill, Dennis J",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Reed, Jill A.",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Rogers, Rick L",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Stein, Jill E",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,Democratic,"Obama, Barack",272,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,Libertarian,"Johnson, Gary",14,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,Reform,"Baldwin, Chuck",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,Republican,"Romney, Mitt",191,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Ayers, Avery L",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Barnett, Andre",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Bush, Kent W",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Christensen, Will",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Duncan, Richard A",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Goode, Virgil",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Hoefling, Tom",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Knill, Dennis J",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Reed, Jill A.",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Rogers, Rick L",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Stein, Jill E",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,Democratic,"Obama, Barack",259,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,Libertarian,"Johnson, Gary",5,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,Reform,"Baldwin, Chuck",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,Republican,"Romney, Mitt",202,00050C
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",2,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Ayers, Avery L",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Barnett, Andre",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Barr, Roseanne C",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Bush, Kent W",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Christensen, Will",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Duncan, Richard A",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Goode, Virgil",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Hoefling, Tom",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Knill, Dennis J",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Reed, Jill A.",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Rogers, Rick L",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Stein, Jill E",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Thorne, Kevin M",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Warner, Gerald L.",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,Democratic,"Obama, Barack",924,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,Libertarian,"Johnson, Gary",21,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,Reform,"Baldwin, Chuck",2,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,Republican,"Romney, Mitt",856,00052A
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Ayers, Avery L",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Barnett, Andre",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Barr, Roseanne C",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Bush, Kent W",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Christensen, Will",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Duncan, Richard A",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Goode, Virgil",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Hoefling, Tom",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Knill, Dennis J",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Reed, Jill A.",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Rogers, Rick L",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Stein, Jill E",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Thorne, Kevin M",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Warner, Gerald L.",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,Democratic,"Obama, Barack",417,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,Libertarian,"Johnson, Gary",17,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,Reform,"Baldwin, Chuck",1,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,Republican,"Romney, Mitt",430,000560
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Ayers, Avery L",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Barnett, Andre",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Barr, Roseanne C",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Bush, Kent W",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Christensen, Will",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Duncan, Richard A",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Goode, Virgil",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Hoefling, Tom",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Knill, Dennis J",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Reed, Jill A.",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Rogers, Rick L",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Stein, Jill E",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Thorne, Kevin M",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Warner, Gerald L.",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,Democratic,"Obama, Barack",211,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,Libertarian,"Johnson, Gary",9,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,Reform,"Baldwin, Chuck",6,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,Republican,"Romney, Mitt",242,000600
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Ayers, Avery L",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Barnett, Andre",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Barr, Roseanne C",1,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Bush, Kent W",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Christensen, Will",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Duncan, Richard A",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Goode, Virgil",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Hoefling, Tom",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Knill, Dennis J",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Reed, Jill A.",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Rogers, Rick L",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Stein, Jill E",2,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Thorne, Kevin M",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Warner, Gerald L.",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,Democratic,"Obama, Barack",430,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,Libertarian,"Johnson, Gary",14,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,Reform,"Baldwin, Chuck",5,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,Republican,"Romney, Mitt",512,000620
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Ayers, Avery L",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Barnett, Andre",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Barr, Roseanne C",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Bush, Kent W",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Christensen, Will",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Duncan, Richard A",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Goode, Virgil",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Hoefling, Tom",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Knill, Dennis J",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Reed, Jill A.",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Rogers, Rick L",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Stein, Jill E",3,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Thorne, Kevin M",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Warner, Gerald L.",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,Democratic,"Obama, Barack",352,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,Libertarian,"Johnson, Gary",10,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,Reform,"Baldwin, Chuck",6,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,Republican,"Romney, Mitt",382,000630
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Ayers, Avery L",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Barnett, Andre",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Barr, Roseanne C",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Bush, Kent W",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Christensen, Will",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Duncan, Richard A",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Goode, Virgil",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Hoefling, Tom",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Knill, Dennis J",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Reed, Jill A.",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Rogers, Rick L",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Stein, Jill E",2,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Thorne, Kevin M",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Warner, Gerald L.",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,Democratic,"Obama, Barack",362,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,Libertarian,"Johnson, Gary",18,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,Reform,"Baldwin, Chuck",9,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,Republican,"Romney, Mitt",577,000640
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",2,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Ayers, Avery L",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Barnett, Andre",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Barr, Roseanne C",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Bush, Kent W",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Christensen, Will",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Duncan, Richard A",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Goode, Virgil",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Hoefling, Tom",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Knill, Dennis J",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Reed, Jill A.",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Rogers, Rick L",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Stein, Jill E",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Thorne, Kevin M",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Warner, Gerald L.",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,Democratic,"Obama, Barack",277,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,Libertarian,"Johnson, Gary",16,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,Reform,"Baldwin, Chuck",2,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,Republican,"Romney, Mitt",342,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Ayers, Avery L",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Barnett, Andre",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Bush, Kent W",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Christensen, Will",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Duncan, Richard A",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Goode, Virgil",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Hoefling, Tom",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Knill, Dennis J",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Reed, Jill A.",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Rogers, Rick L",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Stein, Jill E",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,Democratic,"Obama, Barack",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,Libertarian,"Johnson, Gary",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,Reform,"Baldwin, Chuck",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,Republican,"Romney, Mitt",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Barnett, Andre",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Bush, Kent W",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Christensen, Will",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Goode, Virgil",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Stein, Jill E",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,Democratic,"Obama, Barack",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,Republican,"Romney, Mitt",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Barnett, Andre",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Bush, Kent W",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Christensen, Will",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Goode, Virgil",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Stein, Jill E",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,Democratic,"Obama, Barack",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,Republican,"Romney, Mitt",0,120030
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Barnett, Andre",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Bush, Kent W",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Christensen, Will",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Goode, Virgil",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Stein, Jill E",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,Democratic,"Obama, Barack",22,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,Libertarian,"Johnson, Gary",1,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,Reform,"Baldwin, Chuck",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,Republican,"Romney, Mitt",9,120040
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Barnett, Andre",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Bush, Kent W",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Christensen, Will",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Goode, Virgil",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Stein, Jill E",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,Democratic,"Obama, Barack",69,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,Libertarian,"Johnson, Gary",5,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,Reform,"Baldwin, Chuck",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,Republican,"Romney, Mitt",60,120050
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Ayers, Avery L",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Barnett, Andre",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Barr, Roseanne C",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Bush, Kent W",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Christensen, Will",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Duncan, Richard A",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Goode, Virgil",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Knill, Dennis J",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Reed, Jill A.",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Rogers, Rick L",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Stein, Jill E",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Thorne, Kevin M",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Warner, Gerald L.",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,Democratic,"Obama, Barack",34,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,Libertarian,"Johnson, Gary",1,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,Reform,"Baldwin, Chuck",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,Republican,"Romney, Mitt",8,120060
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Ayers, Avery L",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Barnett, Andre",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Barr, Roseanne C",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Bush, Kent W",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Christensen, Will",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Duncan, Richard A",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Goode, Virgil",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Knill, Dennis J",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Reed, Jill A.",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Rogers, Rick L",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Stein, Jill E",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Thorne, Kevin M",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Warner, Gerald L.",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,Democratic,"Obama, Barack",382,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,Libertarian,"Johnson, Gary",11,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,Reform,"Baldwin, Chuck",3,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,Republican,"Romney, Mitt",417,120070
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Ayers, Avery L",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Barnett, Andre",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Barr, Roseanne C",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Bush, Kent W",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Christensen, Will",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Duncan, Richard A",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Goode, Virgil",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Knill, Dennis J",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Reed, Jill A.",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Rogers, Rick L",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Stein, Jill E",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Thorne, Kevin M",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Warner, Gerald L.",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,Democratic,"Obama, Barack",34,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,Libertarian,"Johnson, Gary",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,Reform,"Baldwin, Chuck",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,Republican,"Romney, Mitt",22,120080
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Ayers, Avery L",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Barnett, Andre",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Barr, Roseanne C",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Bush, Kent W",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Christensen, Will",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Duncan, Richard A",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Goode, Virgil",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Knill, Dennis J",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Reed, Jill A.",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Rogers, Rick L",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Stein, Jill E",2,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Thorne, Kevin M",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Warner, Gerald L.",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,Democratic,"Obama, Barack",122,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,Libertarian,"Johnson, Gary",6,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,Reform,"Baldwin, Chuck",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,Republican,"Romney, Mitt",48,120090
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Ayers, Avery L",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Barnett, Andre",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Barr, Roseanne C",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Bush, Kent W",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Christensen, Will",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Duncan, Richard A",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Goode, Virgil",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Hoefling, Tom",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Knill, Dennis J",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Reed, Jill A.",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Rogers, Rick L",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Stein, Jill E",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Thorne, Kevin M",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Warner, Gerald L.",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,Democratic,"Obama, Barack",255,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,Libertarian,"Johnson, Gary",14,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,Reform,"Baldwin, Chuck",2,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,Republican,"Romney, Mitt",75,120100
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Ayers, Avery L",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Barnett, Andre",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Barr, Roseanne C",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Bush, Kent W",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Christensen, Will",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Duncan, Richard A",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Goode, Virgil",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Hoefling, Tom",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Knill, Dennis J",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Reed, Jill A.",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Rogers, Rick L",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Stein, Jill E",3,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Thorne, Kevin M",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Warner, Gerald L.",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,Democratic,"Obama, Barack",322,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,Libertarian,"Johnson, Gary",10,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,Reform,"Baldwin, Chuck",3,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,Republican,"Romney, Mitt",89,120110
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Ayers, Avery L",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Barnett, Andre",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Barr, Roseanne C",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Bush, Kent W",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Christensen, Will",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Duncan, Richard A",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Goode, Virgil",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Hoefling, Tom",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Knill, Dennis J",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Reed, Jill A.",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Rogers, Rick L",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Stein, Jill E",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Thorne, Kevin M",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Warner, Gerald L.",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,Democratic,"Obama, Barack",73,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,Libertarian,"Johnson, Gary",3,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,Reform,"Baldwin, Chuck",1,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,Republican,"Romney, Mitt",7,120120
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Ayers, Avery L",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Barnett, Andre",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Barr, Roseanne C",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Bush, Kent W",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Christensen, Will",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Duncan, Richard A",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Goode, Virgil",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Hoefling, Tom",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Knill, Dennis J",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Reed, Jill A.",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Rogers, Rick L",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Stein, Jill E",8,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Thorne, Kevin M",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Warner, Gerald L.",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,Democratic,"Obama, Barack",448,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,Libertarian,"Johnson, Gary",14,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,Reform,"Baldwin, Chuck",1,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,Republican,"Romney, Mitt",150,120130
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Ayers, Avery L",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Barnett, Andre",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Barr, Roseanne C",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Bush, Kent W",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Christensen, Will",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Duncan, Richard A",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Goode, Virgil",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Hoefling, Tom",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Knill, Dennis J",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Reed, Jill A.",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Rogers, Rick L",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Stein, Jill E",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Thorne, Kevin M",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Warner, Gerald L.",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,Democratic,"Obama, Barack",25,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,Libertarian,"Johnson, Gary",3,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,Reform,"Baldwin, Chuck",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,Republican,"Romney, Mitt",12,120140
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Ayers, Avery L",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Barnett, Andre",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Barr, Roseanne C",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Bush, Kent W",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Christensen, Will",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Duncan, Richard A",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Goode, Virgil",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Hoefling, Tom",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Knill, Dennis J",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Reed, Jill A.",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Rogers, Rick L",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Stein, Jill E",4,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Thorne, Kevin M",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Warner, Gerald L.",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,Democratic,"Obama, Barack",388,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,Libertarian,"Johnson, Gary",15,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,Reform,"Baldwin, Chuck",2,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,Republican,"Romney, Mitt",146,120150
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Ayers, Avery L",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Barnett, Andre",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Barr, Roseanne C",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Bush, Kent W",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Christensen, Will",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Duncan, Richard A",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Goode, Virgil",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Hoefling, Tom",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Knill, Dennis J",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Reed, Jill A.",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Rogers, Rick L",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Stein, Jill E",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Thorne, Kevin M",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,write - in,"Warner, Gerald L.",0,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,Democratic,"Obama, Barack",329,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,Libertarian,"Johnson, Gary",10,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,Reform,"Baldwin, Chuck",2,120160
+DOUGLAS,Lawrence Precinct 36 S3,President / Vice President,,Republican,"Romney, Mitt",148,120160
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Ayers, Avery L",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Barnett, Andre",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Barr, Roseanne C",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Bush, Kent W",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Christensen, Will",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Duncan, Richard A",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Goode, Virgil",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Hoefling, Tom",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Knill, Dennis J",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Reed, Jill A.",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Rogers, Rick L",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Stein, Jill E",1,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Thorne, Kevin M",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Warner, Gerald L.",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,Democratic,"Obama, Barack",647,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,Libertarian,"Johnson, Gary",39,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,Reform,"Baldwin, Chuck",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,Republican,"Romney, Mitt",336,120170
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Ayers, Avery L",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Barnett, Andre",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Barr, Roseanne C",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Bush, Kent W",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Christensen, Will",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Duncan, Richard A",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Goode, Virgil",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Hoefling, Tom",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Knill, Dennis J",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Reed, Jill A.",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Rogers, Rick L",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Stein, Jill E",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Thorne, Kevin M",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,write - in,"Warner, Gerald L.",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,Democratic,"Obama, Barack",36,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,Libertarian,"Johnson, Gary",1,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,Reform,"Baldwin, Chuck",0,120180
+DOUGLAS,Lawrence Precinct 37 H46,President / Vice President,,Republican,"Romney, Mitt",16,120180
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Ayers, Avery L",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Barnett, Andre",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Barr, Roseanne C",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Bush, Kent W",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Christensen, Will",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Duncan, Richard A",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Goode, Virgil",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Hoefling, Tom",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Knill, Dennis J",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Reed, Jill A.",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Rogers, Rick L",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Stein, Jill E",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Thorne, Kevin M",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Warner, Gerald L.",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,Democratic,"Obama, Barack",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,Libertarian,"Johnson, Gary",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,Reform,"Baldwin, Chuck",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,Republican,"Romney, Mitt",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Ayers, Avery L",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Barnett, Andre",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Bush, Kent W",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Christensen, Will",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Duncan, Richard A",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Goode, Virgil",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Hoefling, Tom",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Knill, Dennis J",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Reed, Jill A.",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Rogers, Rick L",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Stein, Jill E",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,Democratic,"Obama, Barack",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,President / Vice President,,Republican,"Romney, Mitt",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Ayers, Avery L",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Barnett, Andre",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Barr, Roseanne C",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Bush, Kent W",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Christensen, Will",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Duncan, Richard A",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Goode, Virgil",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Hoefling, Tom",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Knill, Dennis J",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Reed, Jill A.",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Rogers, Rick L",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Stein, Jill E",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Thorne, Kevin M",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,write - in,"Warner, Gerald L.",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,Democratic,"Obama, Barack",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,Libertarian,"Johnson, Gary",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,Reform,"Baldwin, Chuck",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,President / Vice President,,Republican,"Romney, Mitt",0,120200
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Ayers, Avery L",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Barnett, Andre",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Bush, Kent W",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Christensen, Will",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Duncan, Richard A",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Goode, Virgil",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Hoefling, Tom",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Knill, Dennis J",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Reed, Jill A.",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Rogers, Rick L",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Stein, Jill E",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,Democratic,"Obama, Barack",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,Republican,"Romney, Mitt",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Ayers, Avery L",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Barnett, Andre",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Barr, Roseanne C",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Bush, Kent W",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Christensen, Will",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Duncan, Richard A",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Goode, Virgil",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Knill, Dennis J",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Reed, Jill A.",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Rogers, Rick L",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Stein, Jill E",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Thorne, Kevin M",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Warner, Gerald L.",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,Democratic,"Obama, Barack",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,Libertarian,"Johnson, Gary",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,Reform,"Baldwin, Chuck",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,Republican,"Romney, Mitt",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Ayers, Avery L",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Barnett, Andre",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Barr, Roseanne C",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Bush, Kent W",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Christensen, Will",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Duncan, Richard A",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Goode, Virgil",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Hoefling, Tom",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Knill, Dennis J",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Reed, Jill A.",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Rogers, Rick L",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Stein, Jill E",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Thorne, Kevin M",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Warner, Gerald L.",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,Democratic,"Obama, Barack",10,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,Libertarian,"Johnson, Gary",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,Reform,"Baldwin, Chuck",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,Republican,"Romney, Mitt",2,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Ayers, Avery L",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Barnett, Andre",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Barr, Roseanne C",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Bush, Kent W",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Christensen, Will",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Duncan, Richard A",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Goode, Virgil",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Knill, Dennis J",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Reed, Jill A.",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Rogers, Rick L",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Stein, Jill E",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Thorne, Kevin M",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Warner, Gerald L.",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,Democratic,"Obama, Barack",1,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,Libertarian,"Johnson, Gary",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,Reform,"Baldwin, Chuck",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,Republican,"Romney, Mitt",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Ayers, Avery L",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Barnett, Andre",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Barr, Roseanne C",1,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Bush, Kent W",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Christensen, Will",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Duncan, Richard A",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Goode, Virgil",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Hoefling, Tom",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Knill, Dennis J",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Reed, Jill A.",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Rogers, Rick L",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Stein, Jill E",7,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Thorne, Kevin M",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Warner, Gerald L.",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,Democratic,"Obama, Barack",816,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,Libertarian,"Johnson, Gary",30,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,Reform,"Baldwin, Chuck",9,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,Republican,"Romney, Mitt",237,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Ayers, Avery L",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Barnett, Andre",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Barr, Roseanne C",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Bush, Kent W",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Christensen, Will",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Duncan, Richard A",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Goode, Virgil",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Knill, Dennis J",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Reed, Jill A.",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Rogers, Rick L",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Stein, Jill E",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Thorne, Kevin M",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Warner, Gerald L.",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,Democratic,"Obama, Barack",197,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,Libertarian,"Johnson, Gary",2,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,Reform,"Baldwin, Chuck",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,Republican,"Romney, Mitt",111,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Ayers, Avery L",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Barnett, Andre",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Barr, Roseanne C",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Bush, Kent W",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Christensen, Will",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Duncan, Richard A",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Goode, Virgil",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Hoefling, Tom",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Knill, Dennis J",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Reed, Jill A.",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Rogers, Rick L",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Stein, Jill E",2,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Thorne, Kevin M",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Warner, Gerald L.",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,Democratic,"Obama, Barack",208,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,Libertarian,"Johnson, Gary",8,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,Reform,"Baldwin, Chuck",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,Republican,"Romney, Mitt",60,120260
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Ayers, Avery L",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Barnett, Andre",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Barr, Roseanne C",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Bush, Kent W",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Christensen, Will",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Duncan, Richard A",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Goode, Virgil",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Hoefling, Tom",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Knill, Dennis J",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Reed, Jill A.",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Rogers, Rick L",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Stein, Jill E",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Thorne, Kevin M",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Warner, Gerald L.",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,Democratic,"Obama, Barack",77,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,Libertarian,"Johnson, Gary",4,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,Reform,"Baldwin, Chuck",1,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,Republican,"Romney, Mitt",42,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Ayers, Avery L",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Barnett, Andre",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Bush, Kent W",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Christensen, Will",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Duncan, Richard A",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Goode, Virgil",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Hoefling, Tom",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Knill, Dennis J",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Reed, Jill A.",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Rogers, Rick L",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Stein, Jill E",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,Democratic,"Obama, Barack",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,Republican,"Romney, Mitt",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Ayers, Avery L",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Barnett, Andre",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Barr, Roseanne C",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Bush, Kent W",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Christensen, Will",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Duncan, Richard A",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Goode, Virgil",1,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Knill, Dennis J",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Reed, Jill A.",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Rogers, Rick L",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Stein, Jill E",2,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Thorne, Kevin M",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Warner, Gerald L.",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,Democratic,"Obama, Barack",282,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,Libertarian,"Johnson, Gary",7,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,Reform,"Baldwin, Chuck",1,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,Republican,"Romney, Mitt",199,120280
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Ayers, Avery L",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Barnett, Andre",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Barr, Roseanne C",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Bush, Kent W",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Christensen, Will",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Duncan, Richard A",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Goode, Virgil",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Hoefling, Tom",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Knill, Dennis J",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Reed, Jill A.",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Rogers, Rick L",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Stein, Jill E",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Thorne, Kevin M",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Warner, Gerald L.",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,Democratic,"Obama, Barack",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,Libertarian,"Johnson, Gary",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,Reform,"Baldwin, Chuck",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,Republican,"Romney, Mitt",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Ayers, Avery L",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Barnett, Andre",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Barr, Roseanne C",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Bush, Kent W",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Christensen, Will",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Duncan, Richard A",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Goode, Virgil",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Hoefling, Tom",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Knill, Dennis J",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Reed, Jill A.",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Rogers, Rick L",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Stein, Jill E",2,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Thorne, Kevin M",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Warner, Gerald L.",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,Democratic,"Obama, Barack",834,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,Libertarian,"Johnson, Gary",37,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,Reform,"Baldwin, Chuck",5,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,Republican,"Romney, Mitt",469,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Ayers, Avery L",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Barnett, Andre",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Barr, Roseanne C",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Bush, Kent W",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Christensen, Will",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Duncan, Richard A",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Goode, Virgil",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Hoefling, Tom",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Knill, Dennis J",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Reed, Jill A.",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Rogers, Rick L",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Stein, Jill E",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Thorne, Kevin M",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Warner, Gerald L.",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,Democratic,"Obama, Barack",53,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,Libertarian,"Johnson, Gary",8,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,Reform,"Baldwin, Chuck",2,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,Republican,"Romney, Mitt",72,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Ayers, Avery L",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Barnett, Andre",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Barr, Roseanne C",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Bush, Kent W",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Christensen, Will",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Duncan, Richard A",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Goode, Virgil",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Hoefling, Tom",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Knill, Dennis J",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Reed, Jill A.",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Rogers, Rick L",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Stein, Jill E",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Thorne, Kevin M",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Warner, Gerald L.",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,Democratic,"Obama, Barack",229,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,Libertarian,"Johnson, Gary",17,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,Reform,"Baldwin, Chuck",8,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,Republican,"Romney, Mitt",237,120320
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Ayers, Avery L",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Barnett, Andre",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Barr, Roseanne C",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Bush, Kent W",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Christensen, Will",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Duncan, Richard A",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Goode, Virgil",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Knill, Dennis J",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Reed, Jill A.",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Rogers, Rick L",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Stein, Jill E",2,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Thorne, Kevin M",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Warner, Gerald L.",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,Democratic,"Obama, Barack",126,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,Libertarian,"Johnson, Gary",4,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,Reform,"Baldwin, Chuck",2,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,Republican,"Romney, Mitt",129,120330
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Ayers, Avery L",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Barnett, Andre",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Barr, Roseanne C",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Bush, Kent W",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Christensen, Will",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Duncan, Richard A",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Goode, Virgil",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Hoefling, Tom",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Knill, Dennis J",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Reed, Jill A.",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Rogers, Rick L",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Stein, Jill E",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Thorne, Kevin M",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Warner, Gerald L.",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,Democratic,"Obama, Barack",76,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,Libertarian,"Johnson, Gary",6,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,Reform,"Baldwin, Chuck",2,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,Republican,"Romney, Mitt",127,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Ayers, Avery L",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Barnett, Andre",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Barr, Roseanne C",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Bush, Kent W",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Christensen, Will",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Duncan, Richard A",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Goode, Virgil",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Knill, Dennis J",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Reed, Jill A.",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Rogers, Rick L",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Stein, Jill E",2,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Thorne, Kevin M",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Warner, Gerald L.",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,Democratic,"Obama, Barack",128,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,Libertarian,"Johnson, Gary",9,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,Reform,"Baldwin, Chuck",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,Republican,"Romney, Mitt",75,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Ayers, Avery L",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Barnett, Andre",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Barr, Roseanne C",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Bush, Kent W",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Christensen, Will",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Duncan, Richard A",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Goode, Virgil",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Hoefling, Tom",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Knill, Dennis J",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Reed, Jill A.",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Rogers, Rick L",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Stein, Jill E",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Thorne, Kevin M",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Warner, Gerald L.",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,Democratic,"Obama, Barack",1,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,Libertarian,"Johnson, Gary",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,Reform,"Baldwin, Chuck",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,Republican,"Romney, Mitt",0,120360
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Ayers, Avery L",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Barnett, Andre",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Barr, Roseanne C",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Bush, Kent W",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Christensen, Will",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Duncan, Richard A",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Goode, Virgil",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Hoefling, Tom",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Knill, Dennis J",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Reed, Jill A.",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Rogers, Rick L",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Stein, Jill E",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Thorne, Kevin M",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Warner, Gerald L.",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,Democratic,"Obama, Barack",154,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,Libertarian,"Johnson, Gary",10,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,Reform,"Baldwin, Chuck",2,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,Republican,"Romney, Mitt",333,120370
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Ayers, Avery L",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Barnett, Andre",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Barr, Roseanne C",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Bush, Kent W",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Christensen, Will",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Duncan, Richard A",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Goode, Virgil",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Hoefling, Tom",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Knill, Dennis J",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Reed, Jill A.",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Rogers, Rick L",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Stein, Jill E",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Thorne, Kevin M",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Warner, Gerald L.",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,Democratic,"Obama, Barack",190,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,Libertarian,"Johnson, Gary",9,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,Reform,"Baldwin, Chuck",2,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,Republican,"Romney, Mitt",331,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Ayers, Avery L",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Barnett, Andre",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Barr, Roseanne C",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Bush, Kent W",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Christensen, Will",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Duncan, Richard A",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Goode, Virgil",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Hoefling, Tom",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Knill, Dennis J",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Reed, Jill A.",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Rogers, Rick L",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Stein, Jill E",1,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Thorne, Kevin M",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Warner, Gerald L.",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,Democratic,"Obama, Barack",127,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,Libertarian,"Johnson, Gary",2,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,Reform,"Baldwin, Chuck",3,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,Republican,"Romney, Mitt",154,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Ayers, Avery L",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Barnett, Andre",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Barr, Roseanne C",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Bush, Kent W",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Christensen, Will",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Duncan, Richard A",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Goode, Virgil",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Knill, Dennis J",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Reed, Jill A.",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Rogers, Rick L",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Stein, Jill E",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Thorne, Kevin M",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Warner, Gerald L.",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,Democratic,"Obama, Barack",74,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,Libertarian,"Johnson, Gary",4,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,Reform,"Baldwin, Chuck",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,Republican,"Romney, Mitt",92,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Ayers, Avery L",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Barnett, Andre",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Barr, Roseanne C",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Bush, Kent W",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Christensen, Will",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Duncan, Richard A",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Goode, Virgil",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Knill, Dennis J",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Reed, Jill A.",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Rogers, Rick L",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Stein, Jill E",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Thorne, Kevin M",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Warner, Gerald L.",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,Democratic,"Obama, Barack",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,Libertarian,"Johnson, Gary",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,Reform,"Baldwin, Chuck",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,Republican,"Romney, Mitt",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Ayers, Avery L",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Barnett, Andre",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Barr, Roseanne C",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Bush, Kent W",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Christensen, Will",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Duncan, Richard A",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Goode, Virgil",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Hoefling, Tom",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Knill, Dennis J",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Reed, Jill A.",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Rogers, Rick L",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Stein, Jill E",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Thorne, Kevin M",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Warner, Gerald L.",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,Democratic,"Obama, Barack",77,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,Libertarian,"Johnson, Gary",10,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,Reform,"Baldwin, Chuck",2,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,Republican,"Romney, Mitt",125,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Ayers, Avery L",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Barnett, Andre",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Barr, Roseanne C",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Bush, Kent W",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Christensen, Will",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Duncan, Richard A",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Goode, Virgil",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Knill, Dennis J",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Reed, Jill A.",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Rogers, Rick L",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Stein, Jill E",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Thorne, Kevin M",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Warner, Gerald L.",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,Democratic,"Obama, Barack",1,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,Libertarian,"Johnson, Gary",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,Reform,"Baldwin, Chuck",1,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,Republican,"Romney, Mitt",0,120420
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Ayers, Avery L",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Barnett, Andre",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Barr, Roseanne C",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Bush, Kent W",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Christensen, Will",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Duncan, Richard A",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Goode, Virgil",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Knill, Dennis J",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Reed, Jill A.",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Rogers, Rick L",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Stein, Jill E",1,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Thorne, Kevin M",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Warner, Gerald L.",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,Democratic,"Obama, Barack",146,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,Libertarian,"Johnson, Gary",10,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,Reform,"Baldwin, Chuck",1,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,Republican,"Romney, Mitt",130,120430
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Ayers, Avery L",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Barnett, Andre",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Barr, Roseanne C",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Bush, Kent W",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Christensen, Will",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Duncan, Richard A",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Goode, Virgil",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Hoefling, Tom",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Knill, Dennis J",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Reed, Jill A.",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Rogers, Rick L",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Stein, Jill E",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Thorne, Kevin M",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Warner, Gerald L.",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,Democratic,"Obama, Barack",105,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,Libertarian,"Johnson, Gary",6,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,Reform,"Baldwin, Chuck",2,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,Republican,"Romney, Mitt",217,120440
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Ayers, Avery L",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Barnett, Andre",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Barr, Roseanne C",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Bush, Kent W",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Christensen, Will",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Duncan, Richard A",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Goode, Virgil",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Knill, Dennis J",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Reed, Jill A.",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Rogers, Rick L",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Stein, Jill E",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Thorne, Kevin M",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Warner, Gerald L.",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,Democratic,"Obama, Barack",43,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,Libertarian,"Johnson, Gary",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,Reform,"Baldwin, Chuck",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,Republican,"Romney, Mitt",52,120450
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Ayers, Avery L",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Barnett, Andre",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Barr, Roseanne C",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Bush, Kent W",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Christensen, Will",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Duncan, Richard A",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Goode, Virgil",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Hoefling, Tom",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Knill, Dennis J",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Reed, Jill A.",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Rogers, Rick L",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Stein, Jill E",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Thorne, Kevin M",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Warner, Gerald L.",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,Democratic,"Obama, Barack",38,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,Libertarian,"Johnson, Gary",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,Reform,"Baldwin, Chuck",1,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,Republican,"Romney, Mitt",35,120460
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Ayers, Avery L",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Barnett, Andre",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Barr, Roseanne C",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Bush, Kent W",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Christensen, Will",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Duncan, Richard A",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Goode, Virgil",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Hoefling, Tom",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Knill, Dennis J",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Reed, Jill A.",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Rogers, Rick L",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Stein, Jill E",2,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Thorne, Kevin M",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Warner, Gerald L.",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,Democratic,"Obama, Barack",172,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,Libertarian,"Johnson, Gary",9,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,Reform,"Baldwin, Chuck",1,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,Republican,"Romney, Mitt",186,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Ayers, Avery L",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Barnett, Andre",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Barr, Roseanne C",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Bush, Kent W",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Christensen, Will",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Duncan, Richard A",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Goode, Virgil",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Knill, Dennis J",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Reed, Jill A.",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Rogers, Rick L",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Stein, Jill E",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Thorne, Kevin M",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Warner, Gerald L.",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,Democratic,"Obama, Barack",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,Libertarian,"Johnson, Gary",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,Reform,"Baldwin, Chuck",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,Republican,"Romney, Mitt",0,400010
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Ayers, Avery L",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Barnett, Andre",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Barr, Roseanne C",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Bush, Kent W",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Christensen, Will",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Duncan, Richard A",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Goode, Virgil",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Hoefling, Tom",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Knill, Dennis J",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Reed, Jill A.",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Rogers, Rick L",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Stein, Jill E",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Thorne, Kevin M",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Warner, Gerald L.",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,Democratic,"Obama, Barack",228,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,Libertarian,"Johnson, Gary",8,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,Reform,"Baldwin, Chuck",2,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,Republican,"Romney, Mitt",204,400030
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Ayers, Avery L",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Barnett, Andre",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Barr, Roseanne C",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Bush, Kent W",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Christensen, Will",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Duncan, Richard A",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Goode, Virgil",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Hoefling, Tom",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Knill, Dennis J",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Reed, Jill A.",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Rogers, Rick L",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Stein, Jill E",4,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Thorne, Kevin M",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Warner, Gerald L.",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,Democratic,"Obama, Barack",585,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,Libertarian,"Johnson, Gary",14,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,Reform,"Baldwin, Chuck",1,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,Republican,"Romney, Mitt",371,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Ayers, Avery L",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Barnett, Andre",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Barr, Roseanne C",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Bush, Kent W",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Christensen, Will",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Duncan, Richard A",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Goode, Virgil",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Hoefling, Tom",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Knill, Dennis J",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Reed, Jill A.",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Rogers, Rick L",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Stein, Jill E",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Thorne, Kevin M",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Warner, Gerald L.",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,Democratic,"Obama, Barack",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,Libertarian,"Johnson, Gary",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,Reform,"Baldwin, Chuck",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,Republican,"Romney, Mitt",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Ayers, Avery L",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Barnett, Andre",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Barr, Roseanne C",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Bush, Kent W",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Christensen, Will",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Duncan, Richard A",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Goode, Virgil",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Hoefling, Tom",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Knill, Dennis J",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Reed, Jill A.",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Rogers, Rick L",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Stein, Jill E",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Thorne, Kevin M",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Warner, Gerald L.",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,Democratic,"Obama, Barack",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,Libertarian,"Johnson, Gary",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,Reform,"Baldwin, Chuck",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,Republican,"Romney, Mitt",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Ayers, Avery L",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Barnett, Andre",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Barr, Roseanne C",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Bush, Kent W",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Christensen, Will",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Duncan, Richard A",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Goode, Virgil",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Knill, Dennis J",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Reed, Jill A.",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Rogers, Rick L",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Stein, Jill E",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Thorne, Kevin M",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Warner, Gerald L.",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,Democratic,"Obama, Barack",424,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,Libertarian,"Johnson, Gary",25,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,Reform,"Baldwin, Chuck",14,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,Republican,"Romney, Mitt",575,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Ayers, Avery L",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Barnett, Andre",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Barr, Roseanne C",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Bush, Kent W",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Christensen, Will",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Duncan, Richard A",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Goode, Virgil",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Hoefling, Tom",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Knill, Dennis J",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Reed, Jill A.",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Rogers, Rick L",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Stein, Jill E",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Thorne, Kevin M",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Warner, Gerald L.",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,Democratic,"Obama, Barack",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,Libertarian,"Johnson, Gary",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,Reform,"Baldwin, Chuck",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,Republican,"Romney, Mitt",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Ayers, Avery L",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Barnett, Andre",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Barr, Roseanne C",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Bush, Kent W",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Christensen, Will",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Duncan, Richard A",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Goode, Virgil",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Knill, Dennis J",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Reed, Jill A.",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Rogers, Rick L",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Stein, Jill E",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Thorne, Kevin M",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Warner, Gerald L.",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,Democratic,"Obama, Barack",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,Libertarian,"Johnson, Gary",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,Reform,"Baldwin, Chuck",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,Republican,"Romney, Mitt",0,400110
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Barnett, Andre",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Bush, Kent W",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Christensen, Will",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Goode, Virgil",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Stein, Jill E",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,Democratic,"Obama, Barack",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,Republican,"Romney, Mitt",0,900010
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Barnett, Andre",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Bush, Kent W",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Christensen, Will",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Goode, Virgil",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Stein, Jill E",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,Democratic,"Obama, Barack",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,Republican,"Romney, Mitt",0,900020
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Barnett, Andre",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Bush, Kent W",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Christensen, Will",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Goode, Virgil",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Stein, Jill E",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,Democratic,"Obama, Barack",7,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,Republican,"Romney, Mitt",10,900040
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Ayers, Avery L",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Barnett, Andre",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Barr, Roseanne C",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Bush, Kent W",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Christensen, Will",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Duncan, Richard A",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Goode, Virgil",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Knill, Dennis J",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Reed, Jill A.",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Rogers, Rick L",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Stein, Jill E",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Thorne, Kevin M",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Warner, Gerald L.",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,Democratic,"Obama, Barack",465,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,Libertarian,"Johnson, Gary",18,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,Reform,"Baldwin, Chuck",3,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,Republican,"Romney, Mitt",321,900050
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Ayers, Avery L",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Barnett, Andre",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Barr, Roseanne C",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Bush, Kent W",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Christensen, Will",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Duncan, Richard A",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Goode, Virgil",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Knill, Dennis J",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Reed, Jill A.",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Rogers, Rick L",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Stein, Jill E",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Thorne, Kevin M",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Warner, Gerald L.",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,Democratic,"Obama, Barack",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,Reform,"Baldwin, Chuck",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,Republican,"Romney, Mitt",0,900060
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Ayers, Avery L",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Barnett, Andre",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Barr, Roseanne C",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Bush, Kent W",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Christensen, Will",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Duncan, Richard A",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Goode, Virgil",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Hoefling, Tom",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Knill, Dennis J",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Reed, Jill A.",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Rogers, Rick L",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Stein, Jill E",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Thorne, Kevin M",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Warner, Gerald L.",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,Democratic,"Obama, Barack",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,Libertarian,"Johnson, Gary",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,Reform,"Baldwin, Chuck",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,Republican,"Romney, Mitt",0,900070
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Ayers, Avery L",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Barnett, Andre",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Barr, Roseanne C",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Bush, Kent W",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Christensen, Will",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Duncan, Richard A",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Goode, Virgil",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Hoefling, Tom",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Knill, Dennis J",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Reed, Jill A.",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Rogers, Rick L",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Stein, Jill E",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Thorne, Kevin M",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Warner, Gerald L.",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,Democratic,"Obama, Barack",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,Libertarian,"Johnson, Gary",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,Reform,"Baldwin, Chuck",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,Republican,"Romney, Mitt",0,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Ayers, Avery L",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Barnett, Andre",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Bush, Kent W",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Christensen, Will",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Duncan, Richard A",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Goode, Virgil",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Knill, Dennis J",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Reed, Jill A.",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Rogers, Rick L",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Stein, Jill E",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,Democratic,"Obama, Barack",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,Republican,"Romney, Mitt",0,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Ayers, Avery L",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Barnett, Andre",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Bush, Kent W",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Christensen, Will",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Duncan, Richard A",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Goode, Virgil",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Knill, Dennis J",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Reed, Jill A.",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Rogers, Rick L",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Stein, Jill E",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,Democratic,"Obama, Barack",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,Republican,"Romney, Mitt",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Ayers, Avery L",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Barnett, Andre",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Bush, Kent W",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Christensen, Will",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Duncan, Richard A",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Goode, Virgil",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Hoefling, Tom",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Knill, Dennis J",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Reed, Jill A.",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Rogers, Rick L",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Stein, Jill E",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,Democratic,"Obama, Barack",24,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,Libertarian,"Johnson, Gary",2,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,Republican,"Romney, Mitt",18,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Ayers, Avery L",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Barnett, Andre",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Bush, Kent W",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Christensen, Will",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Duncan, Richard A",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Goode, Virgil",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Knill, Dennis J",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Reed, Jill A.",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Rogers, Rick L",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Stein, Jill E",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,Democratic,"Obama, Barack",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,Republican,"Romney, Mitt",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Ayers, Avery L",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Barnett, Andre",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Barr, Roseanne C",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Bush, Kent W",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Christensen, Will",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Duncan, Richard A",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Goode, Virgil",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Hoefling, Tom",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Knill, Dennis J",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Reed, Jill A.",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Rogers, Rick L",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Stein, Jill E",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Thorne, Kevin M",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Warner, Gerald L.",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,Democratic,"Obama, Barack",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,Libertarian,"Johnson, Gary",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,Reform,"Baldwin, Chuck",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,Republican,"Romney, Mitt",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Ayers, Avery L",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Barnett, Andre",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Barr, Roseanne C",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Bush, Kent W",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Christensen, Will",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Duncan, Richard A",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Goode, Virgil",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Hoefling, Tom",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Knill, Dennis J",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Reed, Jill A.",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Rogers, Rick L",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Stein, Jill E",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Thorne, Kevin M",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Warner, Gerald L.",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,Democratic,"Obama, Barack",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,Libertarian,"Johnson, Gary",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,Reform,"Baldwin, Chuck",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,Republican,"Romney, Mitt",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Ayers, Avery L",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Barnett, Andre",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Barr, Roseanne C",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Bush, Kent W",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Christensen, Will",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Duncan, Richard A",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Goode, Virgil",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Hoefling, Tom",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Knill, Dennis J",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Reed, Jill A.",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Rogers, Rick L",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Stein, Jill E",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Thorne, Kevin M",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Warner, Gerald L.",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,Democratic,"Obama, Barack",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,Libertarian,"Johnson, Gary",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,Reform,"Baldwin, Chuck",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,Republican,"Romney, Mitt",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Ayers, Avery L",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Barnett, Andre",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Barr, Roseanne C",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Bush, Kent W",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Christensen, Will",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Duncan, Richard A",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Goode, Virgil",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Hoefling, Tom",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Knill, Dennis J",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Reed, Jill A.",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Rogers, Rick L",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Stein, Jill E",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Thorne, Kevin M",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Warner, Gerald L.",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,Democratic,"Obama, Barack",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,Libertarian,"Johnson, Gary",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,Reform,"Baldwin, Chuck",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,Republican,"Romney, Mitt",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Ayers, Avery L",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Barnett, Andre",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Barr, Roseanne C",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Bush, Kent W",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Christensen, Will",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Duncan, Richard A",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Goode, Virgil",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Hoefling, Tom",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Knill, Dennis J",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Reed, Jill A.",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Rogers, Rick L",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Stein, Jill E",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Thorne, Kevin M",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Warner, Gerald L.",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,Democratic,"Obama, Barack",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,Libertarian,"Johnson, Gary",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,Reform,"Baldwin, Chuck",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,Republican,"Romney, Mitt",0,900170
+DOUGLAS,Big Springs Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",97,000010
+DOUGLAS,Big Springs Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,000010
+DOUGLAS,Big Springs Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",98,000010
+DOUGLAS,Central Eudora,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",229,000020
+DOUGLAS,Central Eudora,United States House of Representatives,2,Libertarian,"Hawver, Dennis",34,000020
+DOUGLAS,Central Eudora,United States House of Representatives,2,Republican,"Jenkins, Lynn",428,000020
+DOUGLAS,Clinton Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",136,000030
+DOUGLAS,Clinton Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000030
+DOUGLAS,Clinton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",229,000030
+DOUGLAS,Lawrence Precinct 01,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",370,00007A
+DOUGLAS,Lawrence Precinct 01,United States House of Representatives,2,Libertarian,"Hawver, Dennis",29,00007A
+DOUGLAS,Lawrence Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",99,00007A
+DOUGLAS,Lawrence Precinct 02,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",451,000080
+DOUGLAS,Lawrence Precinct 02,United States House of Representatives,2,Libertarian,"Hawver, Dennis",23,000080
+DOUGLAS,Lawrence Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",87,000080
+DOUGLAS,Lawrence Precinct 03,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",448,000090
+DOUGLAS,Lawrence Precinct 03,United States House of Representatives,2,Libertarian,"Hawver, Dennis",17,000090
+DOUGLAS,Lawrence Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",82,000090
+DOUGLAS,Lawrence Precinct 04,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",398,00010A
+DOUGLAS,Lawrence Precinct 04,United States House of Representatives,2,Libertarian,"Hawver, Dennis",34,00010A
+DOUGLAS,Lawrence Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",117,00010A
+DOUGLAS,Lawrence Precinct 05,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",400,000110
+DOUGLAS,Lawrence Precinct 05,United States House of Representatives,2,Libertarian,"Hawver, Dennis",27,000110
+DOUGLAS,Lawrence Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",270,000110
+DOUGLAS,Lawrence Precinct 06,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",389,00012A
+DOUGLAS,Lawrence Precinct 06,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,00012A
+DOUGLAS,Lawrence Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",294,00012A
+DOUGLAS,Lawrence Precinct 07,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",220,000130
+DOUGLAS,Lawrence Precinct 07,United States House of Representatives,2,Libertarian,"Hawver, Dennis",21,000130
+DOUGLAS,Lawrence Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",66,000130
+DOUGLAS,Lawrence Precinct 08,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",339,000140
+DOUGLAS,Lawrence Precinct 08,United States House of Representatives,2,Libertarian,"Hawver, Dennis",25,000140
+DOUGLAS,Lawrence Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000140
+DOUGLAS,Lawrence Precinct 09,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",269,000150
+DOUGLAS,Lawrence Precinct 09,United States House of Representatives,2,Libertarian,"Hawver, Dennis",20,000150
+DOUGLAS,Lawrence Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,000150
+DOUGLAS,Lawrence Precinct 10,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",244,000160
+DOUGLAS,Lawrence Precinct 10,United States House of Representatives,2,Libertarian,"Hawver, Dennis",27,000160
+DOUGLAS,Lawrence Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",96,000160
+DOUGLAS,Lawrence Precinct 11,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",368,000170
+DOUGLAS,Lawrence Precinct 11,United States House of Representatives,2,Libertarian,"Hawver, Dennis",19,000170
+DOUGLAS,Lawrence Precinct 11,United States House of Representatives,2,Republican,"Jenkins, Lynn",142,000170
+DOUGLAS,Lawrence Precinct 12,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",565,000180
+DOUGLAS,Lawrence Precinct 12,United States House of Representatives,2,Libertarian,"Hawver, Dennis",43,000180
+DOUGLAS,Lawrence Precinct 12,United States House of Representatives,2,Republican,"Jenkins, Lynn",250,000180
+DOUGLAS,Lawrence Precinct 13,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",451,000190
+DOUGLAS,Lawrence Precinct 13,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,000190
+DOUGLAS,Lawrence Precinct 13,United States House of Representatives,2,Republican,"Jenkins, Lynn",264,000190
+DOUGLAS,Lawrence Precinct 14,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",787,000200
+DOUGLAS,Lawrence Precinct 14,United States House of Representatives,2,Libertarian,"Hawver, Dennis",73,000200
+DOUGLAS,Lawrence Precinct 14,United States House of Representatives,2,Republican,"Jenkins, Lynn",493,000200
+DOUGLAS,Lawrence Precinct 15,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",662,000210
+DOUGLAS,Lawrence Precinct 15,United States House of Representatives,2,Libertarian,"Hawver, Dennis",36,000210
+DOUGLAS,Lawrence Precinct 15,United States House of Representatives,2,Republican,"Jenkins, Lynn",243,000210
+DOUGLAS,Lawrence Precinct 16,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",432,000220
+DOUGLAS,Lawrence Precinct 16,United States House of Representatives,2,Libertarian,"Hawver, Dennis",27,000220
+DOUGLAS,Lawrence Precinct 16,United States House of Representatives,2,Republican,"Jenkins, Lynn",275,000220
+DOUGLAS,Lawrence Precinct 17,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",374,000230
+DOUGLAS,Lawrence Precinct 17,United States House of Representatives,2,Libertarian,"Hawver, Dennis",32,000230
+DOUGLAS,Lawrence Precinct 17,United States House of Representatives,2,Republican,"Jenkins, Lynn",274,000230
+DOUGLAS,Lawrence Precinct 18,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",648,000240
+DOUGLAS,Lawrence Precinct 18,United States House of Representatives,2,Libertarian,"Hawver, Dennis",30,000240
+DOUGLAS,Lawrence Precinct 18,United States House of Representatives,2,Republican,"Jenkins, Lynn",551,000240
+DOUGLAS,Lawrence Precinct 19,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",437,000250
+DOUGLAS,Lawrence Precinct 19,United States House of Representatives,2,Libertarian,"Hawver, Dennis",20,000250
+DOUGLAS,Lawrence Precinct 19,United States House of Representatives,2,Republican,"Jenkins, Lynn",482,000250
+DOUGLAS,Lawrence Precinct 20,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",686,000260
+DOUGLAS,Lawrence Precinct 20,United States House of Representatives,2,Libertarian,"Hawver, Dennis",58,000260
+DOUGLAS,Lawrence Precinct 20,United States House of Representatives,2,Republican,"Jenkins, Lynn",427,000260
+DOUGLAS,Lawrence Precinct 21,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",300,000270
+DOUGLAS,Lawrence Precinct 21,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000270
+DOUGLAS,Lawrence Precinct 21,United States House of Representatives,2,Republican,"Jenkins, Lynn",120,000270
+DOUGLAS,Lawrence Precinct 22,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",542,000280
+DOUGLAS,Lawrence Precinct 22,United States House of Representatives,2,Libertarian,"Hawver, Dennis",38,000280
+DOUGLAS,Lawrence Precinct 22,United States House of Representatives,2,Republican,"Jenkins, Lynn",321,000280
+DOUGLAS,Lawrence Precinct 23,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",351,000290
+DOUGLAS,Lawrence Precinct 23,United States House of Representatives,2,Libertarian,"Hawver, Dennis",26,000290
+DOUGLAS,Lawrence Precinct 23,United States House of Representatives,2,Republican,"Jenkins, Lynn",167,000290
+DOUGLAS,Lawrence Precinct 24,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",278,000300
+DOUGLAS,Lawrence Precinct 24,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,000300
+DOUGLAS,Lawrence Precinct 24,United States House of Representatives,2,Republican,"Jenkins, Lynn",194,000300
+DOUGLAS,Lawrence Precinct 25,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",311,000310
+DOUGLAS,Lawrence Precinct 25,United States House of Representatives,2,Libertarian,"Hawver, Dennis",28,000310
+DOUGLAS,Lawrence Precinct 25,United States House of Representatives,2,Republican,"Jenkins, Lynn",111,000310
+DOUGLAS,Lawrence Precinct 26,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",419,000320
+DOUGLAS,Lawrence Precinct 26,United States House of Representatives,2,Libertarian,"Hawver, Dennis",22,000320
+DOUGLAS,Lawrence Precinct 26,United States House of Representatives,2,Republican,"Jenkins, Lynn",93,000320
+DOUGLAS,Lawrence Precinct 27,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",403,000330
+DOUGLAS,Lawrence Precinct 27,United States House of Representatives,2,Libertarian,"Hawver, Dennis",35,000330
+DOUGLAS,Lawrence Precinct 27,United States House of Representatives,2,Republican,"Jenkins, Lynn",131,000330
+DOUGLAS,Lawrence Precinct 28,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",281,000340
+DOUGLAS,Lawrence Precinct 28,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000340
+DOUGLAS,Lawrence Precinct 28,United States House of Representatives,2,Republican,"Jenkins, Lynn",71,000340
+DOUGLAS,Lawrence Precinct 29,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",354,000350
+DOUGLAS,Lawrence Precinct 29,United States House of Representatives,2,Libertarian,"Hawver, Dennis",38,000350
+DOUGLAS,Lawrence Precinct 29,United States House of Representatives,2,Republican,"Jenkins, Lynn",143,000350
+DOUGLAS,Lawrence Precinct 31,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",502,000370
+DOUGLAS,Lawrence Precinct 31,United States House of Representatives,2,Libertarian,"Hawver, Dennis",27,000370
+DOUGLAS,Lawrence Precinct 31,United States House of Representatives,2,Republican,"Jenkins, Lynn",247,000370
+DOUGLAS,Lawrence Precinct 32,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",305,000380
+DOUGLAS,Lawrence Precinct 32,United States House of Representatives,2,Libertarian,"Hawver, Dennis",26,000380
+DOUGLAS,Lawrence Precinct 32,United States House of Representatives,2,Republican,"Jenkins, Lynn",147,000380
+DOUGLAS,Lawrence Precinct 33,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",524,000400
+DOUGLAS,Lawrence Precinct 33,United States House of Representatives,2,Libertarian,"Hawver, Dennis",30,000400
+DOUGLAS,Lawrence Precinct 33,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,000400
+DOUGLAS,Lawrence Precinct 38,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",456,000450
+DOUGLAS,Lawrence Precinct 38,United States House of Representatives,2,Libertarian,"Hawver, Dennis",40,000450
+DOUGLAS,Lawrence Precinct 38,United States House of Representatives,2,Republican,"Jenkins, Lynn",337,000450
+DOUGLAS,Lawrence Precinct 39,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",499,000460
+DOUGLAS,Lawrence Precinct 39,United States House of Representatives,2,Libertarian,"Hawver, Dennis",27,000460
+DOUGLAS,Lawrence Precinct 39,United States House of Representatives,2,Republican,"Jenkins, Lynn",45,000460
+DOUGLAS,Lawrence Precinct 40,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",472,000470
+DOUGLAS,Lawrence Precinct 40,United States House of Representatives,2,Libertarian,"Hawver, Dennis",33,000470
+DOUGLAS,Lawrence Precinct 40,United States House of Representatives,2,Republican,"Jenkins, Lynn",51,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00048C
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",253,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",201,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",224,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",215,00050C
+DOUGLAS,Lawrence Precinct 45,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",792,00052A
+DOUGLAS,Lawrence Precinct 45,United States House of Representatives,2,Libertarian,"Hawver, Dennis",53,00052A
+DOUGLAS,Lawrence Precinct 45,United States House of Representatives,2,Republican,"Jenkins, Lynn",919,00052A
+DOUGLAS,Lawrence Precinct 49,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",380,000560
+DOUGLAS,Lawrence Precinct 49,United States House of Representatives,2,Libertarian,"Hawver, Dennis",30,000560
+DOUGLAS,Lawrence Precinct 49,United States House of Representatives,2,Republican,"Jenkins, Lynn",438,000560
+DOUGLAS,North Eudora Precinct 52,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",169,000600
+DOUGLAS,North Eudora Precinct 52,United States House of Representatives,2,Libertarian,"Hawver, Dennis",36,000600
+DOUGLAS,North Eudora Precinct 52,United States House of Representatives,2,Republican,"Jenkins, Lynn",251,000600
+DOUGLAS,Northeast Baldwin Precinct 61,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",368,000620
+DOUGLAS,Northeast Baldwin Precinct 61,United States House of Representatives,2,Libertarian,"Hawver, Dennis",40,000620
+DOUGLAS,Northeast Baldwin Precinct 61,United States House of Representatives,2,Republican,"Jenkins, Lynn",552,000620
+DOUGLAS,Northwest Baldwin Precinct 60,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",310,000630
+DOUGLAS,Northwest Baldwin Precinct 60,United States House of Representatives,2,Libertarian,"Hawver, Dennis",25,000630
+DOUGLAS,Northwest Baldwin Precinct 60,United States House of Representatives,2,Republican,"Jenkins, Lynn",415,000630
+DOUGLAS,South Baldwin Precinct 62,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",309,000640
+DOUGLAS,South Baldwin Precinct 62,United States House of Representatives,2,Libertarian,"Hawver, Dennis",41,000640
+DOUGLAS,South Baldwin Precinct 62,United States House of Representatives,2,Republican,"Jenkins, Lynn",605,000640
+DOUGLAS,Vinland Precinct 63,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",245,000660
+DOUGLAS,Vinland Precinct 63,United States House of Representatives,2,Libertarian,"Hawver, Dennis",26,000660
+DOUGLAS,Vinland Precinct 63,United States House of Representatives,2,Republican,"Jenkins, Lynn",362,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120030
+DOUGLAS,Grant Township S2 H45,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",19,120040
+DOUGLAS,Grant Township S2 H45,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,120040
+DOUGLAS,Grant Township S2 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",7,120040
+DOUGLAS,Grant Township S3 H45,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",63,120050
+DOUGLAS,Grant Township S3 H45,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,120050
+DOUGLAS,Grant Township S3 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,120050
+DOUGLAS,Grant Township S3 H46,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",24,120060
+DOUGLAS,Grant Township S3 H46,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,120060
+DOUGLAS,Grant Township S3 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",16,120060
+DOUGLAS,Kawaka Township S19,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",357,120070
+DOUGLAS,Kawaka Township S19,United States House of Representatives,2,Libertarian,"Hawver, Dennis",34,120070
+DOUGLAS,Kawaka Township S19,United States House of Representatives,2,Republican,"Jenkins, Lynn",413,120070
+DOUGLAS,Kawaka Township S2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",27,120080
+DOUGLAS,Kawaka Township S2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,120080
+DOUGLAS,Kawaka Township S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",25,120080
+DOUGLAS,Lawrence Precinct 30 S2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",118,120090
+DOUGLAS,Lawrence Precinct 30 S2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,120090
+DOUGLAS,Lawrence Precinct 30 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",54,120090
+DOUGLAS,Lawrence Precinct 30 S3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",228,120100
+DOUGLAS,Lawrence Precinct 30 S3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",25,120100
+DOUGLAS,Lawrence Precinct 30 S3,United States House of Representatives,2,Republican,"Jenkins, Lynn",81,120100
+DOUGLAS,Lawrence Precinct 34 S2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",322,120110
+DOUGLAS,Lawrence Precinct 34 S2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,120110
+DOUGLAS,Lawrence Precinct 34 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",89,120110
+DOUGLAS,Lawrence Precinct 34 S3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",67,120120
+DOUGLAS,Lawrence Precinct 34 S3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,120120
+DOUGLAS,Lawrence Precinct 34 S3,United States House of Representatives,2,Republican,"Jenkins, Lynn",13,120120
+DOUGLAS,Lawrence Precinct 35 S2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",420,120130
+DOUGLAS,Lawrence Precinct 35 S2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",36,120130
+DOUGLAS,Lawrence Precinct 35 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",152,120130
+DOUGLAS,Lawrence Precinct 35 S3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",23,120140
+DOUGLAS,Lawrence Precinct 35 S3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,120140
+DOUGLAS,Lawrence Precinct 35 S3,United States House of Representatives,2,Republican,"Jenkins, Lynn",11,120140
+DOUGLAS,Lawrence Precinct 36 S2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",354,120150
+DOUGLAS,Lawrence Precinct 36 S2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",29,120150
+DOUGLAS,Lawrence Precinct 36 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",156,120150
+DOUGLAS,Lawrence Precinct 36 S3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",286,120160
+DOUGLAS,Lawrence Precinct 36 S3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",26,120160
+DOUGLAS,Lawrence Precinct 36 S3,United States House of Representatives,2,Republican,"Jenkins, Lynn",165,120160
+DOUGLAS,Lawrence Precinct 37 H10,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",600,120170
+DOUGLAS,Lawrence Precinct 37 H10,United States House of Representatives,2,Libertarian,"Hawver, Dennis",53,120170
+DOUGLAS,Lawrence Precinct 37 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",350,120170
+DOUGLAS,Lawrence Precinct 37 H46,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",33,120180
+DOUGLAS,Lawrence Precinct 37 H46,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,120180
+DOUGLAS,Lawrence Precinct 37 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",17,120180
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12020A
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120200
+DOUGLAS,Lawrence Precinct 38 Part 2 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120200
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",9,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",3,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",1,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",743,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States House of Representatives,2,Libertarian,"Hawver, Dennis",52,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",285,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",184,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",114,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",192,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,120260
+DOUGLAS,Lawrence Precinct 44 H44,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",74,120270
+DOUGLAS,Lawrence Precinct 44 H44,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,120270
+DOUGLAS,Lawrence Precinct 44 H44,United States House of Representatives,2,Republican,"Jenkins, Lynn",41,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",248,120280
+DOUGLAS,Lawrence Precinct 44 H45,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,120280
+DOUGLAS,Lawrence Precinct 44 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",222,120280
+DOUGLAS,Lawrence Precinct 46 S19,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",738,120300
+DOUGLAS,Lawrence Precinct 46 S3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",52,120300
+DOUGLAS,Lawrence Precinct 46 S3,United States House of Representatives,2,Republican,"Jenkins, Lynn",509,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",52,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,United States House of Representatives,2,Republican,"Jenkins, Lynn",68,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",199,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",34,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",256,120320
+DOUGLAS,Marion Township Precinct 59 H45,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",115,120330
+DOUGLAS,Marion Township Precinct 59 H45,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,120330
+DOUGLAS,Marion Township Precinct 59 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",138,120330
+DOUGLAS,Marion Township Precinct 59 H54,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",68,120340
+DOUGLAS,Marion Township Precinct 59 H54,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,120340
+DOUGLAS,Marion Township Precinct 59 H54,United States House of Representatives,2,Republican,"Jenkins, Lynn",131,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",127,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",1,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120360
+DOUGLAS,South Eudora Precinct 53 H10,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",131,120370
+DOUGLAS,South Eudora Precinct 53 H10,United States House of Representatives,2,Libertarian,"Hawver, Dennis",22,120370
+DOUGLAS,South Eudora Precinct 53 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",328,120370
+DOUGLAS,South Eudora Precinct 53 H42,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",166,120380
+DOUGLAS,South Eudora Precinct 53 H42,United States House of Representatives,2,Libertarian,"Hawver, Dennis",21,120380
+DOUGLAS,South Eudora Precinct 53 H42,United States House of Representatives,2,Republican,"Jenkins, Lynn",330,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",119,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",159,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",72,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",87,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",68,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",131,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",2,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120420
+DOUGLAS,Willow Springs Township S19 H45,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",133,120430
+DOUGLAS,Willow Springs Township S19 H45,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,120430
+DOUGLAS,Willow Springs Township S19 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",137,120430
+DOUGLAS,Willow Springs Township S19 H54,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",93,120440
+DOUGLAS,Willow Springs Township S19 H54,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,120440
+DOUGLAS,Willow Springs Township S19 H54,United States House of Representatives,2,Republican,"Jenkins, Lynn",221,120440
+DOUGLAS,Willow Springs Township S3 H45,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",36,120450
+DOUGLAS,Willow Springs Township S3 H45,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,120450
+DOUGLAS,Willow Springs Township S3 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",53,120450
+DOUGLAS,Willow Springs Township S3 H54,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",37,120460
+DOUGLAS,Willow Springs Township S3 H54,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,120460
+DOUGLAS,Willow Springs Township S3 H54,United States House of Representatives,2,Republican,"Jenkins, Lynn",38,120460
+DOUGLAS,East Wakarusa H10 Precinct 65,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",153,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,United States House of Representatives,2,Republican,"Jenkins, Lynn",199,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400010
+DOUGLAS,Lawrence Precinct 47,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",204,400030
+DOUGLAS,Lawrence Precinct 47,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,400030
+DOUGLAS,Lawrence Precinct 47,United States House of Representatives,2,Republican,"Jenkins, Lynn",209,400030
+DOUGLAS,Lawrence Precinct 48,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",539,400040
+DOUGLAS,Lawrence Precinct 48,United States House of Representatives,2,Libertarian,"Hawver, Dennis",22,400040
+DOUGLAS,Lawrence Precinct 48,United States House of Representatives,2,Republican,"Jenkins, Lynn",395,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",357,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",45,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",616,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400110
+DOUGLAS,Lawrence Precinct 68,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900010
+DOUGLAS,Lawrence Precinct 68,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900010
+DOUGLAS,Lawrence Precinct 68,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+DOUGLAS,Lawrence Precinct 69,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900020
+DOUGLAS,Lawrence Precinct 69,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900020
+DOUGLAS,Lawrence Precinct 69,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+DOUGLAS,Lawrence Precinct 70,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",3,900040
+DOUGLAS,Lawrence Precinct 70,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900040
+DOUGLAS,Lawrence Precinct 70,United States House of Representatives,2,Republican,"Jenkins, Lynn",12,900040
+DOUGLAS,Lawrence Precinct 71,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",391,900050
+DOUGLAS,Lawrence Precinct 71,United States House of Representatives,2,Libertarian,"Hawver, Dennis",36,900050
+DOUGLAS,Lawrence Precinct 71,United States House of Representatives,2,Republican,"Jenkins, Lynn",359,900050
+DOUGLAS,Lawrence Precinct 72,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900060
+DOUGLAS,Lawrence Precinct 72,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900060
+DOUGLAS,Lawrence Precinct 72,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900060
+DOUGLAS,Lawrence Precinct 73,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900070
+DOUGLAS,Lawrence Precinct 73,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900070
+DOUGLAS,Lawrence Precinct 73,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900070
+DOUGLAS,Lawrence Precinct 74,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900080
+DOUGLAS,Lawrence Precinct 74,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900080
+DOUGLAS,Lawrence Precinct 74,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",28,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",20,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900170

--- a/2012/20121106__ks__general__edwards__precinct.csv
+++ b/2012/20121106__ks__general__edwards__precinct.csv
@@ -1,0 +1,339 @@
+county,precinct,office,district,party,candidate,votes,vtd
+EDWARDS,Belpre Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",31,000010
+EDWARDS,Belpre Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",45,000010
+EDWARDS,Franklin Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",21,000020
+EDWARDS,Franklin Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",19,000020
+EDWARDS,Jackson Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",12,000030
+EDWARDS,Jackson Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",26,000030
+EDWARDS,Kinsley Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",29,000040
+EDWARDS,Kinsley Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",38,000040
+EDWARDS,Kinsley Ward 1,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",159,000050
+EDWARDS,Kinsley Ward 1,Kansas House of Representatives,117,Republican,"Ewy, John L.",186,000050
+EDWARDS,Kinsley Ward 2,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",143,00006A
+EDWARDS,Kinsley Ward 2,Kansas House of Representatives,117,Republican,"Ewy, John L.",165,00006A
+EDWARDS,Kinsley Ward 2 Exclave,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,Kansas House of Representatives,117,Republican,"Ewy, John L.",0,00006B
+EDWARDS,Lincoln Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",38,000070
+EDWARDS,Lincoln Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",27,000070
+EDWARDS,Logan Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",5,000080
+EDWARDS,Logan Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",15,000080
+EDWARDS,North Brown Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",10,000090
+EDWARDS,North Brown Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",15,000090
+EDWARDS,South Brown Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",29,000100
+EDWARDS,South Brown Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",13,000100
+EDWARDS,Trenton Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",32,000110
+EDWARDS,Trenton Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",108,000110
+EDWARDS,Wayne Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",99,000120
+EDWARDS,Wayne Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",103,000120
+EDWARDS,Belpre Township,Kansas Senate,33,Republican,"Holmes, Mitch",65,000010
+EDWARDS,Franklin Township,Kansas Senate,33,Republican,"Holmes, Mitch",34,000020
+EDWARDS,Jackson Township,Kansas Senate,33,Republican,"Holmes, Mitch",30,000030
+EDWARDS,Kinsley Township,Kansas Senate,33,Republican,"Holmes, Mitch",53,000040
+EDWARDS,Kinsley Ward 1,Kansas Senate,33,Republican,"Holmes, Mitch",275,000050
+EDWARDS,Kinsley Ward 2,Kansas Senate,33,Republican,"Holmes, Mitch",231,00006A
+EDWARDS,Kinsley Ward 2 Exclave,Kansas Senate,33,Republican,"Holmes, Mitch",0,00006B
+EDWARDS,Lincoln Township,Kansas Senate,33,Republican,"Holmes, Mitch",59,000070
+EDWARDS,Logan Township,Kansas Senate,33,Republican,"Holmes, Mitch",16,000080
+EDWARDS,North Brown Township,Kansas Senate,33,Republican,"Holmes, Mitch",23,000090
+EDWARDS,South Brown Township,Kansas Senate,33,Republican,"Holmes, Mitch",34,000100
+EDWARDS,Trenton Township,Kansas Senate,33,Republican,"Holmes, Mitch",112,000110
+EDWARDS,Wayne Township,Kansas Senate,33,Republican,"Holmes, Mitch",158,000120
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+EDWARDS,Belpre Township,President / Vice President,,Democratic,"Obama, Barack",22,000010
+EDWARDS,Belpre Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+EDWARDS,Belpre Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+EDWARDS,Belpre Township,President / Vice President,,Republican,"Romney, Mitt",53,000010
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+EDWARDS,Franklin Township,President / Vice President,,Democratic,"Obama, Barack",0,000020
+EDWARDS,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+EDWARDS,Franklin Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+EDWARDS,Franklin Township,President / Vice President,,Republican,"Romney, Mitt",40,000020
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+EDWARDS,Jackson Township,President / Vice President,,Democratic,"Obama, Barack",3,000030
+EDWARDS,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+EDWARDS,Jackson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+EDWARDS,Jackson Township,President / Vice President,,Republican,"Romney, Mitt",32,000030
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,Democratic,"Obama, Barack",13,000040
+EDWARDS,Kinsley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,Republican,"Romney, Mitt",56,000040
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,Democratic,"Obama, Barack",97,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,Republican,"Romney, Mitt",247,000050
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,Democratic,"Obama, Barack",79,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",5,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",2,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,Republican,"Romney, Mitt",221,00006A
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00006B
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",5,000070
+EDWARDS,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",64,000070
+EDWARDS,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+EDWARDS,Logan Township,President / Vice President,,Democratic,"Obama, Barack",4,000080
+EDWARDS,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+EDWARDS,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+EDWARDS,Logan Township,President / Vice President,,Republican,"Romney, Mitt",16,000080
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+EDWARDS,North Brown Township,President / Vice President,,Democratic,"Obama, Barack",4,000090
+EDWARDS,North Brown Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+EDWARDS,North Brown Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+EDWARDS,North Brown Township,President / Vice President,,Republican,"Romney, Mitt",21,000090
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+EDWARDS,South Brown Township,President / Vice President,,Democratic,"Obama, Barack",2,000100
+EDWARDS,South Brown Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+EDWARDS,South Brown Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+EDWARDS,South Brown Township,President / Vice President,,Republican,"Romney, Mitt",41,000100
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+EDWARDS,Trenton Township,President / Vice President,,Democratic,"Obama, Barack",19,000110
+EDWARDS,Trenton Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000110
+EDWARDS,Trenton Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+EDWARDS,Trenton Township,President / Vice President,,Republican,"Romney, Mitt",115,000110
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+EDWARDS,Wayne Township,President / Vice President,,Democratic,"Obama, Barack",50,000120
+EDWARDS,Wayne Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+EDWARDS,Wayne Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000120
+EDWARDS,Wayne Township,President / Vice President,,Republican,"Romney, Mitt",153,000120
+EDWARDS,Belpre Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",12,000010
+EDWARDS,Belpre Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000010
+EDWARDS,Belpre Township,United States House of Representatives,4,Republican,"Pompeo, Mike",62,000010
+EDWARDS,Franklin Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,000020
+EDWARDS,Franklin Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000020
+EDWARDS,Franklin Township,United States House of Representatives,4,Republican,"Pompeo, Mike",37,000020
+EDWARDS,Jackson Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",6,000030
+EDWARDS,Jackson Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000030
+EDWARDS,Jackson Township,United States House of Representatives,4,Republican,"Pompeo, Mike",29,000030
+EDWARDS,Kinsley Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",12,000040
+EDWARDS,Kinsley Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000040
+EDWARDS,Kinsley Township,United States House of Representatives,4,Republican,"Pompeo, Mike",53,000040
+EDWARDS,Kinsley Ward 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",92,000050
+EDWARDS,Kinsley Ward 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",19,000050
+EDWARDS,Kinsley Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",219,000050
+EDWARDS,Kinsley Ward 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",73,00006A
+EDWARDS,Kinsley Ward 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",20,00006A
+EDWARDS,Kinsley Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",205,00006A
+EDWARDS,Kinsley Ward 2 Exclave,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00006B
+EDWARDS,Lincoln Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",7,000070
+EDWARDS,Lincoln Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000070
+EDWARDS,Lincoln Township,United States House of Representatives,4,Republican,"Pompeo, Mike",55,000070
+EDWARDS,Logan Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",5,000080
+EDWARDS,Logan Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000080
+EDWARDS,Logan Township,United States House of Representatives,4,Republican,"Pompeo, Mike",14,000080
+EDWARDS,North Brown Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000090
+EDWARDS,North Brown Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000090
+EDWARDS,North Brown Township,United States House of Representatives,4,Republican,"Pompeo, Mike",22,000090
+EDWARDS,South Brown Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000100
+EDWARDS,South Brown Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000100
+EDWARDS,South Brown Township,United States House of Representatives,4,Republican,"Pompeo, Mike",39,000100
+EDWARDS,Trenton Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",28,000110
+EDWARDS,Trenton Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000110
+EDWARDS,Trenton Township,United States House of Representatives,4,Republican,"Pompeo, Mike",100,000110
+EDWARDS,Wayne Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",47,000120
+EDWARDS,Wayne Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000120
+EDWARDS,Wayne Township,United States House of Representatives,4,Republican,"Pompeo, Mike",144,000120

--- a/2012/20121106__ks__general__elk__precinct.csv
+++ b/2012/20121106__ks__general__elk__precinct.csv
@@ -1,0 +1,264 @@
+county,precinct,office,district,party,candidate,votes,vtd
+ELK,Elk Falls Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",29,000010
+ELK,Elk Falls Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",71,000010
+ELK,Greenfield Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",122,000020
+ELK,Howard Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",347,000030
+ELK,Liberty Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",44,000040
+ELK,Longton Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",51,000050
+ELK,Longton Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",122,000050
+ELK,Oak Valley Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",12,000060
+ELK,Oak Valley Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",44,000060
+ELK,Painterhood Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",32,000070
+ELK,Paw Paw Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",42,000080
+ELK,Union Center Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",44,000090
+ELK,Wildcat Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",214,000100
+ELK,Elk Falls Township,Kansas Senate,14,Democratic,"Fuson, Eden",21,000010
+ELK,Elk Falls Township,Kansas Senate,14,Republican,"Knox, Forrest J.",81,000010
+ELK,Greenfield Township,Kansas Senate,14,Democratic,"Fuson, Eden",20,000020
+ELK,Greenfield Township,Kansas Senate,14,Republican,"Knox, Forrest J.",125,000020
+ELK,Howard Township,Kansas Senate,14,Democratic,"Fuson, Eden",81,000030
+ELK,Howard Township,Kansas Senate,14,Republican,"Knox, Forrest J.",327,000030
+ELK,Liberty Township,Kansas Senate,14,Democratic,"Fuson, Eden",17,000040
+ELK,Liberty Township,Kansas Senate,14,Republican,"Knox, Forrest J.",25,000040
+ELK,Longton Township,Kansas Senate,14,Democratic,"Fuson, Eden",36,000050
+ELK,Longton Township,Kansas Senate,14,Republican,"Knox, Forrest J.",135,000050
+ELK,Oak Valley Township,Kansas Senate,14,Democratic,"Fuson, Eden",8,000060
+ELK,Oak Valley Township,Kansas Senate,14,Republican,"Knox, Forrest J.",49,000060
+ELK,Painterhood Township,Kansas Senate,14,Democratic,"Fuson, Eden",7,000070
+ELK,Painterhood Township,Kansas Senate,14,Republican,"Knox, Forrest J.",25,000070
+ELK,Paw Paw Township,Kansas Senate,14,Democratic,"Fuson, Eden",3,000080
+ELK,Paw Paw Township,Kansas Senate,14,Republican,"Knox, Forrest J.",44,000080
+ELK,Union Center Township,Kansas Senate,14,Democratic,"Fuson, Eden",11,000090
+ELK,Union Center Township,Kansas Senate,14,Republican,"Knox, Forrest J.",37,000090
+ELK,Wildcat Township,Kansas Senate,14,Democratic,"Fuson, Eden",61,000100
+ELK,Wildcat Township,Kansas Senate,14,Republican,"Knox, Forrest J.",193,000100
+ELK,Elk Falls Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+ELK,Elk Falls Township,President / Vice President,,Democratic,"Obama, Barack",18,000010
+ELK,Elk Falls Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000010
+ELK,Elk Falls Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+ELK,Elk Falls Township,President / Vice President,,Republican,"Romney, Mitt",81,000010
+ELK,Greenfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+ELK,Greenfield Township,President / Vice President,,Democratic,"Obama, Barack",33,000020
+ELK,Greenfield Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+ELK,Greenfield Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+ELK,Greenfield Township,President / Vice President,,Republican,"Romney, Mitt",124,000020
+ELK,Howard Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+ELK,Howard Township,President / Vice President,,Democratic,"Obama, Barack",99,000030
+ELK,Howard Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000030
+ELK,Howard Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+ELK,Howard Township,President / Vice President,,Republican,"Romney, Mitt",312,000030
+ELK,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+ELK,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",5,000040
+ELK,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+ELK,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+ELK,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",39,000040
+ELK,Longton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+ELK,Longton Township,President / Vice President,,Democratic,"Obama, Barack",38,000050
+ELK,Longton Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000050
+ELK,Longton Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+ELK,Longton Township,President / Vice President,,Republican,"Romney, Mitt",138,000050
+ELK,Oak Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+ELK,Oak Valley Township,President / Vice President,,Democratic,"Obama, Barack",9,000060
+ELK,Oak Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+ELK,Oak Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+ELK,Oak Valley Township,President / Vice President,,Republican,"Romney, Mitt",49,000060
+ELK,Painterhood Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+ELK,Painterhood Township,President / Vice President,,Democratic,"Obama, Barack",6,000070
+ELK,Painterhood Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+ELK,Painterhood Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+ELK,Painterhood Township,President / Vice President,,Republican,"Romney, Mitt",27,000070
+ELK,Paw Paw Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+ELK,Paw Paw Township,President / Vice President,,Democratic,"Obama, Barack",7,000080
+ELK,Paw Paw Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000080
+ELK,Paw Paw Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+ELK,Paw Paw Township,President / Vice President,,Republican,"Romney, Mitt",40,000080
+ELK,Union Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+ELK,Union Center Township,President / Vice President,,Democratic,"Obama, Barack",8,000090
+ELK,Union Center Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+ELK,Union Center Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+ELK,Union Center Township,President / Vice President,,Republican,"Romney, Mitt",42,000090
+ELK,Wildcat Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+ELK,Wildcat Township,President / Vice President,,Democratic,"Obama, Barack",58,000100
+ELK,Wildcat Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000100
+ELK,Wildcat Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000100
+ELK,Wildcat Township,President / Vice President,,Republican,"Romney, Mitt",197,000100
+ELK,Elk Falls Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",17,000010
+ELK,Elk Falls Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",12,000010
+ELK,Elk Falls Township,United States House of Representatives,4,Republican,"Pompeo, Mike",77,000010
+ELK,Greenfield Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",29,000020
+ELK,Greenfield Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,000020
+ELK,Greenfield Township,United States House of Representatives,4,Republican,"Pompeo, Mike",111,000020
+ELK,Howard Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",82,000030
+ELK,Howard Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",25,000030
+ELK,Howard Township,United States House of Representatives,4,Republican,"Pompeo, Mike",305,000030
+ELK,Liberty Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",6,000040
+ELK,Liberty Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000040
+ELK,Liberty Township,United States House of Representatives,4,Republican,"Pompeo, Mike",29,000040
+ELK,Longton Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",39,000050
+ELK,Longton Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000050
+ELK,Longton Township,United States House of Representatives,4,Republican,"Pompeo, Mike",125,000050
+ELK,Oak Valley Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",8,000060
+ELK,Oak Valley Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000060
+ELK,Oak Valley Township,United States House of Representatives,4,Republican,"Pompeo, Mike",47,000060
+ELK,Painterhood Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",7,000070
+ELK,Painterhood Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000070
+ELK,Painterhood Township,United States House of Representatives,4,Republican,"Pompeo, Mike",23,000070
+ELK,Paw Paw Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",5,000080
+ELK,Paw Paw Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000080
+ELK,Paw Paw Township,United States House of Representatives,4,Republican,"Pompeo, Mike",39,000080
+ELK,Union Center Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",11,000090
+ELK,Union Center Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000090
+ELK,Union Center Township,United States House of Representatives,4,Republican,"Pompeo, Mike",37,000090
+ELK,Wildcat Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",57,000100
+ELK,Wildcat Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",19,000100
+ELK,Wildcat Township,United States House of Representatives,4,Republican,"Pompeo, Mike",183,000100

--- a/2012/20121106__ks__general__ellis__precinct.csv
+++ b/2012/20121106__ks__general__ellis__precinct.csv
@@ -1,0 +1,1101 @@
+county,precinct,office,district,party,candidate,votes,vtd
+ELLIS,Buckeye Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",61,000010
+ELLIS,Buckeye Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",136,000010
+ELLIS,Catherine Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",53,000020
+ELLIS,Catherine Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",90,000020
+ELLIS,East Big Creek Township,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",140,000030
+ELLIS,East Big Creek Township,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",236,000030
+ELLIS,Ellis Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",113,000040
+ELLIS,Ellis Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",82,000040
+ELLIS,Ellis Ward 1,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",165,000050
+ELLIS,Ellis Ward 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",127,000050
+ELLIS,Ellis Ward 2,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",238,000060
+ELLIS,Ellis Ward 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",146,000060
+ELLIS,Ellis Ward 3,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",125,000070
+ELLIS,Ellis Ward 3,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",76,000070
+ELLIS,Freedom Township,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",18,000080
+ELLIS,Freedom Township,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",36,000080
+ELLIS,Hays Ward 1 Precinct 1,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",101,000090
+ELLIS,Hays Ward 1 Precinct 1,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",102,000090
+ELLIS,Hays Ward 1 Precinct 2,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",115,00010A
+ELLIS,Hays Ward 1 Precinct 2,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",149,00010A
+ELLIS,Hays Ward 2 Precinct 1,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",237,000110
+ELLIS,Hays Ward 2 Precinct 1,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",224,000110
+ELLIS,Hays Ward 2 Precinct 2,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",203,000120
+ELLIS,Hays Ward 2 Precinct 2,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",195,000120
+ELLIS,Hays Ward 2 Precinct 3,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",164,000130
+ELLIS,Hays Ward 2 Precinct 3,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",132,000130
+ELLIS,Hays Ward 2 Precinct 4,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",169,000140
+ELLIS,Hays Ward 2 Precinct 4,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",194,000140
+ELLIS,Hays Ward 2 Precinct 5,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",127,000150
+ELLIS,Hays Ward 2 Precinct 5,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",125,000150
+ELLIS,Hays Ward 3 Precinct 1,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",180,00016A
+ELLIS,Hays Ward 3 Precinct 1,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",222,00016A
+ELLIS,Hays Ward 3 Precinct 2,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",267,000170
+ELLIS,Hays Ward 3 Precinct 2,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",328,000170
+ELLIS,Hays Ward 3 Precinct 3,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",310,000180
+ELLIS,Hays Ward 3 Precinct 3,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",343,000180
+ELLIS,Hays Ward 3 Precinct 4,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",499,00019A
+ELLIS,Hays Ward 3 Precinct 4,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",638,00019A
+ELLIS,Hays Ward 4 Precinct 1,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",203,000200
+ELLIS,Hays Ward 4 Precinct 1,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",256,000200
+ELLIS,Hays Ward 4 Precinct 2,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",259,00021A
+ELLIS,Hays Ward 4 Precinct 2,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",308,00021A
+ELLIS,Hays Ward 4 Precinct 3,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",261,000220
+ELLIS,Hays Ward 4 Precinct 3,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",288,000220
+ELLIS,Hays Ward 4 Precinct 4,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",398,000230
+ELLIS,Hays Ward 4 Precinct 4,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",485,000230
+ELLIS,Hays Ward 4 Precinct 5,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",262,000240
+ELLIS,Hays Ward 4 Precinct 5,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",342,000240
+ELLIS,South Lookout Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",56,000280
+ELLIS,South Lookout Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",69,000280
+ELLIS,Victoria Township,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",153,000290
+ELLIS,Victoria Township,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",251,000290
+ELLIS,Wheatland Township,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",76,000310
+ELLIS,Wheatland Township,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",114,000310
+ELLIS,Herzog Township H110,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",30,120020
+ELLIS,Herzog Township H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",92,120020
+ELLIS,Herzog Township H111,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",96,120030
+ELLIS,Herzog Township H111,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",140,120030
+ELLIS,North Big Creek Township H110,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",30,120040
+ELLIS,North Big Creek Township H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",56,120040
+ELLIS,North Big Creek Township H111,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",105,120050
+ELLIS,North Big Creek Township H111,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",164,120050
+ELLIS,North Lookout Township H110,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",35,120060
+ELLIS,North Lookout Township H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",38,120060
+ELLIS,North Lookout Township H111,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",31,120070
+ELLIS,North Lookout Township H111,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",59,120070
+ELLIS,West Big Creek Township H110,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",8,120080
+ELLIS,West Big Creek Township H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",31,120080
+ELLIS,West Big Creek Township H111,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",13,120090
+ELLIS,West Big Creek Township H111,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",21,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900040
+ELLIS,North Big Creek Township Enclave 1,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",0,900050
+ELLIS,North Big Creek Township Enclave 1,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900050
+ELLIS,North Big Creek Township Enclave 2,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",0,900060
+ELLIS,North Big Creek Township Enclave 2,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900060
+ELLIS,North Big Creek Township Enclave 3,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",0,900070
+ELLIS,North Big Creek Township Enclave 3,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900070
+ELLIS,North Big Creek Township Enclave 4,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",0,900080
+ELLIS,North Big Creek Township Enclave 4,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,900080
+ELLIS,PROVISIONAL,Kansas House of Representatives,111,Democratic,"Phelps, Eber E.",0,999999
+ELLIS,PROVISIONAL,Kansas House of Representatives,111,Republican,"Boldra, Sue E.",0,999999
+ELLIS,Buckeye Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",89,000010
+ELLIS,Buckeye Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",112,000010
+ELLIS,Catherine Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",69,000020
+ELLIS,Catherine Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",77,000020
+ELLIS,East Big Creek Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",162,000030
+ELLIS,East Big Creek Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",209,000030
+ELLIS,Ellis Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",87,000040
+ELLIS,Ellis Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",109,000040
+ELLIS,Ellis Ward 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",111,000050
+ELLIS,Ellis Ward 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",169,000050
+ELLIS,Ellis Ward 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",144,000060
+ELLIS,Ellis Ward 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",231,000060
+ELLIS,Ellis Ward 3,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",72,000070
+ELLIS,Ellis Ward 3,Kansas Senate,40,Republican,"Ostmeyer, Ralph",127,000070
+ELLIS,Freedom Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",23,000080
+ELLIS,Freedom Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",30,000080
+ELLIS,Hays Ward 1 Precinct 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",114,000090
+ELLIS,Hays Ward 1 Precinct 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",85,000090
+ELLIS,Hays Ward 1 Precinct 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",134,00010A
+ELLIS,Hays Ward 1 Precinct 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",118,00010A
+ELLIS,Hays Ward 2 Precinct 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",246,000110
+ELLIS,Hays Ward 2 Precinct 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",210,000110
+ELLIS,Hays Ward 2 Precinct 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",234,000120
+ELLIS,Hays Ward 2 Precinct 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",154,000120
+ELLIS,Hays Ward 2 Precinct 3,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",172,000130
+ELLIS,Hays Ward 2 Precinct 3,Kansas Senate,40,Republican,"Ostmeyer, Ralph",121,000130
+ELLIS,Hays Ward 2 Precinct 4,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",186,000140
+ELLIS,Hays Ward 2 Precinct 4,Kansas Senate,40,Republican,"Ostmeyer, Ralph",178,000140
+ELLIS,Hays Ward 2 Precinct 5,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",143,000150
+ELLIS,Hays Ward 2 Precinct 5,Kansas Senate,40,Republican,"Ostmeyer, Ralph",105,000150
+ELLIS,Hays Ward 3 Precinct 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",197,00016A
+ELLIS,Hays Ward 3 Precinct 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",199,00016A
+ELLIS,Hays Ward 3 Precinct 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",300,000170
+ELLIS,Hays Ward 3 Precinct 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",283,000170
+ELLIS,Hays Ward 3 Precinct 3,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",324,000180
+ELLIS,Hays Ward 3 Precinct 3,Kansas Senate,40,Republican,"Ostmeyer, Ralph",315,000180
+ELLIS,Hays Ward 3 Precinct 4,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",499,00019A
+ELLIS,Hays Ward 3 Precinct 4,Kansas Senate,40,Republican,"Ostmeyer, Ralph",626,00019A
+ELLIS,Hays Ward 4 Precinct 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",250,000200
+ELLIS,Hays Ward 4 Precinct 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",201,000200
+ELLIS,Hays Ward 4 Precinct 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",313,00021A
+ELLIS,Hays Ward 4 Precinct 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",244,00021A
+ELLIS,Hays Ward 4 Precinct 3,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",281,000220
+ELLIS,Hays Ward 4 Precinct 3,Kansas Senate,40,Republican,"Ostmeyer, Ralph",261,000220
+ELLIS,Hays Ward 4 Precinct 4,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",463,000230
+ELLIS,Hays Ward 4 Precinct 4,Kansas Senate,40,Republican,"Ostmeyer, Ralph",402,000230
+ELLIS,Hays Ward 4 Precinct 5,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",285,000240
+ELLIS,Hays Ward 4 Precinct 5,Kansas Senate,40,Republican,"Ostmeyer, Ralph",300,000240
+ELLIS,South Lookout Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",71,000280
+ELLIS,South Lookout Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",54,000280
+ELLIS,Victoria Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",179,000290
+ELLIS,Victoria Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",221,000290
+ELLIS,Wheatland Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",92,000310
+ELLIS,Wheatland Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",94,000310
+ELLIS,Herzog Township H110,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",53,120020
+ELLIS,Herzog Township H110,Kansas Senate,40,Republican,"Ostmeyer, Ralph",71,120020
+ELLIS,Herzog Township H111,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",115,120030
+ELLIS,Herzog Township H111,Kansas Senate,40,Republican,"Ostmeyer, Ralph",116,120030
+ELLIS,North Big Creek Township H110,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",39,120040
+ELLIS,North Big Creek Township H110,Kansas Senate,40,Republican,"Ostmeyer, Ralph",48,120040
+ELLIS,North Big Creek Township H111,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",126,120050
+ELLIS,North Big Creek Township H111,Kansas Senate,40,Republican,"Ostmeyer, Ralph",139,120050
+ELLIS,North Lookout Township H110,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",35,120060
+ELLIS,North Lookout Township H110,Kansas Senate,40,Republican,"Ostmeyer, Ralph",40,120060
+ELLIS,North Lookout Township H111,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",40,120070
+ELLIS,North Lookout Township H111,Kansas Senate,40,Republican,"Ostmeyer, Ralph",49,120070
+ELLIS,West Big Creek Township H110,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",14,120080
+ELLIS,West Big Creek Township H110,Kansas Senate,40,Republican,"Ostmeyer, Ralph",27,120080
+ELLIS,West Big Creek Township H111,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",16,120090
+ELLIS,West Big Creek Township H111,Kansas Senate,40,Republican,"Ostmeyer, Ralph",16,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,900040
+ELLIS,North Big Creek Township Enclave 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,900050
+ELLIS,North Big Creek Township Enclave 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,900050
+ELLIS,North Big Creek Township Enclave 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,900060
+ELLIS,North Big Creek Township Enclave 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,900060
+ELLIS,North Big Creek Township Enclave 3,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,900070
+ELLIS,North Big Creek Township Enclave 3,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,900070
+ELLIS,North Big Creek Township Enclave 4,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,900080
+ELLIS,North Big Creek Township Enclave 4,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,900080
+ELLIS,PROVISIONAL,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,999999
+ELLIS,PROVISIONAL,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,999999
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+ELLIS,Buckeye Township,President / Vice President,,Democratic,"Obama, Barack",31,000010
+ELLIS,Buckeye Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+ELLIS,Buckeye Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+ELLIS,Buckeye Township,President / Vice President,,Republican,"Romney, Mitt",170,000010
+ELLIS,Catherine Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+ELLIS,Catherine Township,President / Vice President,,Democratic,"Obama, Barack",20,000020
+ELLIS,Catherine Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000020
+ELLIS,Catherine Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000020
+ELLIS,Catherine Township,President / Vice President,,Republican,"Romney, Mitt",124,000020
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,Democratic,"Obama, Barack",68,000030
+ELLIS,East Big Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+ELLIS,East Big Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,Republican,"Romney, Mitt",311,000030
+ELLIS,Ellis Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+ELLIS,Ellis Township,President / Vice President,,Democratic,"Obama, Barack",50,000040
+ELLIS,Ellis Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+ELLIS,Ellis Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+ELLIS,Ellis Township,President / Vice President,,Republican,"Romney, Mitt",148,000040
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,Democratic,"Obama, Barack",73,000050
+ELLIS,Ellis Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",6,000050
+ELLIS,Ellis Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",6,000050
+ELLIS,Ellis Ward 1,President / Vice President,,Republican,"Romney, Mitt",207,000050
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,Democratic,"Obama, Barack",114,000060
+ELLIS,Ellis Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",4,000060
+ELLIS,Ellis Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+ELLIS,Ellis Ward 2,President / Vice President,,Republican,"Romney, Mitt",266,000060
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,Democratic,"Obama, Barack",57,000070
+ELLIS,Ellis Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",7,000070
+ELLIS,Ellis Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+ELLIS,Ellis Ward 3,President / Vice President,,Republican,"Romney, Mitt",139,000070
+ELLIS,Freedom Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+ELLIS,Freedom Township,President / Vice President,,Democratic,"Obama, Barack",12,000080
+ELLIS,Freedom Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+ELLIS,Freedom Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+ELLIS,Freedom Township,President / Vice President,,Republican,"Romney, Mitt",42,000080
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",1,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",83,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",15,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",107,000090
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",1,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",97,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",5,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",158,00010A
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",169,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",11,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",285,000110
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",1,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",164,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",10,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",231,000120
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",103,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",10,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",4,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",178,000130
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Goode, Virgil",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Stein, Jill E",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,Democratic,"Obama, Barack",129,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",13,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,Republican,"Romney, Mitt",224,000140
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Barnett, Andre",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Bush, Kent W",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Christensen, Will",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Goode, Virgil",1,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Stein, Jill E",3,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,Democratic,"Obama, Barack",77,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",6,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,Reform,"Baldwin, Chuck",4,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,Republican,"Romney, Mitt",160,000150
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",126,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",6,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",273,00016A
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",158,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",437,000170
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",138,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",6,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",514,000180
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Goode, Virgil",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Stein, Jill E",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,Democratic,"Obama, Barack",279,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",14,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,Republican,"Romney, Mitt",860,00019A
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",126,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",3,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",323,000200
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",168,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",13,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",382,00021A
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",142,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",3,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",3,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",407,000220
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Goode, Virgil",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Stein, Jill E",1,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,Democratic,"Obama, Barack",224,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",12,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",3,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,Republican,"Romney, Mitt",642,000230
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Barnett, Andre",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Bush, Kent W",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Christensen, Will",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Goode, Virgil",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Stein, Jill E",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,Democratic,"Obama, Barack",146,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",8,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,Reform,"Baldwin, Chuck",2,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,Republican,"Romney, Mitt",451,000240
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Barnett, Andre",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Bush, Kent W",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Christensen, Will",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Goode, Virgil",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Stein, Jill E",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+ELLIS,South Lookout Township,President / Vice President,,Democratic,"Obama, Barack",30,000280
+ELLIS,South Lookout Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000280
+ELLIS,South Lookout Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000280
+ELLIS,South Lookout Township,President / Vice President,,Republican,"Romney, Mitt",96,000280
+ELLIS,Victoria Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Barnett, Andre",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Bush, Kent W",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Christensen, Will",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Goode, Virgil",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Stein, Jill E",1,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+ELLIS,Victoria Township,President / Vice President,,Democratic,"Obama, Barack",72,000290
+ELLIS,Victoria Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000290
+ELLIS,Victoria Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000290
+ELLIS,Victoria Township,President / Vice President,,Republican,"Romney, Mitt",329,000290
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Barnett, Andre",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Bush, Kent W",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Christensen, Will",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Goode, Virgil",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Stein, Jill E",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+ELLIS,Wheatland Township,President / Vice President,,Democratic,"Obama, Barack",27,000310
+ELLIS,Wheatland Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000310
+ELLIS,Wheatland Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000310
+ELLIS,Wheatland Township,President / Vice President,,Republican,"Romney, Mitt",153,000310
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Barnett, Andre",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Bush, Kent W",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Christensen, Will",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Goode, Virgil",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Stein, Jill E",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,Democratic,"Obama, Barack",14,120020
+ELLIS,Herzog Township H110,President / Vice President,,Libertarian,"Johnson, Gary",2,120020
+ELLIS,Herzog Township H110,President / Vice President,,Reform,"Baldwin, Chuck",1,120020
+ELLIS,Herzog Township H110,President / Vice President,,Republican,"Romney, Mitt",112,120020
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Barnett, Andre",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Bush, Kent W",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Christensen, Will",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Goode, Virgil",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Stein, Jill E",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,Democratic,"Obama, Barack",61,120030
+ELLIS,Herzog Township H111,President / Vice President,,Libertarian,"Johnson, Gary",2,120030
+ELLIS,Herzog Township H111,President / Vice President,,Reform,"Baldwin, Chuck",1,120030
+ELLIS,Herzog Township H111,President / Vice President,,Republican,"Romney, Mitt",177,120030
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Barnett, Andre",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Bush, Kent W",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Christensen, Will",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Goode, Virgil",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Stein, Jill E",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,Democratic,"Obama, Barack",18,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,Libertarian,"Johnson, Gary",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,Reform,"Baldwin, Chuck",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,Republican,"Romney, Mitt",71,120040
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Barnett, Andre",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Bush, Kent W",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Christensen, Will",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Goode, Virgil",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Stein, Jill E",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,Democratic,"Obama, Barack",45,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,Libertarian,"Johnson, Gary",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,Reform,"Baldwin, Chuck",1,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,Republican,"Romney, Mitt",224,120050
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Ayers, Avery L",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Barnett, Andre",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Barr, Roseanne C",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Bush, Kent W",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Christensen, Will",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Duncan, Richard A",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Goode, Virgil",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Knill, Dennis J",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Reed, Jill A.",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Rogers, Rick L",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Stein, Jill E",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Thorne, Kevin M",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Warner, Gerald L.",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,Democratic,"Obama, Barack",12,120060
+ELLIS,North Lookout Township H110,President / Vice President,,Libertarian,"Johnson, Gary",5,120060
+ELLIS,North Lookout Township H110,President / Vice President,,Reform,"Baldwin, Chuck",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,Republican,"Romney, Mitt",59,120060
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Ayers, Avery L",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Barnett, Andre",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Barr, Roseanne C",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Bush, Kent W",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Christensen, Will",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Duncan, Richard A",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Goode, Virgil",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Knill, Dennis J",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Reed, Jill A.",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Rogers, Rick L",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Stein, Jill E",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Thorne, Kevin M",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Warner, Gerald L.",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,Democratic,"Obama, Barack",15,120070
+ELLIS,North Lookout Township H111,President / Vice President,,Libertarian,"Johnson, Gary",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,Reform,"Baldwin, Chuck",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,Republican,"Romney, Mitt",75,120070
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Ayers, Avery L",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Barnett, Andre",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Barr, Roseanne C",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Bush, Kent W",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Christensen, Will",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Duncan, Richard A",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Goode, Virgil",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Knill, Dennis J",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Reed, Jill A.",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Rogers, Rick L",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Stein, Jill E",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Thorne, Kevin M",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Warner, Gerald L.",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,Democratic,"Obama, Barack",6,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,Libertarian,"Johnson, Gary",3,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,Reform,"Baldwin, Chuck",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,Republican,"Romney, Mitt",34,120080
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Ayers, Avery L",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Barnett, Andre",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Barr, Roseanne C",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Bush, Kent W",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Christensen, Will",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Duncan, Richard A",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Goode, Virgil",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Knill, Dennis J",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Reed, Jill A.",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Rogers, Rick L",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Stein, Jill E",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Thorne, Kevin M",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Warner, Gerald L.",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,Democratic,"Obama, Barack",3,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,Libertarian,"Johnson, Gary",1,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,Reform,"Baldwin, Chuck",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,Republican,"Romney, Mitt",30,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Christensen, Will",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Christensen, Will",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Christensen, Will",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Christensen, Will",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900040
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Christensen, Will",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900050
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Christensen, Will",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900060
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Ayers, Avery L",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Barnett, Andre",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Barr, Roseanne C",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Bush, Kent W",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Christensen, Will",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Duncan, Richard A",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Goode, Virgil",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Hoefling, Tom",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Knill, Dennis J",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Reed, Jill A.",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Rogers, Rick L",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Stein, Jill E",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Thorne, Kevin M",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Warner, Gerald L.",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,Democratic,"Obama, Barack",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,Libertarian,"Johnson, Gary",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,Reform,"Baldwin, Chuck",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,Republican,"Romney, Mitt",0,900070
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Ayers, Avery L",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Barnett, Andre",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Barr, Roseanne C",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Bush, Kent W",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Christensen, Will",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Duncan, Richard A",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Goode, Virgil",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Hoefling, Tom",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Knill, Dennis J",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Reed, Jill A.",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Rogers, Rick L",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Stein, Jill E",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Thorne, Kevin M",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Warner, Gerald L.",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,Democratic,"Obama, Barack",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,Libertarian,"Johnson, Gary",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,Reform,"Baldwin, Chuck",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,Republican,"Romney, Mitt",0,900080
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Ayers, Avery L",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Barnett, Andre",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Barr, Roseanne C",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Bush, Kent W",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Christensen, Will",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Duncan, Richard A",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Goode, Virgil",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Hoefling, Tom",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Knill, Dennis J",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Reed, Jill A.",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Rogers, Rick L",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Stein, Jill E",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Thorne, Kevin M",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,write - in,"Warner, Gerald L.",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,Democratic,"Obama, Barack",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,Libertarian,"Johnson, Gary",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,Reform,"Baldwin, Chuck",0,999999
+ELLIS,PROVISIONAL,President / Vice President,,Republican,"Romney, Mitt",0,999999
+ELLIS,Buckeye Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",173,000010
+ELLIS,Catherine Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",115,000020
+ELLIS,East Big Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",314,000030
+ELLIS,Ellis Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",158,000040
+ELLIS,Ellis Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",235,000050
+ELLIS,Ellis Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",315,000060
+ELLIS,Ellis Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",173,000070
+ELLIS,Freedom Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000080
+ELLIS,Hays Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",144,000090
+ELLIS,Hays Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",207,00010A
+ELLIS,Hays Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",343,000110
+ELLIS,Hays Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",276,000120
+ELLIS,Hays Ward 2 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",220,000130
+ELLIS,Hays Ward 2 Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",277,000140
+ELLIS,Hays Ward 2 Precinct 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",208,000150
+ELLIS,Hays Ward 3 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",290,00016A
+ELLIS,Hays Ward 3 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",464,000170
+ELLIS,Hays Ward 3 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",534,000180
+ELLIS,Hays Ward 3 Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",879,00019A
+ELLIS,Hays Ward 4 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",367,000200
+ELLIS,Hays Ward 4 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",467,00021A
+ELLIS,Hays Ward 4 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",442,000220
+ELLIS,Hays Ward 4 Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",685,000230
+ELLIS,Hays Ward 4 Precinct 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",488,000240
+ELLIS,South Lookout Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",105,000280
+ELLIS,Victoria Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",327,000290
+ELLIS,Wheatland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",158,000310
+ELLIS,Herzog Township H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",122,120020
+ELLIS,Herzog Township H111,United States House of Representatives,1,Republican,"Huelskamp, Tim",183,120030
+ELLIS,North Big Creek Township H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",75,120040
+ELLIS,North Big Creek Township H111,United States House of Representatives,1,Republican,"Huelskamp, Tim",222,120050
+ELLIS,North Lookout Township H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",64,120060
+ELLIS,North Lookout Township H111,United States House of Representatives,1,Republican,"Huelskamp, Tim",72,120070
+ELLIS,West Big Creek Township H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,120080
+ELLIS,West Big Creek Township H111,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900040
+ELLIS,North Big Creek Township Enclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900050
+ELLIS,North Big Creek Township Enclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900060
+ELLIS,North Big Creek Township Enclave 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900070
+ELLIS,North Big Creek Township Enclave 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900080
+ELLIS,PROVISIONAL,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,999999

--- a/2012/20121106__ks__general__ellsworth__precinct.csv
+++ b/2012/20121106__ks__general__ellsworth__precinct.csv
@@ -1,0 +1,601 @@
+county,precinct,office,district,party,candidate,votes,vtd
+ELLSWORTH,Ash Creek Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",27,000010
+ELLSWORTH,Black Wolf Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",36,000020
+ELLSWORTH,Buckeye Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",29,000030
+ELLSWORTH,Carneiro Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",18,000040
+ELLSWORTH,Clear Creek Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",48,000050
+ELLSWORTH,Columbia Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",21,000060
+ELLSWORTH,Ellsworth City East Ward 1,Kansas House of Representatives,108,Republican,"Johnson, Steven",266,000070
+ELLSWORTH,Ellsworth City East Ward 2,Kansas House of Representatives,108,Republican,"Johnson, Steven",264,000080
+ELLSWORTH,Ellsworth City West,Kansas House of Representatives,108,Republican,"Johnson, Steven",273,00009A
+ELLSWORTH,Canren Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",32,00009B
+ELLSWORTH,Ellsworth Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",84,000100
+ELLSWORTH,Garfield Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",28,000110
+ELLSWORTH,Green Garden Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",72,000120
+ELLSWORTH,Kanopolis Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",203,000130
+ELLSWORTH,Langley Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",36,000140
+ELLSWORTH,Lincoln Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",26,000150
+ELLSWORTH,Mulberry Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",17,000160
+ELLSWORTH,Noble Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",25,000170
+ELLSWORTH,Palacky Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",32,000180
+ELLSWORTH,Sherman Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",34,000190
+ELLSWORTH,Thomas Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",29,000200
+ELLSWORTH,Trivoli Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",20,000210
+ELLSWORTH,Valley Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",205,000220
+ELLSWORTH,Venango Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",53,000230
+ELLSWORTH,Wilson Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",323,000240
+ELLSWORTH,Ash Creek Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",2,000010
+ELLSWORTH,Ash Creek Township,Kansas Senate,35,Republican,"Emler, Jay Scott",30,000010
+ELLSWORTH,Black Wolf Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",8,000020
+ELLSWORTH,Black Wolf Township,Kansas Senate,35,Republican,"Emler, Jay Scott",36,000020
+ELLSWORTH,Buckeye Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",4,000030
+ELLSWORTH,Buckeye Township,Kansas Senate,35,Republican,"Emler, Jay Scott",30,000030
+ELLSWORTH,Carneiro Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",5,000040
+ELLSWORTH,Carneiro Township,Kansas Senate,35,Republican,"Emler, Jay Scott",16,000040
+ELLSWORTH,Clear Creek Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",9,000050
+ELLSWORTH,Clear Creek Township,Kansas Senate,35,Republican,"Emler, Jay Scott",51,000050
+ELLSWORTH,Columbia Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",5,000060
+ELLSWORTH,Columbia Township,Kansas Senate,35,Republican,"Emler, Jay Scott",16,000060
+ELLSWORTH,Ellsworth City East Ward 1,Kansas Senate,35,Libertarian,"Bryant, Jesse",53,000070
+ELLSWORTH,Ellsworth City East Ward 1,Kansas Senate,35,Republican,"Emler, Jay Scott",262,000070
+ELLSWORTH,Ellsworth City East Ward 2,Kansas Senate,35,Libertarian,"Bryant, Jesse",39,000080
+ELLSWORTH,Ellsworth City East Ward 2,Kansas Senate,35,Republican,"Emler, Jay Scott",246,000080
+ELLSWORTH,Ellsworth City West,Kansas Senate,35,Libertarian,"Bryant, Jesse",56,00009A
+ELLSWORTH,Ellsworth City West,Kansas Senate,35,Republican,"Emler, Jay Scott",259,00009A
+ELLSWORTH,Canren Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",4,00009B
+ELLSWORTH,Canren Township,Kansas Senate,35,Republican,"Emler, Jay Scott",36,00009B
+ELLSWORTH,Ellsworth Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",5,000100
+ELLSWORTH,Ellsworth Township,Kansas Senate,35,Republican,"Emler, Jay Scott",87,000100
+ELLSWORTH,Garfield Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",3,000110
+ELLSWORTH,Garfield Township,Kansas Senate,35,Republican,"Emler, Jay Scott",26,000110
+ELLSWORTH,Green Garden Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",11,000120
+ELLSWORTH,Green Garden Township,Kansas Senate,35,Republican,"Emler, Jay Scott",68,000120
+ELLSWORTH,Kanopolis Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",41,000130
+ELLSWORTH,Kanopolis Township,Kansas Senate,35,Republican,"Emler, Jay Scott",188,000130
+ELLSWORTH,Langley Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",6,000140
+ELLSWORTH,Langley Township,Kansas Senate,35,Republican,"Emler, Jay Scott",34,000140
+ELLSWORTH,Lincoln Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",10,000150
+ELLSWORTH,Lincoln Township,Kansas Senate,35,Republican,"Emler, Jay Scott",18,000150
+ELLSWORTH,Mulberry Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",0,000160
+ELLSWORTH,Mulberry Township,Kansas Senate,35,Republican,"Emler, Jay Scott",18,000160
+ELLSWORTH,Noble Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",9,000170
+ELLSWORTH,Noble Township,Kansas Senate,35,Republican,"Emler, Jay Scott",22,000170
+ELLSWORTH,Palacky Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",6,000180
+ELLSWORTH,Palacky Township,Kansas Senate,35,Republican,"Emler, Jay Scott",27,000180
+ELLSWORTH,Sherman Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",0,000190
+ELLSWORTH,Sherman Township,Kansas Senate,35,Republican,"Emler, Jay Scott",35,000190
+ELLSWORTH,Thomas Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",4,000200
+ELLSWORTH,Thomas Township,Kansas Senate,35,Republican,"Emler, Jay Scott",31,000200
+ELLSWORTH,Trivoli Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",3,000210
+ELLSWORTH,Trivoli Township,Kansas Senate,35,Republican,"Emler, Jay Scott",21,000210
+ELLSWORTH,Valley Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",37,000220
+ELLSWORTH,Valley Township,Kansas Senate,35,Republican,"Emler, Jay Scott",186,000220
+ELLSWORTH,Venango Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",11,000230
+ELLSWORTH,Venango Township,Kansas Senate,35,Republican,"Emler, Jay Scott",49,000230
+ELLSWORTH,Wilson Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",70,000240
+ELLSWORTH,Wilson Township,Kansas Senate,35,Republican,"Emler, Jay Scott",292,000240
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,Democratic,"Obama, Barack",3,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,Republican,"Romney, Mitt",30,000010
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,Democratic,"Obama, Barack",13,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,Republican,"Romney, Mitt",36,000020
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,Democratic,"Obama, Barack",7,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,Republican,"Romney, Mitt",30,000030
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,Democratic,"Obama, Barack",2,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,Republican,"Romney, Mitt",18,000040
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,Democratic,"Obama, Barack",19,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,Republican,"Romney, Mitt",46,000050
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,Democratic,"Obama, Barack",3,000060
+ELLSWORTH,Columbia Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,Republican,"Romney, Mitt",22,000060
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Goode, Virgil",1,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,Democratic,"Obama, Barack",99,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",7,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,Republican,"Romney, Mitt",232,000070
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,Democratic,"Obama, Barack",97,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,Republican,"Romney, Mitt",209,000080
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Ayers, Avery L",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Barnett, Andre",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Barr, Roseanne C",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Bush, Kent W",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Christensen, Will",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Duncan, Richard A",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Goode, Virgil",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Hoefling, Tom",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Knill, Dennis J",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Reed, Jill A.",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Rogers, Rick L",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Stein, Jill E",1,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Thorne, Kevin M",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Warner, Gerald L.",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,Democratic,"Obama, Barack",92,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,Libertarian,"Johnson, Gary",9,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,Reform,"Baldwin, Chuck",2,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,Republican,"Romney, Mitt",244,00009A
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Ayers, Avery L",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Barnett, Andre",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Bush, Kent W",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Christensen, Will",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Duncan, Richard A",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Goode, Virgil",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Hoefling, Tom",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Knill, Dennis J",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Reed, Jill A.",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Rogers, Rick L",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Stein, Jill E",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,Democratic,"Obama, Barack",19,00009B
+ELLSWORTH,Canren Township,President / Vice President,,Libertarian,"Johnson, Gary",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,Reform,"Baldwin, Chuck",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,Republican,"Romney, Mitt",25,00009B
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,Democratic,"Obama, Barack",23,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,Republican,"Romney, Mitt",74,000100
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,Democratic,"Obama, Barack",3,000110
+ELLSWORTH,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+ELLSWORTH,Garfield Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,Republican,"Romney, Mitt",26,000110
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,Democratic,"Obama, Barack",15,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,Republican,"Romney, Mitt",75,000120
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,Democratic,"Obama, Barack",84,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,Republican,"Romney, Mitt",174,000130
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,Democratic,"Obama, Barack",6,000140
+ELLSWORTH,Langley Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000140
+ELLSWORTH,Langley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,Republican,"Romney, Mitt",31,000140
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",6,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",21,000150
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,Democratic,"Obama, Barack",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,Republican,"Romney, Mitt",16,000160
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,Democratic,"Obama, Barack",8,000170
+ELLSWORTH,Noble Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000170
+ELLSWORTH,Noble Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000170
+ELLSWORTH,Noble Township,President / Vice President,,Republican,"Romney, Mitt",24,000170
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,Democratic,"Obama, Barack",7,000180
+ELLSWORTH,Palacky Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+ELLSWORTH,Palacky Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,Republican,"Romney, Mitt",27,000180
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,Democratic,"Obama, Barack",2,000190
+ELLSWORTH,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+ELLSWORTH,Sherman Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000190
+ELLSWORTH,Sherman Township,President / Vice President,,Republican,"Romney, Mitt",34,000190
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,Democratic,"Obama, Barack",2,000200
+ELLSWORTH,Thomas Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,Republican,"Romney, Mitt",35,000200
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,Democratic,"Obama, Barack",6,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,Republican,"Romney, Mitt",20,000210
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,Democratic,"Obama, Barack",50,000220
+ELLSWORTH,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000220
+ELLSWORTH,Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000220
+ELLSWORTH,Valley Township,President / Vice President,,Republican,"Romney, Mitt",178,000220
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,Democratic,"Obama, Barack",18,000230
+ELLSWORTH,Venango Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000230
+ELLSWORTH,Venango Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,Republican,"Romney, Mitt",46,000230
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,Democratic,"Obama, Barack",118,000240
+ELLSWORTH,Wilson Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000240
+ELLSWORTH,Wilson Township,President / Vice President,,Reform,"Baldwin, Chuck",6,000240
+ELLSWORTH,Wilson Township,President / Vice President,,Republican,"Romney, Mitt",257,000240
+ELLSWORTH,Ash Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000010
+ELLSWORTH,Black Wolf Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000020
+ELLSWORTH,Buckeye Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000030
+ELLSWORTH,Carneiro Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000040
+ELLSWORTH,Clear Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000050
+ELLSWORTH,Columbia Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000060
+ELLSWORTH,Ellsworth City East Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",252,000070
+ELLSWORTH,Ellsworth City East Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",236,000080
+ELLSWORTH,Ellsworth City West,United States House of Representatives,1,Republican,"Huelskamp, Tim",267,00009A
+ELLSWORTH,Canren Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,00009B
+ELLSWORTH,Ellsworth Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",80,000100
+ELLSWORTH,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000110
+ELLSWORTH,Green Garden Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",75,000120
+ELLSWORTH,Kanopolis Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",187,000130
+ELLSWORTH,Langley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000140
+ELLSWORTH,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000150
+ELLSWORTH,Mulberry Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000160
+ELLSWORTH,Noble Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000170
+ELLSWORTH,Palacky Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000180
+ELLSWORTH,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000190
+ELLSWORTH,Thomas Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000200
+ELLSWORTH,Trivoli Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000210
+ELLSWORTH,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",204,000220
+ELLSWORTH,Venango Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000230
+ELLSWORTH,Wilson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",316,000240

--- a/2012/20121106__ks__general__finney__precinct.csv
+++ b/2012/20121106__ks__general__finney__precinct.csv
@@ -1,0 +1,761 @@
+county,precinct,office,district,party,candidate,votes,vtd
+FINNEY,Friend Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",37,000010
+FINNEY,Garden City Ward 2,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",244,000030
+FINNEY,Garden City Ward 3,Kansas House of Representatives,123,Republican,"Doll, John",376,000040
+FINNEY,Garden City Ward 5,Kansas House of Representatives,123,Republican,"Doll, John",286,000060
+FINNEY,Garden City Ward 6,Kansas House of Representatives,123,Republican,"Doll, John",320,000070
+FINNEY,Garden City Ward 7,Kansas House of Representatives,123,Republican,"Doll, John",242,000080
+FINNEY,Garden City Ward 8,Kansas House of Representatives,123,Republican,"Doll, John",393,00009A
+FINNEY,Garden City Ward 8 Exclave,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",0,00009B
+FINNEY,Garden City Ward 9,Kansas House of Representatives,123,Republican,"Doll, John",235,000100
+FINNEY,Garden City Ward 10,Kansas House of Representatives,123,Republican,"Doll, John",308,000110
+FINNEY,Garden City Ward 11,Kansas House of Representatives,123,Republican,"Doll, John",412,000120
+FINNEY,Garden City Ward 12,Kansas House of Representatives,123,Republican,"Doll, John",426,000130
+FINNEY,Garden City Ward 13,Kansas House of Representatives,123,Republican,"Doll, John",394,000140
+FINNEY,Garden City Ward 14,Kansas House of Representatives,123,Republican,"Doll, John",258,000150
+FINNEY,Garden City Ward 15,Kansas House of Representatives,123,Republican,"Doll, John",279,000160
+FINNEY,Garden City Ward 16,Kansas House of Representatives,123,Republican,"Doll, John",508,000170
+FINNEY,Garden City Ward 17,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",295,00018A
+FINNEY,Holcomb Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",698,000190
+FINNEY,Huffman Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",186,000200
+FINNEY,Jennie Barker Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",353,00021A
+FINNEY,Kalvesta Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",58,000220
+FINNEY,Kalvesta Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",5,000220
+FINNEY,Mack Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",122,000230
+FINNEY,Pleasant Valley Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",66,000250
+FINNEY,Plymell Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",143,000260
+FINNEY,Theoni Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",56,000280
+FINNEY,Garden City Ward 1 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",29,120020
+FINNEY,Garden City Ward 1 H123,Kansas House of Representatives,123,Republican,"Doll, John",150,120030
+FINNEY,Garden City Ward 4 H117,Kansas House of Representatives,123,Republican,"Doll, John",0,200010
+FINNEY,Garden City Ward 4 H123,Kansas House of Representatives,123,Republican,"Doll, John",221,200020
+FINNEY,Pierceville Precinct H117,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",65,200030
+FINNEY,Pierceville Precinct H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",124,200040
+FINNEY,Riverside Precinct H117,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",348,200050
+FINNEY,Riverside Precinct H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",101,200060
+FINNEY,Friend Township,Kansas Senate,39,Republican,"Powell, Larry R.",38,000010
+FINNEY,Garden City Ward 2,Kansas Senate,39,Republican,"Powell, Larry R.",254,000030
+FINNEY,Garden City Ward 3,Kansas Senate,39,Republican,"Powell, Larry R.",366,000040
+FINNEY,Garden City Ward 5,Kansas Senate,39,Republican,"Powell, Larry R.",272,000060
+FINNEY,Garden City Ward 6,Kansas Senate,39,Republican,"Powell, Larry R.",324,000070
+FINNEY,Garden City Ward 7,Kansas Senate,39,Republican,"Powell, Larry R.",233,000080
+FINNEY,Garden City Ward 8,Kansas Senate,39,Republican,"Powell, Larry R.",387,00009A
+FINNEY,Garden City Ward 8 Exclave,Kansas Senate,39,Republican,"Powell, Larry R.",0,00009B
+FINNEY,Garden City Ward 9,Kansas Senate,39,Republican,"Powell, Larry R.",228,000100
+FINNEY,Garden City Ward 10,Kansas Senate,39,Republican,"Powell, Larry R.",298,000110
+FINNEY,Garden City Ward 11,Kansas Senate,39,Republican,"Powell, Larry R.",405,000120
+FINNEY,Garden City Ward 12,Kansas Senate,39,Republican,"Powell, Larry R.",394,000130
+FINNEY,Garden City Ward 13,Kansas Senate,39,Republican,"Powell, Larry R.",380,000140
+FINNEY,Garden City Ward 14,Kansas Senate,39,Republican,"Powell, Larry R.",253,000150
+FINNEY,Garden City Ward 15,Kansas Senate,39,Republican,"Powell, Larry R.",277,000160
+FINNEY,Garden City Ward 16,Kansas Senate,39,Republican,"Powell, Larry R.",471,000170
+FINNEY,Garden City Ward 17,Kansas Senate,39,Republican,"Powell, Larry R.",283,00018A
+FINNEY,Holcomb Township,Kansas Senate,39,Republican,"Powell, Larry R.",704,000190
+FINNEY,Huffman Township,Kansas Senate,39,Republican,"Powell, Larry R.",189,000200
+FINNEY,Jennie Barker Township,Kansas Senate,39,Republican,"Powell, Larry R.",345,00021A
+FINNEY,Kalvesta Township,Kansas Senate,39,Republican,"Powell, Larry R.",55,000220
+FINNEY,Mack Township,Kansas Senate,39,Republican,"Powell, Larry R.",121,000230
+FINNEY,Pleasant Valley Township,Kansas Senate,39,Republican,"Powell, Larry R.",66,000250
+FINNEY,Plymell Township,Kansas Senate,39,Republican,"Powell, Larry R.",138,000260
+FINNEY,Theoni Township,Kansas Senate,39,Republican,"Powell, Larry R.",54,000280
+FINNEY,Garden City Ward 1 H122,Kansas Senate,39,Republican,"Powell, Larry R.",24,120020
+FINNEY,Garden City Ward 1 H123,Kansas Senate,39,Republican,"Powell, Larry R.",152,120030
+FINNEY,Garden City Ward 4 H117,Kansas Senate,39,Republican,"Powell, Larry R.",0,200010
+FINNEY,Garden City Ward 4 H123,Kansas Senate,39,Republican,"Powell, Larry R.",217,200020
+FINNEY,Pierceville Precinct H117,Kansas Senate,39,Republican,"Powell, Larry R.",61,200030
+FINNEY,Pierceville Precinct H122,Kansas Senate,39,Republican,"Powell, Larry R.",128,200040
+FINNEY,Riverside Precinct H117,Kansas Senate,39,Republican,"Powell, Larry R.",301,200050
+FINNEY,Riverside Precinct H122,Kansas Senate,39,Republican,"Powell, Larry R.",85,200060
+FINNEY,Friend Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+FINNEY,Friend Township,President / Vice President,,Democratic,"Obama, Barack",6,000010
+FINNEY,Friend Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+FINNEY,Friend Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+FINNEY,Friend Township,President / Vice President,,Republican,"Romney, Mitt",34,000010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+FINNEY,Garden City Ward 2,President / Vice President,,Democratic,"Obama, Barack",173,000030
+FINNEY,Garden City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+FINNEY,Garden City Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+FINNEY,Garden City Ward 2,President / Vice President,,Republican,"Romney, Mitt",139,000030
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,Democratic,"Obama, Barack",143,000040
+FINNEY,Garden City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",17,000040
+FINNEY,Garden City Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",4,000040
+FINNEY,Garden City Ward 3,President / Vice President,,Republican,"Romney, Mitt",289,000040
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Barnett, Andre",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Bush, Kent W",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Christensen, Will",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Goode, Virgil",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Stein, Jill E",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,Democratic,"Obama, Barack",122,000060
+FINNEY,Garden City Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",7,000060
+FINNEY,Garden City Ward 5,President / Vice President,,Reform,"Baldwin, Chuck",2,000060
+FINNEY,Garden City Ward 5,President / Vice President,,Republican,"Romney, Mitt",219,000060
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Barnett, Andre",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Bush, Kent W",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Christensen, Will",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Goode, Virgil",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Stein, Jill E",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,Democratic,"Obama, Barack",163,000070
+FINNEY,Garden City Ward 6,President / Vice President,,Libertarian,"Johnson, Gary",6,000070
+FINNEY,Garden City Ward 6,President / Vice President,,Reform,"Baldwin, Chuck",3,000070
+FINNEY,Garden City Ward 6,President / Vice President,,Republican,"Romney, Mitt",211,000070
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Barnett, Andre",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Bush, Kent W",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Christensen, Will",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Goode, Virgil",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Stein, Jill E",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,Democratic,"Obama, Barack",116,000080
+FINNEY,Garden City Ward 7,President / Vice President,,Libertarian,"Johnson, Gary",8,000080
+FINNEY,Garden City Ward 7,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,Republican,"Romney, Mitt",162,000080
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Ayers, Avery L",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Barnett, Andre",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Barr, Roseanne C",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Bush, Kent W",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Christensen, Will",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Duncan, Richard A",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Goode, Virgil",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Hoefling, Tom",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Knill, Dennis J",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Reed, Jill A.",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Rogers, Rick L",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Stein, Jill E",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Thorne, Kevin M",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Warner, Gerald L.",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,Democratic,"Obama, Barack",226,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,Libertarian,"Johnson, Gary",6,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,Reform,"Baldwin, Chuck",2,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,Republican,"Romney, Mitt",253,00009A
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00009B
+FINNEY,Garden City Ward 8 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00009B
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Barnett, Andre",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Bush, Kent W",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Christensen, Will",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Goode, Virgil",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Stein, Jill E",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,Democratic,"Obama, Barack",108,000100
+FINNEY,Garden City Ward 9,President / Vice President,,Libertarian,"Johnson, Gary",3,000100
+FINNEY,Garden City Ward 9,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+FINNEY,Garden City Ward 9,President / Vice President,,Republican,"Romney, Mitt",164,000100
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Barnett, Andre",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Bush, Kent W",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Christensen, Will",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Goode, Virgil",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Stein, Jill E",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,Democratic,"Obama, Barack",107,000110
+FINNEY,Garden City Ward 10,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+FINNEY,Garden City Ward 10,President / Vice President,,Reform,"Baldwin, Chuck",3,000110
+FINNEY,Garden City Ward 10,President / Vice President,,Republican,"Romney, Mitt",261,000110
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Barnett, Andre",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Bush, Kent W",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Christensen, Will",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Goode, Virgil",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Stein, Jill E",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,Democratic,"Obama, Barack",133,000120
+FINNEY,Garden City Ward 11,President / Vice President,,Libertarian,"Johnson, Gary",4,000120
+FINNEY,Garden City Ward 11,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,Republican,"Romney, Mitt",352,000120
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Barnett, Andre",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Bush, Kent W",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Christensen, Will",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Goode, Virgil",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Stein, Jill E",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,Democratic,"Obama, Barack",113,000130
+FINNEY,Garden City Ward 12,President / Vice President,,Libertarian,"Johnson, Gary",4,000130
+FINNEY,Garden City Ward 12,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,Republican,"Romney, Mitt",382,000130
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Barnett, Andre",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Bush, Kent W",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Christensen, Will",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Goode, Virgil",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Stein, Jill E",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,Democratic,"Obama, Barack",87,000140
+FINNEY,Garden City Ward 13,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+FINNEY,Garden City Ward 13,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+FINNEY,Garden City Ward 13,President / Vice President,,Republican,"Romney, Mitt",371,000140
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Barnett, Andre",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Bush, Kent W",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Christensen, Will",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Goode, Virgil",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Stein, Jill E",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+FINNEY,Garden City Ward 14,President / Vice President,,Democratic,"Obama, Barack",108,000150
+FINNEY,Garden City Ward 14,President / Vice President,,Libertarian,"Johnson, Gary",9,000150
+FINNEY,Garden City Ward 14,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+FINNEY,Garden City Ward 14,President / Vice President,,Republican,"Romney, Mitt",188,000150
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Barnett, Andre",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Bush, Kent W",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Christensen, Will",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Goode, Virgil",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Stein, Jill E",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,Democratic,"Obama, Barack",84,000160
+FINNEY,Garden City Ward 15,President / Vice President,,Libertarian,"Johnson, Gary",8,000160
+FINNEY,Garden City Ward 15,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+FINNEY,Garden City Ward 15,President / Vice President,,Republican,"Romney, Mitt",226,000160
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Barnett, Andre",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Bush, Kent W",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Christensen, Will",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Goode, Virgil",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Stein, Jill E",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,Democratic,"Obama, Barack",151,000170
+FINNEY,Garden City Ward 16,President / Vice President,,Libertarian,"Johnson, Gary",6,000170
+FINNEY,Garden City Ward 16,President / Vice President,,Reform,"Baldwin, Chuck",4,000170
+FINNEY,Garden City Ward 16,President / Vice President,,Republican,"Romney, Mitt",402,000170
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Ayers, Avery L",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Barnett, Andre",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Barr, Roseanne C",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Bush, Kent W",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Christensen, Will",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Duncan, Richard A",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Goode, Virgil",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Hoefling, Tom",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Knill, Dennis J",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Reed, Jill A.",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Rogers, Rick L",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Stein, Jill E",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Thorne, Kevin M",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,write - in,"Warner, Gerald L.",0,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,Democratic,"Obama, Barack",90,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,Libertarian,"Johnson, Gary",8,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,Reform,"Baldwin, Chuck",1,00018A
+FINNEY,Garden City Ward 17,President / Vice President,,Republican,"Romney, Mitt",231,00018A
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+FINNEY,Holcomb Township,President / Vice President,,Democratic,"Obama, Barack",161,000190
+FINNEY,Holcomb Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000190
+FINNEY,Holcomb Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000190
+FINNEY,Holcomb Township,President / Vice President,,Republican,"Romney, Mitt",608,000190
+FINNEY,Huffman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+FINNEY,Huffman Township,President / Vice President,,Democratic,"Obama, Barack",70,000200
+FINNEY,Huffman Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000200
+FINNEY,Huffman Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000200
+FINNEY,Huffman Township,President / Vice President,,Republican,"Romney, Mitt",151,000200
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Ayers, Avery L",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Barnett, Andre",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Bush, Kent W",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Christensen, Will",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Duncan, Richard A",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Goode, Virgil",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Hoefling, Tom",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Knill, Dennis J",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Reed, Jill A.",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Rogers, Rick L",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Stein, Jill E",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,Democratic,"Obama, Barack",80,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,Libertarian,"Johnson, Gary",5,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,Reform,"Baldwin, Chuck",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,Republican,"Romney, Mitt",316,00021A
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,Democratic,"Obama, Barack",8,000220
+FINNEY,Kalvesta Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000220
+FINNEY,Kalvesta Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,Republican,"Romney, Mitt",55,000220
+FINNEY,Mack Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+FINNEY,Mack Township,President / Vice President,,Democratic,"Obama, Barack",62,000230
+FINNEY,Mack Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000230
+FINNEY,Mack Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+FINNEY,Mack Township,President / Vice President,,Republican,"Romney, Mitt",88,000230
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,Democratic,"Obama, Barack",5,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,Republican,"Romney, Mitt",66,000250
+FINNEY,Plymell Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Barnett, Andre",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Bush, Kent W",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Christensen, Will",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Goode, Virgil",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Stein, Jill E",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+FINNEY,Plymell Township,President / Vice President,,Democratic,"Obama, Barack",29,000260
+FINNEY,Plymell Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+FINNEY,Plymell Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000260
+FINNEY,Plymell Township,President / Vice President,,Republican,"Romney, Mitt",135,000260
+FINNEY,Theoni Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Barnett, Andre",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Bush, Kent W",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Christensen, Will",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Goode, Virgil",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Stein, Jill E",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+FINNEY,Theoni Township,President / Vice President,,Democratic,"Obama, Barack",6,000280
+FINNEY,Theoni Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000280
+FINNEY,Theoni Township,President / Vice President,,Reform,"Baldwin, Chuck",13,000280
+FINNEY,Theoni Township,President / Vice President,,Republican,"Romney, Mitt",57,000280
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Barnett, Andre",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Bush, Kent W",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Christensen, Will",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Goode, Virgil",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Stein, Jill E",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,Democratic,"Obama, Barack",25,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,Libertarian,"Johnson, Gary",1,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+FINNEY,Garden City Ward 1 H122,President / Vice President,,Republican,"Romney, Mitt",10,120020
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Barnett, Andre",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Bush, Kent W",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Christensen, Will",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Goode, Virgil",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Stein, Jill E",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,Democratic,"Obama, Barack",100,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,Libertarian,"Johnson, Gary",6,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+FINNEY,Garden City Ward 1 H123,President / Vice President,,Republican,"Romney, Mitt",71,120030
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Ayers, Avery L",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Barnett, Andre",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Barr, Roseanne C",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Bush, Kent W",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Christensen, Will",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Duncan, Richard A",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Goode, Virgil",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Hoefling, Tom",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Knill, Dennis J",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Reed, Jill A.",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Rogers, Rick L",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Stein, Jill E",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Thorne, Kevin M",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,write - in,"Warner, Gerald L.",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,Democratic,"Obama, Barack",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,Libertarian,"Johnson, Gary",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,Reform,"Baldwin, Chuck",0,200010
+FINNEY,Garden City Ward 4 H117,President / Vice President,,Republican,"Romney, Mitt",0,200010
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Ayers, Avery L",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Barnett, Andre",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Barr, Roseanne C",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Bush, Kent W",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Christensen, Will",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Duncan, Richard A",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Goode, Virgil",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Hoefling, Tom",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Knill, Dennis J",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Reed, Jill A.",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Rogers, Rick L",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Stein, Jill E",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Thorne, Kevin M",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,write - in,"Warner, Gerald L.",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,Democratic,"Obama, Barack",78,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,Libertarian,"Johnson, Gary",1,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,Reform,"Baldwin, Chuck",0,200020
+FINNEY,Garden City Ward 4 H123,President / Vice President,,Republican,"Romney, Mitt",194,200020
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Ayers, Avery L",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Barnett, Andre",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Barr, Roseanne C",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Bush, Kent W",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Christensen, Will",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Duncan, Richard A",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Goode, Virgil",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Hoefling, Tom",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Knill, Dennis J",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Reed, Jill A.",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Rogers, Rick L",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Stein, Jill E",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Thorne, Kevin M",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,write - in,"Warner, Gerald L.",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,Democratic,"Obama, Barack",23,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,Libertarian,"Johnson, Gary",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,Reform,"Baldwin, Chuck",0,200030
+FINNEY,Pierceville Precinct H117,President / Vice President,,Republican,"Romney, Mitt",48,200030
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Ayers, Avery L",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Barnett, Andre",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Barr, Roseanne C",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Bush, Kent W",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Christensen, Will",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Duncan, Richard A",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Goode, Virgil",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Hoefling, Tom",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Knill, Dennis J",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Reed, Jill A.",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Rogers, Rick L",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Stein, Jill E",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Thorne, Kevin M",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Warner, Gerald L.",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,Democratic,"Obama, Barack",29,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,Libertarian,"Johnson, Gary",6,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,Reform,"Baldwin, Chuck",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,Republican,"Romney, Mitt",109,200040
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Ayers, Avery L",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Barnett, Andre",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Barr, Roseanne C",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Bush, Kent W",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Christensen, Will",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Duncan, Richard A",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Goode, Virgil",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Hoefling, Tom",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Knill, Dennis J",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Reed, Jill A.",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Rogers, Rick L",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Stein, Jill E",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Thorne, Kevin M",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,write - in,"Warner, Gerald L.",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,Democratic,"Obama, Barack",52,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,Libertarian,"Johnson, Gary",3,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,Reform,"Baldwin, Chuck",0,200050
+FINNEY,Riverside Precinct H117,President / Vice President,,Republican,"Romney, Mitt",335,200050
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Ayers, Avery L",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Barnett, Andre",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Barr, Roseanne C",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Bush, Kent W",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Christensen, Will",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Duncan, Richard A",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Goode, Virgil",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Hoefling, Tom",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Knill, Dennis J",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Reed, Jill A.",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Rogers, Rick L",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Stein, Jill E",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Thorne, Kevin M",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Warner, Gerald L.",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,Democratic,"Obama, Barack",24,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,Libertarian,"Johnson, Gary",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,Reform,"Baldwin, Chuck",2,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,Republican,"Romney, Mitt",92,200060
+FINNEY,Friend Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000010
+FINNEY,Garden City Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",244,000030
+FINNEY,Garden City Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",362,000040
+FINNEY,Garden City Ward 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",271,000060
+FINNEY,Garden City Ward 6,United States House of Representatives,1,Republican,"Huelskamp, Tim",322,000070
+FINNEY,Garden City Ward 7,United States House of Representatives,1,Republican,"Huelskamp, Tim",239,000080
+FINNEY,Garden City Ward 8,United States House of Representatives,1,Republican,"Huelskamp, Tim",383,00009A
+FINNEY,Garden City Ward 8 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00009B
+FINNEY,Garden City Ward 9,United States House of Representatives,1,Republican,"Huelskamp, Tim",231,000100
+FINNEY,Garden City Ward 10,United States House of Representatives,1,Republican,"Huelskamp, Tim",304,000110
+FINNEY,Garden City Ward 11,United States House of Representatives,1,Republican,"Huelskamp, Tim",405,000120
+FINNEY,Garden City Ward 12,United States House of Representatives,1,Republican,"Huelskamp, Tim",408,000130
+FINNEY,Garden City Ward 13,United States House of Representatives,1,Republican,"Huelskamp, Tim",387,000140
+FINNEY,Garden City Ward 14,United States House of Representatives,1,Republican,"Huelskamp, Tim",256,000150
+FINNEY,Garden City Ward 15,United States House of Representatives,1,Republican,"Huelskamp, Tim",274,000160
+FINNEY,Garden City Ward 16,United States House of Representatives,1,Republican,"Huelskamp, Tim",489,000170
+FINNEY,Garden City Ward 17,United States House of Representatives,1,Republican,"Huelskamp, Tim",287,00018A
+FINNEY,Holcomb Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",698,000190
+FINNEY,Huffman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",192,000200
+FINNEY,Jennie Barker Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",352,00021A
+FINNEY,Kalvesta Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",58,000220
+FINNEY,Mack Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",122,000230
+FINNEY,Pleasant Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",67,000250
+FINNEY,Plymell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",144,000260
+FINNEY,Theoni Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",58,000280
+FINNEY,Garden City Ward 1 H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,120020
+FINNEY,Garden City Ward 1 H123,United States House of Representatives,1,Republican,"Huelskamp, Tim",137,120030
+FINNEY,Garden City Ward 4 H117,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,200010
+FINNEY,Garden City Ward 4 H123,United States House of Representatives,1,Republican,"Huelskamp, Tim",213,200020
+FINNEY,Pierceville Precinct H117,United States House of Representatives,1,Republican,"Huelskamp, Tim",58,200030
+FINNEY,Pierceville Precinct H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",135,200040
+FINNEY,Riverside Precinct H117,United States House of Representatives,1,Republican,"Huelskamp, Tim",335,200050
+FINNEY,Riverside Precinct H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",93,200060

--- a/2012/20121106__ks__general__ford__precinct.csv
+++ b/2012/20121106__ks__general__ford__precinct.csv
@@ -1,0 +1,976 @@
+county,precinct,office,district,party,candidate,votes,vtd
+FORD,Bloom Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",11,000010
+FORD,Bloom Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",30,000010
+FORD,Bucklin City,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",141,000020
+FORD,Bucklin City,Kansas House of Representatives,117,Republican,"Ewy, John L.",179,000020
+FORD,Bucklin Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",28,000030
+FORD,Bucklin Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",35,000030
+FORD,Concord Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",12,000040
+FORD,Concord Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",34,000040
+FORD,Dodge City Precinct 01,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",270,00005A
+FORD,Dodge City Precinct 01,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",281,00005A
+FORD,Dodge City Airport,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",0,00005B
+FORD,Dodge City Airport,Kansas House of Representatives,119,Republican,"Weber, Brian A.",0,00005B
+FORD,Dodge City Industrial Park,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",0,00005C
+FORD,Dodge City Industrial Park,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",0,00005C
+FORD,Dodge City Precinct 02,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",141,000060
+FORD,Dodge City Precinct 02,Kansas House of Representatives,119,Republican,"Weber, Brian A.",214,000060
+FORD,Dodge City Precinct 03,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",214,000070
+FORD,Dodge City Precinct 03,Kansas House of Representatives,119,Republican,"Weber, Brian A.",226,000070
+FORD,Dodge City Precinct 04,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",339,00008A
+FORD,Dodge City Precinct 04,Kansas House of Representatives,119,Republican,"Weber, Brian A.",590,00008A
+FORD,Dodge City Excel #1,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",0,00008B
+FORD,Dodge City Excel #1,Kansas House of Representatives,119,Republican,"Weber, Brian A.",0,00008B
+FORD,Dodge City Excel #2,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",0,00008C
+FORD,Dodge City Excel #2,Kansas House of Representatives,119,Republican,"Weber, Brian A.",0,00008C
+FORD,Dodge City Millard,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",0,00008D
+FORD,Dodge City Millard,Kansas House of Representatives,119,Republican,"Weber, Brian A.",0,00008D
+FORD,Dodge City Precinct 05,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",395,000090
+FORD,Dodge City Precinct 05,Kansas House of Representatives,119,Republican,"Weber, Brian A.",1075,000090
+FORD,Dodge City Precinct 06,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",456,000100
+FORD,Dodge City Precinct 06,Kansas House of Representatives,119,Republican,"Weber, Brian A.",1292,000100
+FORD,Dodge Township Ward 3,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",8,000200
+FORD,Dodge Township Ward 3,Kansas House of Representatives,119,Republican,"Weber, Brian A.",26,000200
+FORD,Fairview Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",25,000220
+FORD,Fairview Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",97,000220
+FORD,Ford City,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",18,000230
+FORD,Ford City,Kansas House of Representatives,117,Republican,"Ewy, John L.",75,000230
+FORD,Ford Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",18,000240
+FORD,Ford Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",60,000240
+FORD,Richland Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",65,000260
+FORD,Richland Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",132,000260
+FORD,Royal Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",22,000270
+FORD,Royal Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",88,000270
+FORD,Sodville Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",11,000280
+FORD,Sodville Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",34,000280
+FORD,Spearville City,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",115,000300
+FORD,Spearville City,Kansas House of Representatives,117,Republican,"Ewy, John L.",248,000300
+FORD,Spearville Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",42,000310
+FORD,Spearville Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",142,000310
+FORD,Wheatland Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",19,000320
+FORD,Wheatland Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",56,000320
+FORD,Wilburn Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",5,000330
+FORD,Wilburn Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",29,000330
+FORD,Dodge Township H115,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",61,120020
+FORD,Dodge Township H115,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",129,120020
+FORD,Dodge Township H119 A,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",0,12003A
+FORD,Dodge Township H119 A,Kansas House of Representatives,119,Republican,"Weber, Brian A.",0,12003A
+FORD,Dodge Township H119,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",7,120030
+FORD,Dodge Township H119,Kansas House of Representatives,119,Republican,"Weber, Brian A.",33,120030
+FORD,Enterprise Township H115,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",67,120040
+FORD,Enterprise Township H115,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",112,120040
+FORD,Enterprise Township H119,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",1,120050
+FORD,Enterprise Township H119,Kansas House of Representatives,119,Republican,"Weber, Brian A.",2,120050
+FORD,Grandview Township H115,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",48,120060
+FORD,Grandview Township H115,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",115,120060
+FORD,Grandview Township H119 A,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",0,12007A
+FORD,Grandview Township H119 A,Kansas House of Representatives,119,Republican,"Weber, Brian A.",0,12007A
+FORD,Grandview Township H119,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",0,120070
+FORD,Grandview Township H119,Kansas House of Representatives,119,Republican,"Weber, Brian A.",3,120070
+FORD,Grandview Township Ward 2 H115,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",31,120080
+FORD,Grandview Township Ward 2 H115,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",38,120080
+FORD,Grandview Township Ward 2 H119,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",0,120090
+FORD,Grandview Township Ward 2 H119,Kansas House of Representatives,119,Republican,"Weber, Brian A.",4,120090
+FORD,Dodge City Precinct 07,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",13,600010
+FORD,Dodge City Precinct 07,Kansas House of Representatives,119,Republican,"Weber, Brian A.",39,600010
+FORD,Dodge City Precinct 08,Kansas House of Representatives,119,Democratic,"Blake, Lawrence ""Larry""",0,800010
+FORD,Dodge City Precinct 08,Kansas House of Representatives,119,Republican,"Weber, Brian A.",2,800010
+FORD,Dodge City Precinct 09,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",6,900010
+FORD,Dodge City Precinct 09,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",9,900010
+FORD,Bloom Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",7,000010
+FORD,Bloom Township,Kansas Senate,38,Republican,"Love, Garrett",34,000010
+FORD,Bucklin City,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",46,000020
+FORD,Bucklin City,Kansas Senate,38,Republican,"Love, Garrett",275,000020
+FORD,Bucklin Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",11,000030
+FORD,Bucklin Township,Kansas Senate,38,Republican,"Love, Garrett",51,000030
+FORD,Concord Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",8,000040
+FORD,Concord Township,Kansas Senate,38,Republican,"Love, Garrett",42,000040
+FORD,Dodge City Precinct 01,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",209,00005A
+FORD,Dodge City Precinct 01,Kansas Senate,38,Republican,"Love, Garrett",360,00005A
+FORD,Dodge City Airport,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",0,00005B
+FORD,Dodge City Airport,Kansas Senate,38,Republican,"Love, Garrett",0,00005B
+FORD,Dodge City Industrial Park,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",0,00005C
+FORD,Dodge City Industrial Park,Kansas Senate,38,Republican,"Love, Garrett",0,00005C
+FORD,Dodge City Precinct 02,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",140,000060
+FORD,Dodge City Precinct 02,Kansas Senate,38,Republican,"Love, Garrett",215,000060
+FORD,Dodge City Precinct 03,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",201,000070
+FORD,Dodge City Precinct 03,Kansas Senate,38,Republican,"Love, Garrett",229,000070
+FORD,Dodge City Precinct 04,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",326,00008A
+FORD,Dodge City Precinct 04,Kansas Senate,38,Republican,"Love, Garrett",587,00008A
+FORD,Dodge City Excel #1,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",0,00008B
+FORD,Dodge City Excel #1,Kansas Senate,38,Republican,"Love, Garrett",0,00008B
+FORD,Dodge City Excel #2,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",0,00008C
+FORD,Dodge City Excel #2,Kansas Senate,38,Republican,"Love, Garrett",0,00008C
+FORD,Dodge City Millard,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",0,00008D
+FORD,Dodge City Millard,Kansas Senate,38,Republican,"Love, Garrett",0,00008D
+FORD,Dodge City Precinct 05,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",381,000090
+FORD,Dodge City Precinct 05,Kansas Senate,38,Republican,"Love, Garrett",1082,000090
+FORD,Dodge City Precinct 06,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",383,000100
+FORD,Dodge City Precinct 06,Kansas Senate,38,Republican,"Love, Garrett",1352,000100
+FORD,Dodge Township Ward 3,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",9,000200
+FORD,Dodge Township Ward 3,Kansas Senate,38,Republican,"Love, Garrett",26,000200
+FORD,Fairview Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",19,000220
+FORD,Fairview Township,Kansas Senate,38,Republican,"Love, Garrett",107,000220
+FORD,Ford City,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",15,000230
+FORD,Ford City,Kansas Senate,38,Republican,"Love, Garrett",79,000230
+FORD,Ford Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",11,000240
+FORD,Ford Township,Kansas Senate,38,Republican,"Love, Garrett",67,000240
+FORD,Richland Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",43,000260
+FORD,Richland Township,Kansas Senate,38,Republican,"Love, Garrett",158,000260
+FORD,Royal Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",16,000270
+FORD,Royal Township,Kansas Senate,38,Republican,"Love, Garrett",103,000270
+FORD,Sodville Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",6,000280
+FORD,Sodville Township,Kansas Senate,38,Republican,"Love, Garrett",38,000280
+FORD,Spearville City,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",87,000300
+FORD,Spearville City,Kansas Senate,38,Republican,"Love, Garrett",276,000300
+FORD,Spearville Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",35,000310
+FORD,Spearville Township,Kansas Senate,38,Republican,"Love, Garrett",147,000310
+FORD,Wheatland Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",16,000320
+FORD,Wheatland Township,Kansas Senate,38,Republican,"Love, Garrett",58,000320
+FORD,Wilburn Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",2,000330
+FORD,Wilburn Township,Kansas Senate,38,Republican,"Love, Garrett",33,000330
+FORD,Dodge Township H115,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",40,120020
+FORD,Dodge Township H115,Kansas Senate,38,Republican,"Love, Garrett",161,120020
+FORD,Dodge Township H119 A,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",0,12003A
+FORD,Dodge Township H119 A,Kansas Senate,38,Republican,"Love, Garrett",0,12003A
+FORD,Dodge Township H119,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",3,120030
+FORD,Dodge Township H119,Kansas Senate,38,Republican,"Love, Garrett",36,120030
+FORD,Enterprise Township H115,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",53,120040
+FORD,Enterprise Township H115,Kansas Senate,38,Republican,"Love, Garrett",128,120040
+FORD,Enterprise Township H119,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",2,120050
+FORD,Enterprise Township H119,Kansas Senate,38,Republican,"Love, Garrett",1,120050
+FORD,Grandview Township H115,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",45,120060
+FORD,Grandview Township H115,Kansas Senate,38,Republican,"Love, Garrett",132,120060
+FORD,Grandview Township H119 A,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",0,12007A
+FORD,Grandview Township H119 A,Kansas Senate,38,Republican,"Love, Garrett",0,12007A
+FORD,Grandview Township H119,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",1,120070
+FORD,Grandview Township H119,Kansas Senate,38,Republican,"Love, Garrett",2,120070
+FORD,Grandview Township Ward 2 H115,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",25,120080
+FORD,Grandview Township Ward 2 H115,Kansas Senate,38,Republican,"Love, Garrett",51,120080
+FORD,Grandview Township Ward 2 H119,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",2,120090
+FORD,Grandview Township Ward 2 H119,Kansas Senate,38,Republican,"Love, Garrett",2,120090
+FORD,Dodge City Precinct 07,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",7,600010
+FORD,Dodge City Precinct 07,Kansas Senate,38,Republican,"Love, Garrett",45,600010
+FORD,Dodge City Precinct 08,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",0,800010
+FORD,Dodge City Precinct 08,Kansas Senate,38,Republican,"Love, Garrett",2,800010
+FORD,Dodge City Precinct 09,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",5,900010
+FORD,Dodge City Precinct 09,Kansas Senate,38,Republican,"Love, Garrett",10,900010
+FORD,Bloom Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+FORD,Bloom Township,President / Vice President,,Democratic,"Obama, Barack",5,000010
+FORD,Bloom Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000010
+FORD,Bloom Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+FORD,Bloom Township,President / Vice President,,Republican,"Romney, Mitt",33,000010
+FORD,Bucklin City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Barnett, Andre",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Bush, Kent W",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Christensen, Will",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Goode, Virgil",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Stein, Jill E",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+FORD,Bucklin City,President / Vice President,,Democratic,"Obama, Barack",43,000020
+FORD,Bucklin City,President / Vice President,,Libertarian,"Johnson, Gary",5,000020
+FORD,Bucklin City,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+FORD,Bucklin City,President / Vice President,,Republican,"Romney, Mitt",279,000020
+FORD,Bucklin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+FORD,Bucklin Township,President / Vice President,,Democratic,"Obama, Barack",11,000030
+FORD,Bucklin Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+FORD,Bucklin Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+FORD,Bucklin Township,President / Vice President,,Republican,"Romney, Mitt",50,000030
+FORD,Concord Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+FORD,Concord Township,President / Vice President,,Democratic,"Obama, Barack",7,000040
+FORD,Concord Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+FORD,Concord Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+FORD,Concord Township,President / Vice President,,Republican,"Romney, Mitt",42,000040
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,Democratic,"Obama, Barack",261,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",11,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",4,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,Republican,"Romney, Mitt",320,00005A
+FORD,Dodge City Airport,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Ayers, Avery L",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Barnett, Andre",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Barr, Roseanne C",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Bush, Kent W",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Christensen, Will",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Duncan, Richard A",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Goode, Virgil",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Knill, Dennis J",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Reed, Jill A.",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Rogers, Rick L",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Stein, Jill E",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Thorne, Kevin M",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Warner, Gerald L.",0,00005B
+FORD,Dodge City Airport,President / Vice President,,Democratic,"Obama, Barack",0,00005B
+FORD,Dodge City Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+FORD,Dodge City Airport,President / Vice President,,Reform,"Baldwin, Chuck",0,00005B
+FORD,Dodge City Airport,President / Vice President,,Republican,"Romney, Mitt",0,00005B
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Ayers, Avery L",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Barnett, Andre",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Barr, Roseanne C",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Bush, Kent W",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Christensen, Will",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Duncan, Richard A",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Goode, Virgil",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Hoefling, Tom",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Knill, Dennis J",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Reed, Jill A.",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Rogers, Rick L",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Stein, Jill E",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Thorne, Kevin M",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Warner, Gerald L.",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,Democratic,"Obama, Barack",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,Libertarian,"Johnson, Gary",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,Reform,"Baldwin, Chuck",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,Republican,"Romney, Mitt",0,00005C
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+FORD,Dodge City Precinct 02,President / Vice President,,Democratic,"Obama, Barack",175,000060
+FORD,Dodge City Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",9,000060
+FORD,Dodge City Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",4,000060
+FORD,Dodge City Precinct 02,President / Vice President,,Republican,"Romney, Mitt",190,000060
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,Democratic,"Obama, Barack",288,000070
+FORD,Dodge City Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",3,000070
+FORD,Dodge City Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",5,000070
+FORD,Dodge City Precinct 03,President / Vice President,,Republican,"Romney, Mitt",176,000070
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,Democratic,"Obama, Barack",389,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",22,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",2,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,Republican,"Romney, Mitt",545,00008A
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Ayers, Avery L",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Barnett, Andre",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Barr, Roseanne C",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Bush, Kent W",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Christensen, Will",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Duncan, Richard A",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Goode, Virgil",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Hoefling, Tom",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Knill, Dennis J",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Reed, Jill A.",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Rogers, Rick L",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Stein, Jill E",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Thorne, Kevin M",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Warner, Gerald L.",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,Democratic,"Obama, Barack",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,Libertarian,"Johnson, Gary",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,Reform,"Baldwin, Chuck",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,Republican,"Romney, Mitt",0,00008B
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Ayers, Avery L",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Barnett, Andre",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Barr, Roseanne C",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Bush, Kent W",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Christensen, Will",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Duncan, Richard A",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Goode, Virgil",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Hoefling, Tom",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Knill, Dennis J",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Reed, Jill A.",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Rogers, Rick L",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Stein, Jill E",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Thorne, Kevin M",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Warner, Gerald L.",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,Democratic,"Obama, Barack",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,Libertarian,"Johnson, Gary",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,Reform,"Baldwin, Chuck",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,Republican,"Romney, Mitt",0,00008C
+FORD,Dodge City Millard,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Ayers, Avery L",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Barnett, Andre",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Barr, Roseanne C",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Bush, Kent W",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Christensen, Will",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Duncan, Richard A",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Goode, Virgil",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Hoefling, Tom",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Knill, Dennis J",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Reed, Jill A.",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Rogers, Rick L",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Stein, Jill E",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Thorne, Kevin M",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Warner, Gerald L.",0,00008D
+FORD,Dodge City Millard,President / Vice President,,Democratic,"Obama, Barack",0,00008D
+FORD,Dodge City Millard,President / Vice President,,Libertarian,"Johnson, Gary",0,00008D
+FORD,Dodge City Millard,President / Vice President,,Reform,"Baldwin, Chuck",0,00008D
+FORD,Dodge City Millard,President / Vice President,,Republican,"Romney, Mitt",0,00008D
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+FORD,Dodge City Precinct 05,President / Vice President,,Democratic,"Obama, Barack",485,000090
+FORD,Dodge City Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",16,000090
+FORD,Dodge City Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",10,000090
+FORD,Dodge City Precinct 05,President / Vice President,,Republican,"Romney, Mitt",1013,000090
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Barnett, Andre",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Bush, Kent W",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Christensen, Will",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Goode, Virgil",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Stein, Jill E",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,Democratic,"Obama, Barack",508,000100
+FORD,Dodge City Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",11,000100
+FORD,Dodge City Precinct 06,President / Vice President,,Reform,"Baldwin, Chuck",8,000100
+FORD,Dodge City Precinct 06,President / Vice President,,Republican,"Romney, Mitt",1266,000100
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,Democratic,"Obama, Barack",8,000200
+FORD,Dodge Township Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,Republican,"Romney, Mitt",27,000200
+FORD,Fairview Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+FORD,Fairview Township,President / Vice President,,Democratic,"Obama, Barack",22,000220
+FORD,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+FORD,Fairview Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+FORD,Fairview Township,President / Vice President,,Republican,"Romney, Mitt",106,000220
+FORD,Ford City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Barnett, Andre",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Bush, Kent W",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Christensen, Will",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Goode, Virgil",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Stein, Jill E",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+FORD,Ford City,President / Vice President,,Democratic,"Obama, Barack",12,000230
+FORD,Ford City,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+FORD,Ford City,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+FORD,Ford City,President / Vice President,,Republican,"Romney, Mitt",81,000230
+FORD,Ford Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+FORD,Ford Township,President / Vice President,,Democratic,"Obama, Barack",7,000240
+FORD,Ford Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000240
+FORD,Ford Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000240
+FORD,Ford Township,President / Vice President,,Republican,"Romney, Mitt",69,000240
+FORD,Richland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Barnett, Andre",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Bush, Kent W",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Christensen, Will",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Goode, Virgil",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Stein, Jill E",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+FORD,Richland Township,President / Vice President,,Democratic,"Obama, Barack",54,000260
+FORD,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000260
+FORD,Richland Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000260
+FORD,Richland Township,President / Vice President,,Republican,"Romney, Mitt",152,000260
+FORD,Royal Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Barnett, Andre",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Bush, Kent W",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Christensen, Will",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Goode, Virgil",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Stein, Jill E",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+FORD,Royal Township,President / Vice President,,Democratic,"Obama, Barack",24,000270
+FORD,Royal Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000270
+FORD,Royal Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000270
+FORD,Royal Township,President / Vice President,,Republican,"Romney, Mitt",97,000270
+FORD,Sodville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Barnett, Andre",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Bush, Kent W",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Christensen, Will",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Goode, Virgil",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Stein, Jill E",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+FORD,Sodville Township,President / Vice President,,Democratic,"Obama, Barack",4,000280
+FORD,Sodville Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000280
+FORD,Sodville Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000280
+FORD,Sodville Township,President / Vice President,,Republican,"Romney, Mitt",40,000280
+FORD,Spearville City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Barnett, Andre",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Bush, Kent W",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Christensen, Will",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Goode, Virgil",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Stein, Jill E",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+FORD,Spearville City,President / Vice President,,Democratic,"Obama, Barack",79,000300
+FORD,Spearville City,President / Vice President,,Libertarian,"Johnson, Gary",9,000300
+FORD,Spearville City,President / Vice President,,Reform,"Baldwin, Chuck",1,000300
+FORD,Spearville City,President / Vice President,,Republican,"Romney, Mitt",281,000300
+FORD,Spearville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Barnett, Andre",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Bush, Kent W",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Christensen, Will",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Goode, Virgil",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Stein, Jill E",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+FORD,Spearville Township,President / Vice President,,Democratic,"Obama, Barack",16,000310
+FORD,Spearville Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000310
+FORD,Spearville Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000310
+FORD,Spearville Township,President / Vice President,,Republican,"Romney, Mitt",165,000310
+FORD,Wheatland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Barnett, Andre",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Bush, Kent W",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Christensen, Will",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Goode, Virgil",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Stein, Jill E",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+FORD,Wheatland Township,President / Vice President,,Democratic,"Obama, Barack",13,000320
+FORD,Wheatland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000320
+FORD,Wheatland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000320
+FORD,Wheatland Township,President / Vice President,,Republican,"Romney, Mitt",63,000320
+FORD,Wilburn Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Ayers, Avery L",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Barnett, Andre",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Bush, Kent W",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Christensen, Will",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Duncan, Richard A",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Goode, Virgil",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Knill, Dennis J",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Reed, Jill A.",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Rogers, Rick L",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Stein, Jill E",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000330
+FORD,Wilburn Township,President / Vice President,,Democratic,"Obama, Barack",7,000330
+FORD,Wilburn Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000330
+FORD,Wilburn Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000330
+FORD,Wilburn Township,President / Vice President,,Republican,"Romney, Mitt",29,000330
+FORD,Dodge Township H115,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Barnett, Andre",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Bush, Kent W",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Christensen, Will",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Goode, Virgil",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Stein, Jill E",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+FORD,Dodge Township H115,President / Vice President,,Democratic,"Obama, Barack",42,120020
+FORD,Dodge Township H115,President / Vice President,,Libertarian,"Johnson, Gary",1,120020
+FORD,Dodge Township H115,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+FORD,Dodge Township H115,President / Vice President,,Republican,"Romney, Mitt",163,120020
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Ayers, Avery L",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Barnett, Andre",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Bush, Kent W",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Christensen, Will",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Duncan, Richard A",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Goode, Virgil",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Hoefling, Tom",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Knill, Dennis J",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Reed, Jill A.",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Rogers, Rick L",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Stein, Jill E",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,Democratic,"Obama, Barack",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,Republican,"Romney, Mitt",0,12003A
+FORD,Dodge Township H119,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Barnett, Andre",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Bush, Kent W",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Christensen, Will",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Goode, Virgil",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Stein, Jill E",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+FORD,Dodge Township H119,President / Vice President,,Democratic,"Obama, Barack",3,120030
+FORD,Dodge Township H119,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+FORD,Dodge Township H119,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+FORD,Dodge Township H119,President / Vice President,,Republican,"Romney, Mitt",38,120030
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Barnett, Andre",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Bush, Kent W",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Christensen, Will",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Goode, Virgil",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Stein, Jill E",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+FORD,Enterprise Township H115,President / Vice President,,Democratic,"Obama, Barack",58,120040
+FORD,Enterprise Township H115,President / Vice President,,Libertarian,"Johnson, Gary",3,120040
+FORD,Enterprise Township H115,President / Vice President,,Reform,"Baldwin, Chuck",3,120040
+FORD,Enterprise Township H115,President / Vice President,,Republican,"Romney, Mitt",127,120040
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Barnett, Andre",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Bush, Kent W",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Christensen, Will",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Goode, Virgil",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Stein, Jill E",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+FORD,Enterprise Township H119,President / Vice President,,Democratic,"Obama, Barack",3,120050
+FORD,Enterprise Township H119,President / Vice President,,Libertarian,"Johnson, Gary",0,120050
+FORD,Enterprise Township H119,President / Vice President,,Reform,"Baldwin, Chuck",0,120050
+FORD,Enterprise Township H119,President / Vice President,,Republican,"Romney, Mitt",1,120050
+FORD,Grandview Township H115,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Ayers, Avery L",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Barnett, Andre",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Barr, Roseanne C",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Bush, Kent W",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Christensen, Will",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Duncan, Richard A",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Goode, Virgil",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Knill, Dennis J",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Reed, Jill A.",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Rogers, Rick L",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Stein, Jill E",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Thorne, Kevin M",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Warner, Gerald L.",0,120060
+FORD,Grandview Township H115,President / Vice President,,Democratic,"Obama, Barack",27,120060
+FORD,Grandview Township H115,President / Vice President,,Libertarian,"Johnson, Gary",5,120060
+FORD,Grandview Township H115,President / Vice President,,Reform,"Baldwin, Chuck",0,120060
+FORD,Grandview Township H115,President / Vice President,,Republican,"Romney, Mitt",148,120060
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Ayers, Avery L",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Barnett, Andre",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Bush, Kent W",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Christensen, Will",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Duncan, Richard A",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Goode, Virgil",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Hoefling, Tom",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Knill, Dennis J",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Reed, Jill A.",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Rogers, Rick L",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Stein, Jill E",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,Democratic,"Obama, Barack",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12007A
+FORD,Grandview Township H119 A,President / Vice President,,Republican,"Romney, Mitt",0,12007A
+FORD,Grandview Township H119,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Ayers, Avery L",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Barnett, Andre",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Barr, Roseanne C",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Bush, Kent W",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Christensen, Will",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Duncan, Richard A",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Goode, Virgil",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Knill, Dennis J",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Reed, Jill A.",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Rogers, Rick L",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Stein, Jill E",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Thorne, Kevin M",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Warner, Gerald L.",0,120070
+FORD,Grandview Township H119,President / Vice President,,Democratic,"Obama, Barack",1,120070
+FORD,Grandview Township H119,President / Vice President,,Libertarian,"Johnson, Gary",0,120070
+FORD,Grandview Township H119,President / Vice President,,Reform,"Baldwin, Chuck",0,120070
+FORD,Grandview Township H119,President / Vice President,,Republican,"Romney, Mitt",2,120070
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Ayers, Avery L",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Barnett, Andre",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Barr, Roseanne C",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Bush, Kent W",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Christensen, Will",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Duncan, Richard A",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Goode, Virgil",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Knill, Dennis J",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Reed, Jill A.",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Rogers, Rick L",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Stein, Jill E",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Thorne, Kevin M",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Warner, Gerald L.",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,Democratic,"Obama, Barack",30,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,Libertarian,"Johnson, Gary",6,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,Reform,"Baldwin, Chuck",1,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,Republican,"Romney, Mitt",41,120080
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Ayers, Avery L",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Barnett, Andre",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Barr, Roseanne C",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Bush, Kent W",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Christensen, Will",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Duncan, Richard A",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Goode, Virgil",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Knill, Dennis J",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Reed, Jill A.",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Rogers, Rick L",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Stein, Jill E",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Thorne, Kevin M",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Warner, Gerald L.",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,Democratic,"Obama, Barack",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,Libertarian,"Johnson, Gary",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,Reform,"Baldwin, Chuck",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,Republican,"Romney, Mitt",4,120090
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Ayers, Avery L",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Barnett, Andre",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Barr, Roseanne C",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Bush, Kent W",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Christensen, Will",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Duncan, Richard A",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Goode, Virgil",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Knill, Dennis J",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Reed, Jill A.",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Rogers, Rick L",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Stein, Jill E",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Thorne, Kevin M",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Warner, Gerald L.",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,Democratic,"Obama, Barack",12,600010
+FORD,Dodge City Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,Reform,"Baldwin, Chuck",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,Republican,"Romney, Mitt",41,600010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Ayers, Avery L",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Barnett, Andre",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Barr, Roseanne C",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Bush, Kent W",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Christensen, Will",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Duncan, Richard A",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Goode, Virgil",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Knill, Dennis J",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Reed, Jill A.",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Rogers, Rick L",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Stein, Jill E",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Thorne, Kevin M",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Warner, Gerald L.",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,Democratic,"Obama, Barack",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,Reform,"Baldwin, Chuck",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,Republican,"Romney, Mitt",2,800010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Barnett, Andre",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Bush, Kent W",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Christensen, Will",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Goode, Virgil",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Stein, Jill E",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,Democratic,"Obama, Barack",6,900010
+FORD,Dodge City Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+FORD,Dodge City Precinct 09,President / Vice President,,Republican,"Romney, Mitt",11,900010
+FORD,Bloom Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000010
+FORD,Bucklin City,United States House of Representatives,1,Republican,"Huelskamp, Tim",278,000020
+FORD,Bucklin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",54,000030
+FORD,Concord Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,000040
+FORD,Dodge City Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",468,00005A
+FORD,Dodge City Airport,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00005B
+FORD,Dodge City Industrial Park,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00005C
+FORD,Dodge City Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",289,000060
+FORD,Dodge City Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",354,000070
+FORD,Dodge City Precinct 04,United States House of Representatives,1,Republican,"Huelskamp, Tim",727,00008A
+FORD,Dodge City Excel #1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00008B
+FORD,Dodge City Excel #2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00008C
+FORD,Dodge City Millard,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00008D
+FORD,Dodge City Precinct 05,United States House of Representatives,1,Republican,"Huelskamp, Tim",1224,000090
+FORD,Dodge City Precinct 06,United States House of Representatives,1,Republican,"Huelskamp, Tim",1431,000100
+FORD,Dodge Township Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000200
+FORD,Fairview Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",113,000220
+FORD,Ford City,United States House of Representatives,1,Republican,"Huelskamp, Tim",91,000230
+FORD,Ford Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",72,000240
+FORD,Richland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",180,000260
+FORD,Royal Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",103,000270
+FORD,Sodville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000280
+FORD,Spearville City,United States House of Representatives,1,Republican,"Huelskamp, Tim",308,000300
+FORD,Spearville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",167,000310
+FORD,Wheatland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",66,000320
+FORD,Wilburn Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000330
+FORD,Dodge Township H115,United States House of Representatives,1,Republican,"Huelskamp, Tim",175,120020
+FORD,Dodge Township H119 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,12003A
+FORD,Dodge Township H119,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,120030
+FORD,Enterprise Township H115,United States House of Representatives,1,Republican,"Huelskamp, Tim",157,120040
+FORD,Enterprise Township H119,United States House of Representatives,1,Republican,"Huelskamp, Tim",1,120050
+FORD,Grandview Township H115,United States House of Representatives,1,Republican,"Huelskamp, Tim",152,120060
+FORD,Grandview Township H119 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,12007A
+FORD,Grandview Township H119,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,120070
+FORD,Grandview Township Ward 2 H115,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,120080
+FORD,Grandview Township Ward 2 H119,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,120090
+FORD,Dodge City Precinct 07,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,600010
+FORD,Dodge City Precinct 08,United States House of Representatives,1,Republican,"Huelskamp, Tim",1,800010
+FORD,Dodge City Precinct 09,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,900010

--- a/2012/20121106__ks__general__franklin__precinct.csv
+++ b/2012/20121106__ks__general__franklin__precinct.csv
@@ -1,0 +1,757 @@
+county,precinct,office,district,party,candidate,votes,vtd
+FRANKLIN,Appanoose Township,Kansas House of Representatives,59,Democratic,"Correll, Caleb",33,000010
+FRANKLIN,Appanoose Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",92,000010
+FRANKLIN,Centropolis North Township,Kansas House of Representatives,59,Democratic,"Correll, Caleb",54,000020
+FRANKLIN,Centropolis North Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",158,000020
+FRANKLIN,Centropolis South Township,Kansas House of Representatives,59,Democratic,"Correll, Caleb",60,000030
+FRANKLIN,Centropolis South Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",169,000030
+FRANKLIN,Cutler Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",151,000040
+FRANKLIN,Cutler Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",226,000040
+FRANKLIN,Franklin Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",363,000050
+FRANKLIN,Franklin Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",971,000050
+FRANKLIN,Greenwood Township,Kansas House of Representatives,59,Democratic,"Correll, Caleb",49,000060
+FRANKLIN,Greenwood Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",156,000060
+FRANKLIN,Harrison Township,Kansas House of Representatives,59,Democratic,"Correll, Caleb",44,000070
+FRANKLIN,Harrison Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",214,000070
+FRANKLIN,Hayes Township,Kansas House of Representatives,59,Democratic,"Correll, Caleb",50,000080
+FRANKLIN,Hayes Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",163,000080
+FRANKLIN,Homewood Township,Kansas House of Representatives,59,Democratic,"Correll, Caleb",90,000090
+FRANKLIN,Homewood Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",193,000090
+FRANKLIN,Lincoln Township,Kansas House of Representatives,59,Democratic,"Correll, Caleb",122,000100
+FRANKLIN,Lincoln Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",390,000100
+FRANKLIN,Ohio Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",163,000110
+FRANKLIN,Ohio Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",207,000110
+FRANKLIN,Ottawa Township,Kansas House of Representatives,59,Democratic,"Correll, Caleb",81,00012A
+FRANKLIN,Ottawa Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",323,00012A
+FRANKLIN,Ottawa Precinct 1,Kansas House of Representatives,59,Democratic,"Correll, Caleb",88,00013A
+FRANKLIN,Ottawa Precinct 1,Kansas House of Representatives,59,Republican,"Finch, Blaine",180,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Kansas House of Representatives,59,Democratic,"Correll, Caleb",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Kansas House of Representatives,59,Republican,"Finch, Blaine",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Kansas House of Representatives,59,Democratic,"Correll, Caleb",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Kansas House of Representatives,59,Republican,"Finch, Blaine",0,00013C
+FRANKLIN,Ottawa Precinct 2,Kansas House of Representatives,59,Democratic,"Correll, Caleb",212,000140
+FRANKLIN,Ottawa Precinct 2,Kansas House of Representatives,59,Republican,"Finch, Blaine",440,000140
+FRANKLIN,Ottawa Precinct 3,Kansas House of Representatives,59,Democratic,"Correll, Caleb",100,000150
+FRANKLIN,Ottawa Precinct 3,Kansas House of Representatives,59,Republican,"Finch, Blaine",167,000150
+FRANKLIN,Ottawa Precinct 4,Kansas House of Representatives,59,Democratic,"Correll, Caleb",126,000160
+FRANKLIN,Ottawa Precinct 4,Kansas House of Representatives,59,Republican,"Finch, Blaine",309,000160
+FRANKLIN,Ottawa Precinct 5,Kansas House of Representatives,59,Democratic,"Correll, Caleb",140,000170
+FRANKLIN,Ottawa Precinct 5,Kansas House of Representatives,59,Republican,"Finch, Blaine",431,000170
+FRANKLIN,Ottawa Precinct 6,Kansas House of Representatives,59,Democratic,"Correll, Caleb",85,000180
+FRANKLIN,Ottawa Precinct 6,Kansas House of Representatives,59,Republican,"Finch, Blaine",283,000180
+FRANKLIN,Ottawa Precinct 7,Kansas House of Representatives,59,Democratic,"Correll, Caleb",239,000190
+FRANKLIN,Ottawa Precinct 7,Kansas House of Representatives,59,Republican,"Finch, Blaine",618,000190
+FRANKLIN,Ottawa Precinct 8,Kansas House of Representatives,59,Democratic,"Correll, Caleb",286,00020A
+FRANKLIN,Ottawa Precinct 8,Kansas House of Representatives,59,Republican,"Finch, Blaine",802,00020A
+FRANKLIN,Peoria Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",109,000210
+FRANKLIN,Peoria Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",253,000210
+FRANKLIN,Pomona Township,Kansas House of Representatives,59,Democratic,"Correll, Caleb",92,000220
+FRANKLIN,Pomona Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",328,000220
+FRANKLIN,Pottawatomie Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",139,000230
+FRANKLIN,Pottawatomie Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",136,000230
+FRANKLIN,Richmond Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",189,000240
+FRANKLIN,Richmond Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",158,000240
+FRANKLIN,Williamsburg Township,Kansas House of Representatives,59,Democratic,"Correll, Caleb",83,000250
+FRANKLIN,Williamsburg Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",172,000250
+FRANKLIN,Ottawa Exclave Airport,Kansas House of Representatives,59,Democratic,"Correll, Caleb",0,900010
+FRANKLIN,Ottawa Exclave Airport,Kansas House of Representatives,59,Republican,"Finch, Blaine",0,900010
+FRANKLIN,Appanoose Township,Kansas Senate,12,Democratic,"Cassells, Denise",35,000010
+FRANKLIN,Appanoose Township,Kansas Senate,12,Republican,"Tyson, Caryn",87,000010
+FRANKLIN,Centropolis North Township,Kansas Senate,12,Democratic,"Cassells, Denise",72,000020
+FRANKLIN,Centropolis North Township,Kansas Senate,12,Republican,"Tyson, Caryn",142,000020
+FRANKLIN,Centropolis South Township,Kansas Senate,12,Democratic,"Cassells, Denise",63,000030
+FRANKLIN,Centropolis South Township,Kansas Senate,12,Republican,"Tyson, Caryn",167,000030
+FRANKLIN,Cutler Township,Kansas Senate,12,Democratic,"Cassells, Denise",115,000040
+FRANKLIN,Cutler Township,Kansas Senate,12,Republican,"Tyson, Caryn",253,000040
+FRANKLIN,Franklin Township,Kansas Senate,12,Democratic,"Cassells, Denise",452,000050
+FRANKLIN,Franklin Township,Kansas Senate,12,Republican,"Tyson, Caryn",841,000050
+FRANKLIN,Greenwood Township,Kansas Senate,12,Democratic,"Cassells, Denise",61,000060
+FRANKLIN,Greenwood Township,Kansas Senate,12,Republican,"Tyson, Caryn",146,000060
+FRANKLIN,Harrison Township,Kansas Senate,12,Democratic,"Cassells, Denise",60,000070
+FRANKLIN,Harrison Township,Kansas Senate,12,Republican,"Tyson, Caryn",211,000070
+FRANKLIN,Hayes Township,Kansas Senate,12,Democratic,"Cassells, Denise",63,000080
+FRANKLIN,Hayes Township,Kansas Senate,12,Republican,"Tyson, Caryn",143,000080
+FRANKLIN,Homewood Township,Kansas Senate,12,Democratic,"Cassells, Denise",111,000090
+FRANKLIN,Homewood Township,Kansas Senate,12,Republican,"Tyson, Caryn",171,000090
+FRANKLIN,Lincoln Township,Kansas Senate,12,Democratic,"Cassells, Denise",162,000100
+FRANKLIN,Lincoln Township,Kansas Senate,12,Republican,"Tyson, Caryn",347,000100
+FRANKLIN,Ohio Township,Kansas Senate,12,Democratic,"Cassells, Denise",103,000110
+FRANKLIN,Ohio Township,Kansas Senate,12,Republican,"Tyson, Caryn",256,000110
+FRANKLIN,Ottawa Township,Kansas Senate,12,Democratic,"Cassells, Denise",123,00012A
+FRANKLIN,Ottawa Township,Kansas Senate,12,Republican,"Tyson, Caryn",289,00012A
+FRANKLIN,Ottawa Precinct 1,Kansas Senate,12,Democratic,"Cassells, Denise",85,00013A
+FRANKLIN,Ottawa Precinct 1,Kansas Senate,12,Republican,"Tyson, Caryn",175,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Kansas Senate,12,Democratic,"Cassells, Denise",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Kansas Senate,12,Republican,"Tyson, Caryn",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Kansas Senate,12,Democratic,"Cassells, Denise",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Kansas Senate,12,Republican,"Tyson, Caryn",0,00013C
+FRANKLIN,Ottawa Precinct 2,Kansas Senate,12,Democratic,"Cassells, Denise",244,000140
+FRANKLIN,Ottawa Precinct 2,Kansas Senate,12,Republican,"Tyson, Caryn",402,000140
+FRANKLIN,Ottawa Precinct 3,Kansas Senate,12,Democratic,"Cassells, Denise",116,000150
+FRANKLIN,Ottawa Precinct 3,Kansas Senate,12,Republican,"Tyson, Caryn",148,000150
+FRANKLIN,Ottawa Precinct 4,Kansas Senate,12,Democratic,"Cassells, Denise",181,000160
+FRANKLIN,Ottawa Precinct 4,Kansas Senate,12,Republican,"Tyson, Caryn",249,000160
+FRANKLIN,Ottawa Precinct 5,Kansas Senate,12,Democratic,"Cassells, Denise",198,000170
+FRANKLIN,Ottawa Precinct 5,Kansas Senate,12,Republican,"Tyson, Caryn",366,000170
+FRANKLIN,Ottawa Precinct 6,Kansas Senate,12,Democratic,"Cassells, Denise",133,000180
+FRANKLIN,Ottawa Precinct 6,Kansas Senate,12,Republican,"Tyson, Caryn",226,000180
+FRANKLIN,Ottawa Precinct 7,Kansas Senate,12,Democratic,"Cassells, Denise",328,000190
+FRANKLIN,Ottawa Precinct 7,Kansas Senate,12,Republican,"Tyson, Caryn",523,000190
+FRANKLIN,Ottawa Precinct 8,Kansas Senate,12,Democratic,"Cassells, Denise",411,00020A
+FRANKLIN,Ottawa Precinct 8,Kansas Senate,12,Republican,"Tyson, Caryn",657,00020A
+FRANKLIN,Peoria Township,Kansas Senate,12,Democratic,"Cassells, Denise",114,000210
+FRANKLIN,Peoria Township,Kansas Senate,12,Republican,"Tyson, Caryn",243,000210
+FRANKLIN,Pomona Township,Kansas Senate,12,Democratic,"Cassells, Denise",139,000220
+FRANKLIN,Pomona Township,Kansas Senate,12,Republican,"Tyson, Caryn",269,000220
+FRANKLIN,Pottawatomie Township,Kansas Senate,12,Democratic,"Cassells, Denise",84,000230
+FRANKLIN,Pottawatomie Township,Kansas Senate,12,Republican,"Tyson, Caryn",190,000230
+FRANKLIN,Richmond Township,Kansas Senate,12,Democratic,"Cassells, Denise",120,000240
+FRANKLIN,Richmond Township,Kansas Senate,12,Republican,"Tyson, Caryn",223,000240
+FRANKLIN,Williamsburg Township,Kansas Senate,12,Democratic,"Cassells, Denise",88,000250
+FRANKLIN,Williamsburg Township,Kansas Senate,12,Republican,"Tyson, Caryn",170,000250
+FRANKLIN,Ottawa Exclave Airport,Kansas Senate,12,Democratic,"Cassells, Denise",0,900010
+FRANKLIN,Ottawa Exclave Airport,Kansas Senate,12,Republican,"Tyson, Caryn",0,900010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,Democratic,"Obama, Barack",36,000010
+FRANKLIN,Appanoose Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,Republican,"Romney, Mitt",91,000010
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,Democratic,"Obama, Barack",67,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,Republican,"Romney, Mitt",145,000020
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,Democratic,"Obama, Barack",70,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,Republican,"Romney, Mitt",157,000030
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,Democratic,"Obama, Barack",118,000040
+FRANKLIN,Cutler Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000040
+FRANKLIN,Cutler Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000040
+FRANKLIN,Cutler Township,President / Vice President,,Republican,"Romney, Mitt",264,000040
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Goode, Virgil",1,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,Democratic,"Obama, Barack",428,000050
+FRANKLIN,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",16,000050
+FRANKLIN,Franklin Township,President / Vice President,,Reform,"Baldwin, Chuck",13,000050
+FRANKLIN,Franklin Township,President / Vice President,,Republican,"Romney, Mitt",883,000050
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,Democratic,"Obama, Barack",55,000060
+FRANKLIN,Greenwood Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000060
+FRANKLIN,Greenwood Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+FRANKLIN,Greenwood Township,President / Vice President,,Republican,"Romney, Mitt",154,000060
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,Democratic,"Obama, Barack",58,000070
+FRANKLIN,Harrison Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000070
+FRANKLIN,Harrison Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000070
+FRANKLIN,Harrison Township,President / Vice President,,Republican,"Romney, Mitt",214,000070
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,Democratic,"Obama, Barack",65,000080
+FRANKLIN,Hayes Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000080
+FRANKLIN,Hayes Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000080
+FRANKLIN,Hayes Township,President / Vice President,,Republican,"Romney, Mitt",145,000080
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,Democratic,"Obama, Barack",111,000090
+FRANKLIN,Homewood Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000090
+FRANKLIN,Homewood Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000090
+FRANKLIN,Homewood Township,President / Vice President,,Republican,"Romney, Mitt",167,000090
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",161,000100
+FRANKLIN,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000100
+FRANKLIN,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000100
+FRANKLIN,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",352,000100
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,Democratic,"Obama, Barack",104,000110
+FRANKLIN,Ohio Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000110
+FRANKLIN,Ohio Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000110
+FRANKLIN,Ohio Township,President / Vice President,,Republican,"Romney, Mitt",260,000110
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Ayers, Avery L",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Barnett, Andre",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Bush, Kent W",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Christensen, Will",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Duncan, Richard A",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Goode, Virgil",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Knill, Dennis J",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Reed, Jill A.",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Rogers, Rick L",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Stein, Jill E",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,Democratic,"Obama, Barack",123,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,Libertarian,"Johnson, Gary",4,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,Reform,"Baldwin, Chuck",5,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,Republican,"Romney, Mitt",287,00012A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,Democratic,"Obama, Barack",93,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",7,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,Republican,"Romney, Mitt",172,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Ayers, Avery L",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Barnett, Andre",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Barr, Roseanne C",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Bush, Kent W",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Christensen, Will",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Duncan, Richard A",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Goode, Virgil",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Hoefling, Tom",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Knill, Dennis J",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Reed, Jill A.",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Rogers, Rick L",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Stein, Jill E",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Thorne, Kevin M",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Warner, Gerald L.",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,Democratic,"Obama, Barack",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,Libertarian,"Johnson, Gary",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,Reform,"Baldwin, Chuck",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,Republican,"Romney, Mitt",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Ayers, Avery L",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Barnett, Andre",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Barr, Roseanne C",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Bush, Kent W",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Christensen, Will",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Duncan, Richard A",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Goode, Virgil",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Hoefling, Tom",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Knill, Dennis J",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Reed, Jill A.",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Rogers, Rick L",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Stein, Jill E",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Thorne, Kevin M",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Warner, Gerald L.",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,Democratic,"Obama, Barack",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,Libertarian,"Johnson, Gary",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,Reform,"Baldwin, Chuck",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,Republican,"Romney, Mitt",0,00013C
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,Democratic,"Obama, Barack",253,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",17,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",6,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,Republican,"Romney, Mitt",394,000140
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",1,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,Democratic,"Obama, Barack",110,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",8,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",2,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,Republican,"Romney, Mitt",156,000150
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Goode, Virgil",1,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Stein, Jill E",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,Democratic,"Obama, Barack",185,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",15,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",2,000160
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,Republican,"Romney, Mitt",246,000160
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Barnett, Andre",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Bush, Kent W",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Christensen, Will",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Goode, Virgil",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Stein, Jill E",1,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,Democratic,"Obama, Barack",205,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",13,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,Reform,"Baldwin, Chuck",4,000170
+FRANKLIN,Ottawa Precinct 5,President / Vice President,,Republican,"Romney, Mitt",361,000170
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Barnett, Andre",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Bush, Kent W",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Christensen, Will",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Goode, Virgil",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Stein, Jill E",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,Democratic,"Obama, Barack",142,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,Libertarian,"Johnson, Gary",8,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,Republican,"Romney, Mitt",226,000180
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Barnett, Andre",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Barr, Roseanne C",1,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Bush, Kent W",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Christensen, Will",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Goode, Virgil",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Stein, Jill E",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,Democratic,"Obama, Barack",339,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,Libertarian,"Johnson, Gary",22,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,Reform,"Baldwin, Chuck",9,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,Republican,"Romney, Mitt",518,000190
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Ayers, Avery L",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Barnett, Andre",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Barr, Roseanne C",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Bush, Kent W",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Christensen, Will",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Duncan, Richard A",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Goode, Virgil",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Hoefling, Tom",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Knill, Dennis J",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Reed, Jill A.",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Rogers, Rick L",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Stein, Jill E",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Thorne, Kevin M",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Warner, Gerald L.",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,Democratic,"Obama, Barack",446,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,Libertarian,"Johnson, Gary",10,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,Reform,"Baldwin, Chuck",4,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,Republican,"Romney, Mitt",672,00020A
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,Democratic,"Obama, Barack",99,000210
+FRANKLIN,Peoria Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000210
+FRANKLIN,Peoria Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000210
+FRANKLIN,Peoria Township,President / Vice President,,Republican,"Romney, Mitt",257,000210
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Stein, Jill E",1,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,Democratic,"Obama, Barack",141,000220
+FRANKLIN,Pomona Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000220
+FRANKLIN,Pomona Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000220
+FRANKLIN,Pomona Township,President / Vice President,,Republican,"Romney, Mitt",276,000220
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,Democratic,"Obama, Barack",92,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,Republican,"Romney, Mitt",181,000230
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,Democratic,"Obama, Barack",106,000240
+FRANKLIN,Richmond Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000240
+FRANKLIN,Richmond Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000240
+FRANKLIN,Richmond Township,President / Vice President,,Republican,"Romney, Mitt",239,000240
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,Democratic,"Obama, Barack",87,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,Republican,"Romney, Mitt",167,000250
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Barnett, Andre",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Bush, Kent W",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Christensen, Will",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Goode, Virgil",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Stein, Jill E",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,Democratic,"Obama, Barack",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,Republican,"Romney, Mitt",0,900010
+FRANKLIN,Appanoose Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",33,000010
+FRANKLIN,Appanoose Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000010
+FRANKLIN,Appanoose Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",87,000010
+FRANKLIN,Centropolis North Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",62,000020
+FRANKLIN,Centropolis North Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000020
+FRANKLIN,Centropolis North Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",150,000020
+FRANKLIN,Centropolis South Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",51,000030
+FRANKLIN,Centropolis South Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000030
+FRANKLIN,Centropolis South Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",177,000030
+FRANKLIN,Cutler Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",91,000040
+FRANKLIN,Cutler Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000040
+FRANKLIN,Cutler Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",278,000040
+FRANKLIN,Franklin Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",337,000050
+FRANKLIN,Franklin Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",55,000050
+FRANKLIN,Franklin Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",936,000050
+FRANKLIN,Greenwood Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",44,000060
+FRANKLIN,Greenwood Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000060
+FRANKLIN,Greenwood Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",163,000060
+FRANKLIN,Harrison Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",44,000070
+FRANKLIN,Harrison Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000070
+FRANKLIN,Harrison Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",227,000070
+FRANKLIN,Hayes Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",49,000080
+FRANKLIN,Hayes Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000080
+FRANKLIN,Hayes Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",156,000080
+FRANKLIN,Homewood Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",78,000090
+FRANKLIN,Homewood Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",22,000090
+FRANKLIN,Homewood Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",190,000090
+FRANKLIN,Lincoln Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",125,000100
+FRANKLIN,Lincoln Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",22,000100
+FRANKLIN,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",373,000100
+FRANKLIN,Ohio Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",88,000110
+FRANKLIN,Ohio Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000110
+FRANKLIN,Ohio Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",267,000110
+FRANKLIN,Ottawa Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",97,00012A
+FRANKLIN,Ottawa Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,00012A
+FRANKLIN,Ottawa Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",312,00012A
+FRANKLIN,Ottawa Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",70,00013A
+FRANKLIN,Ottawa Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,00013A
+FRANKLIN,Ottawa Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",187,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013C
+FRANKLIN,Ottawa Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",185,000140
+FRANKLIN,Ottawa Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",22,000140
+FRANKLIN,Ottawa Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",447,000140
+FRANKLIN,Ottawa Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",84,000150
+FRANKLIN,Ottawa Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,000150
+FRANKLIN,Ottawa Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",173,000150
+FRANKLIN,Ottawa Precinct 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",137,000160
+FRANKLIN,Ottawa Precinct 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",25,000160
+FRANKLIN,Ottawa Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",280,000160
+FRANKLIN,Ottawa Precinct 5,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",151,000170
+FRANKLIN,Ottawa Precinct 5,United States House of Representatives,2,Libertarian,"Hawver, Dennis",30,000170
+FRANKLIN,Ottawa Precinct 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",394,000170
+FRANKLIN,Ottawa Precinct 6,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",114,000180
+FRANKLIN,Ottawa Precinct 6,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000180
+FRANKLIN,Ottawa Precinct 6,United States House of Representatives,2,Republican,"Jenkins, Lynn",236,000180
+FRANKLIN,Ottawa Precinct 7,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",261,000190
+FRANKLIN,Ottawa Precinct 7,United States House of Representatives,2,Libertarian,"Hawver, Dennis",42,000190
+FRANKLIN,Ottawa Precinct 7,United States House of Representatives,2,Republican,"Jenkins, Lynn",569,000190
+FRANKLIN,Ottawa Precinct 8,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",324,00020A
+FRANKLIN,Ottawa Precinct 8,United States House of Representatives,2,Libertarian,"Hawver, Dennis",38,00020A
+FRANKLIN,Ottawa Precinct 8,United States House of Representatives,2,Republican,"Jenkins, Lynn",745,00020A
+FRANKLIN,Peoria Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",75,000210
+FRANKLIN,Peoria Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",21,000210
+FRANKLIN,Peoria Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",271,000210
+FRANKLIN,Pomona Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",105,000220
+FRANKLIN,Pomona Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",23,000220
+FRANKLIN,Pomona Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",298,000220
+FRANKLIN,Pottawatomie Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",73,000230
+FRANKLIN,Pottawatomie Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,000230
+FRANKLIN,Pottawatomie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",191,000230
+FRANKLIN,Richmond Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",82,000240
+FRANKLIN,Richmond Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,000240
+FRANKLIN,Richmond Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",255,000240
+FRANKLIN,Williamsburg Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",68,000250
+FRANKLIN,Williamsburg Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",20,000250
+FRANKLIN,Williamsburg Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",173,000250
+FRANKLIN,Ottawa Exclave Airport,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900010
+FRANKLIN,Ottawa Exclave Airport,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900010
+FRANKLIN,Ottawa Exclave Airport,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010

--- a/2012/20121106__ks__general__geary__precinct.csv
+++ b/2012/20121106__ks__general__geary__precinct.csv
@@ -1,0 +1,1872 @@
+county,precinct,office,district,party,candidate,votes,vtd
+GEARY,Blakely Township,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",17,000010
+GEARY,Blakely Township,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",40,000010
+GEARY,Fort Riley Precinct B,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",23,00002B
+GEARY,Fort Riley Precinct B,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",12,00002B
+GEARY,Fort Riley Precinct C,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,00002C
+GEARY,Fort Riley Precinct C,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,00002C
+GEARY,Fort Riley Precinct D,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",3,00002D
+GEARY,Fort Riley Precinct D,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",3,00002D
+GEARY,Fort Riley Precinct E,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,00002E
+GEARY,Fort Riley Precinct E,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,00002E
+GEARY,Fort Riley Precinct F,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,00002F
+GEARY,Fort Riley Precinct F,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,00002F
+GEARY,Fort Riley Precinct G,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",2,00002G
+GEARY,Fort Riley Precinct G,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",5,00002G
+GEARY,Fort Riley Precinct H,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",1,00002H
+GEARY,Fort Riley Precinct H,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",4,00002H
+GEARY,Fort Riley Precinct I,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",3,00002I
+GEARY,Fort Riley Precinct I,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",2,00002I
+GEARY,Fort Riley Precinct J,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",2,00002J
+GEARY,Fort Riley Precinct J,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",1,00002J
+GEARY,Fort Riley Precinct K,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,00002K
+GEARY,Fort Riley Precinct K,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,00002K
+GEARY,Fort Riley Precinct M,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",39,00002M
+GEARY,Fort Riley Precinct M,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",33,00002M
+GEARY,Fort Riley Precinct N,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",4,00002N
+GEARY,Fort Riley Precinct N,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",1,00002N
+GEARY,Fort Riley Milford Township Block 401,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,00002O
+GEARY,Fort Riley Milford Township Block 401,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,00002O
+GEARY,Fort Riley Milford Township Block 501,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,00002P
+GEARY,Fort Riley Milford Township Block 501,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,00002P
+GEARY,Fort Riley Milford Township Block 601,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,00002R
+GEARY,Fort Riley Milford Township Block 701,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,00002R
+GEARY,Wingfield Township,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",35,000040
+GEARY,Wingfield Township,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",44,000040
+GEARY,Jackson Township,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",14,000050
+GEARY,Jackson Township,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",26,000050
+GEARY,Jefferson Township,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",110,000060
+GEARY,Jefferson Township,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",260,000060
+GEARY,Junction City Ward 1 Precinct 1,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",94,00007A
+GEARY,Junction City Ward 1 Precinct 1,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",55,00007A
+GEARY,Junction City Ward 1 Precinct 2,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",60,000080
+GEARY,Junction City Ward 1 Precinct 2,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",56,000080
+GEARY,Junction City Ward 1 Precinct 3,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",100,000090
+GEARY,Junction City Ward 1 Precinct 3,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",135,000090
+GEARY,Junction City Ward 1 Precinct 4,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",383,000100
+GEARY,Junction City Ward 1 Precinct 7,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",377,00013A
+GEARY,Junction City Ward 2 Precinct 1,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",44,000140
+GEARY,Junction City Ward 2 Precinct 1,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",40,000140
+GEARY,Junction City Ward 2 Precinct 2,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",160,000150
+GEARY,Junction City Ward 2 Precinct 2,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",117,000150
+GEARY,Junction City Ward 2 Precinct 3,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",242,00016A
+GEARY,Junction City Ward 3 Precinct 1,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",77,000180
+GEARY,Junction City Ward 3 Precinct 1,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",55,000180
+GEARY,Junction City Ward 3 Precinct 2,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",203,000190
+GEARY,Junction City Ward 3 Precinct 2,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",162,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",66,000230
+GEARY,Junction City Ward 4 Precinct 4,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",30,000230
+GEARY,Liberty Township,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",33,000240
+GEARY,Liberty Township,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",59,000240
+GEARY,Lyon Township,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",149,000250
+GEARY,Marshall Field,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,000260
+GEARY,Marshall Field,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,000260
+GEARY,Milford Township,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",258,000270
+GEARY,Milford Township,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",473,000270
+GEARY,Fort Riley Precinct A S17 A,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,12002A
+GEARY,Fort Riley Precinct A S17 A,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,12002A
+GEARY, Fort Riley Precinct A S17,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",34,120020
+GEARY, Fort Riley Precinct A S17,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",24,120020
+GEARY,Fort Riley Precinct A S22,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",21,120030
+GEARY,Fort Riley Precinct A S22,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",18,120030
+GEARY,Fort Riley Precinct L S17,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",5,120040
+GEARY,Fort Riley Precinct L S17,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",5,120040
+GEARY,Fort Riley Precinct L S22,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,120050
+GEARY,Fort Riley Precinct L S22,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,120050
+GEARY,Junction City Ward 1 Precinct 5 H65,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",52,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",31,120060
+GEARY,Junction City Ward 1 Precinct 5 H68,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",221,120070
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",135,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",52,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",184,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",51,120110
+GEARY,Junction City Ward 4 Precinct 3 H65,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",260,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",141,120120
+GEARY,Junction City Ward 4 Precinct 3 H68,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,120130
+GEARY,Smokey Hill Township S17 H65,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",4,120140
+GEARY,Smokey Hill Township S17 H65,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,120140
+GEARY,Smokey Hill Township S17 H68 A,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",77,12015A
+GEARY,Smokey Hill Township S17 H68 B,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,12015B
+GEARY,Smokey Hill Township S17 H68,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",22,120150
+GEARY,Smokey  Hill Township S22 H65,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",36,120160
+GEARY,Smokey  Hill Township S22 H65,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",45,120160
+GEARY,Smokey Hill Township S22 H68 A,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,12017A
+GEARY,Smokey Hill Township S22 H68,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",162,120170
+GEARY,Smokey Hill Township Enclave A,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,900020
+GEARY,Smokey Hill Township Enclave A,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,900020
+GEARY,Smokey Hill Township Enclave B,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,900030
+GEARY,Smokey Hill Township Enclave C,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,900040
+GEARY,Smokey Hill Township Enclave D,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,900050
+GEARY,Smokey Hill Township Enclave E,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,900060
+GEARY,Smokey Hill Township Enclave F,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,900070
+GEARY,Smokey Hill Township Enclave G,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,900080
+GEARY,Grandview Township,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",44,900090
+GEARY,Grandview Township,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",85,900090
+GEARY,Grandview Township Enclave A,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,900100
+GEARY,Grandview Township Enclave A,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,900100
+GEARY,Junction City Ward 1 Precinct 6 Part 1,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",303,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 2,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,900130
+GEARY,Junction City Ward 2 Precinct 4 Part 1,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",131,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 2,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",35,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 3,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",8,900160
+GEARY,Junction City Ward 4 Precinct 1,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",124,900190
+GEARY,Junction City Ward 4 Precinct 1,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",65,900190
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",0,900200
+GEARY,Junction City Ward 4 Precinct 2,Kansas House of Representatives,65,Democratic,"Saxton, Melody J.",182,900210
+GEARY,Junction City Ward 4 Precinct 2,Kansas House of Representatives,65,Republican,"Rothlisberg, Allan",100,900210
+GEARY,Junction City Ward 4 Precinct 2 Exclave,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,900220
+GEARY,Blakely Township,Kansas Senate,17,Democratic,"Moran, Susan K.",17,000010
+GEARY,Blakely Township,Kansas Senate,17,Republican,"Longbine, Jeff",38,000010
+GEARY,Fort Riley Precinct B,Kansas Senate,17,Democratic,"Moran, Susan K.",23,00002B
+GEARY,Fort Riley Precinct B,Kansas Senate,17,Republican,"Longbine, Jeff",11,00002B
+GEARY,Fort Riley Precinct C,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00002C
+GEARY,Fort Riley Precinct C,Kansas Senate,17,Republican,"Longbine, Jeff",0,00002C
+GEARY,Fort Riley Precinct D,Kansas Senate,17,Democratic,"Moran, Susan K.",2,00002D
+GEARY,Fort Riley Precinct D,Kansas Senate,17,Republican,"Longbine, Jeff",3,00002D
+GEARY,Fort Riley Precinct E,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00002E
+GEARY,Fort Riley Precinct E,Kansas Senate,17,Republican,"Longbine, Jeff",0,00002E
+GEARY,Fort Riley Precinct F,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00002F
+GEARY,Fort Riley Precinct F,Kansas Senate,17,Republican,"Longbine, Jeff",0,00002F
+GEARY,Fort Riley Precinct G,Kansas Senate,17,Democratic,"Moran, Susan K.",2,00002G
+GEARY,Fort Riley Precinct G,Kansas Senate,17,Republican,"Longbine, Jeff",5,00002G
+GEARY,Fort Riley Precinct H,Kansas Senate,17,Democratic,"Moran, Susan K.",1,00002H
+GEARY,Fort Riley Precinct H,Kansas Senate,17,Republican,"Longbine, Jeff",4,00002H
+GEARY,Fort Riley Precinct I,Kansas Senate,17,Democratic,"Moran, Susan K.",3,00002I
+GEARY,Fort Riley Precinct I,Kansas Senate,17,Republican,"Longbine, Jeff",2,00002I
+GEARY,Fort Riley Precinct J,Kansas Senate,17,Democratic,"Moran, Susan K.",3,00002J
+GEARY,Fort Riley Precinct J,Kansas Senate,17,Republican,"Longbine, Jeff",1,00002J
+GEARY,Fort Riley Precinct K,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00002K
+GEARY,Fort Riley Precinct K,Kansas Senate,17,Republican,"Longbine, Jeff",0,00002K
+GEARY,Fort Riley Precinct M,Kansas Senate,17,Democratic,"Moran, Susan K.",42,00002M
+GEARY,Fort Riley Precinct M,Kansas Senate,17,Republican,"Longbine, Jeff",33,00002M
+GEARY,Fort Riley Precinct N,Kansas Senate,17,Democratic,"Moran, Susan K.",4,00002N
+GEARY,Fort Riley Precinct N,Kansas Senate,17,Republican,"Longbine, Jeff",1,00002N
+GEARY,Fort Riley Milford Township Block 401,Kansas Senate,22,Democratic,"Hawk, Tom",0,00002O
+GEARY,Fort Riley Milford Township Block 401,Kansas Senate,22,Republican,"Reader, Bob",0,00002O
+GEARY,Fort Riley Milford Township Block 501,Kansas Senate,22,Democratic,"Hawk, Tom",0,00002P
+GEARY,Fort Riley Milford Township Block 501,Kansas Senate,22,Republican,"Reader, Bob",0,00002P
+GEARY,Fort Riley Milford Township Block 601,Kansas Senate,22,Democratic,"Hawk, Tom",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,Kansas Senate,22,Republican,"Reader, Bob",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,Kansas Senate,22,Democratic,"Hawk, Tom",0,00002R
+GEARY,Fort Riley Milford Township Block 701,Kansas Senate,22,Republican,"Reader, Bob",0,00002R
+GEARY,Wingfield Township,Kansas Senate,17,Democratic,"Moran, Susan K.",31,000040
+GEARY,Wingfield Township,Kansas Senate,17,Republican,"Longbine, Jeff",51,000040
+GEARY,Jackson Township,Kansas Senate,17,Democratic,"Moran, Susan K.",16,000050
+GEARY,Jackson Township,Kansas Senate,17,Republican,"Longbine, Jeff",22,000050
+GEARY,Jefferson Township,Kansas Senate,17,Democratic,"Moran, Susan K.",120,000060
+GEARY,Jefferson Township,Kansas Senate,17,Republican,"Longbine, Jeff",232,000060
+GEARY,Junction City Ward 1 Precinct 1,Kansas Senate,17,Democratic,"Moran, Susan K.",73,00007A
+GEARY,Junction City Ward 1 Precinct 1,Kansas Senate,17,Republican,"Longbine, Jeff",67,00007A
+GEARY,Junction City Ward 1 Precinct 2,Kansas Senate,17,Democratic,"Moran, Susan K.",53,000080
+GEARY,Junction City Ward 1 Precinct 2,Kansas Senate,17,Republican,"Longbine, Jeff",58,000080
+GEARY,Junction City Ward 1 Precinct 3,Kansas Senate,17,Democratic,"Moran, Susan K.",71,000090
+GEARY,Junction City Ward 1 Precinct 3,Kansas Senate,17,Republican,"Longbine, Jeff",160,000090
+GEARY,Junction City Ward 1 Precinct 4,Kansas Senate,17,Democratic,"Moran, Susan K.",173,000100
+GEARY,Junction City Ward 1 Precinct 4,Kansas Senate,17,Republican,"Longbine, Jeff",308,000100
+GEARY,Junction City Ward 1 Precinct 7,Kansas Senate,17,Democratic,"Moran, Susan K.",237,00013A
+GEARY,Junction City Ward 1 Precinct 7,Kansas Senate,17,Republican,"Longbine, Jeff",260,00013A
+GEARY,Junction City Ward 2 Precinct 1,Kansas Senate,17,Democratic,"Moran, Susan K.",41,000140
+GEARY,Junction City Ward 2 Precinct 1,Kansas Senate,17,Republican,"Longbine, Jeff",43,000140
+GEARY,Junction City Ward 2 Precinct 2,Kansas Senate,17,Democratic,"Moran, Susan K.",123,000150
+GEARY,Junction City Ward 2 Precinct 2,Kansas Senate,17,Republican,"Longbine, Jeff",137,000150
+GEARY,Junction City Ward 2 Precinct 3,Kansas Senate,17,Democratic,"Moran, Susan K.",131,00016A
+GEARY,Junction City Ward 2 Precinct 3,Kansas Senate,17,Republican,"Longbine, Jeff",170,00016A
+GEARY,Junction City Ward 3 Precinct 1,Kansas Senate,17,Democratic,"Moran, Susan K.",75,000180
+GEARY,Junction City Ward 3 Precinct 1,Kansas Senate,17,Republican,"Longbine, Jeff",51,000180
+GEARY,Junction City Ward 3 Precinct 2,Kansas Senate,17,Democratic,"Moran, Susan K.",197,000190
+GEARY,Junction City Ward 3 Precinct 2,Kansas Senate,17,Republican,"Longbine, Jeff",152,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Kansas Senate,22,Democratic,"Hawk, Tom",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Kansas Senate,22,Republican,"Reader, Bob",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,Kansas Senate,17,Democratic,"Moran, Susan K.",66,000230
+GEARY,Junction City Ward 4 Precinct 4,Kansas Senate,17,Republican,"Longbine, Jeff",27,000230
+GEARY,Liberty Township,Kansas Senate,17,Democratic,"Moran, Susan K.",33,000240
+GEARY,Liberty Township,Kansas Senate,17,Republican,"Longbine, Jeff",59,000240
+GEARY,Lyon Township,Kansas Senate,17,Democratic,"Moran, Susan K.",30,000250
+GEARY,Lyon Township,Kansas Senate,17,Republican,"Longbine, Jeff",126,000250
+GEARY,Marshall Field,Kansas Senate,17,Democratic,"Moran, Susan K.",0,000260
+GEARY,Marshall Field,Kansas Senate,17,Republican,"Longbine, Jeff",0,000260
+GEARY,Milford Township,Kansas Senate,22,Democratic,"Hawk, Tom",226,000270
+GEARY,Milford Township,Kansas Senate,22,Republican,"Reader, Bob",493,000270
+GEARY,Fort Riley Precinct A S17 A,Kansas Senate,17,Democratic,"Moran, Susan K.",0,12002A
+GEARY,Fort Riley Precinct A S17 A,Kansas Senate,17,Republican,"Longbine, Jeff",0,12002A
+GEARY, Fort Riley Precinct A S17,Kansas Senate,17,Democratic,"Moran, Susan K.",32,120020
+GEARY, Fort Riley Precinct A S17,Kansas Senate,17,Republican,"Longbine, Jeff",27,120020
+GEARY,Fort Riley Precinct A S22,Kansas Senate,22,Democratic,"Hawk, Tom",20,120030
+GEARY,Fort Riley Precinct A S22,Kansas Senate,22,Republican,"Reader, Bob",19,120030
+GEARY,Fort Riley Precinct L S17,Kansas Senate,17,Democratic,"Moran, Susan K.",5,120040
+GEARY,Fort Riley Precinct L S17,Kansas Senate,17,Republican,"Longbine, Jeff",5,120040
+GEARY,Fort Riley Precinct L S22,Kansas Senate,22,Democratic,"Hawk, Tom",0,120050
+GEARY,Fort Riley Precinct L S22,Kansas Senate,22,Republican,"Reader, Bob",0,120050
+GEARY,Junction City Ward 1 Precinct 5 H65,Kansas Senate,17,Democratic,"Moran, Susan K.",42,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,Kansas Senate,17,Republican,"Longbine, Jeff",39,120060
+GEARY,Junction City Ward 1 Precinct 5 H68,Kansas Senate,17,Democratic,"Moran, Susan K.",152,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,Kansas Senate,17,Republican,"Longbine, Jeff",151,120070
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,Kansas Senate,17,Democratic,"Moran, Susan K.",93,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,Kansas Senate,17,Republican,"Longbine, Jeff",78,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,Kansas Senate,22,Democratic,"Hawk, Tom",20,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,Kansas Senate,22,Republican,"Reader, Bob",41,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,Kansas Senate,17,Democratic,"Moran, Susan K.",108,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,Kansas Senate,17,Republican,"Longbine, Jeff",127,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,Kansas Senate,22,Democratic,"Hawk, Tom",24,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,Kansas Senate,22,Republican,"Reader, Bob",33,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,Kansas Senate,22,Democratic,"Hawk, Tom",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,Kansas Senate,22,Republican,"Reader, Bob",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,Kansas Senate,22,Democratic,"Hawk, Tom",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,Kansas Senate,22,Republican,"Reader, Bob",0,120110
+GEARY,Junction City Ward 4 Precinct 3 H65,Kansas Senate,17,Democratic,"Moran, Susan K.",243,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,Kansas Senate,17,Republican,"Longbine, Jeff",135,120120
+GEARY,Junction City Ward 4 Precinct 3 H68,Kansas Senate,17,Democratic,"Moran, Susan K.",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,Kansas Senate,17,Republican,"Longbine, Jeff",0,120130
+GEARY,Smokey Hill Township S17 H65,Kansas Senate,17,Democratic,"Moran, Susan K.",3,120140
+GEARY,Smokey Hill Township S17 H65,Kansas Senate,17,Republican,"Longbine, Jeff",0,120140
+GEARY,Smokey Hill Township S17 H68 A,Kansas Senate,17,Democratic,"Moran, Susan K.",25,12015A
+GEARY,Smokey Hill Township S17 H68 A,Kansas Senate,17,Republican,"Longbine, Jeff",65,12015A
+GEARY,Smokey Hill Township S17 H68 B,Kansas Senate,17,Democratic,"Moran, Susan K.",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,Kansas Senate,17,Republican,"Longbine, Jeff",0,12015B
+GEARY,Smokey Hill Township S17 H68,Kansas Senate,17,Democratic,"Moran, Susan K.",5,120150
+GEARY,Smokey Hill Township S17 H68,Kansas Senate,17,Republican,"Longbine, Jeff",20,120150
+GEARY,Smokey  Hill Township S22 H65,Kansas Senate,22,Democratic,"Hawk, Tom",34,120160
+GEARY,Smokey  Hill Township S22 H65,Kansas Senate,22,Republican,"Reader, Bob",49,120160
+GEARY,Smokey Hill Township S22 H68 A,Kansas Senate,22,Democratic,"Hawk, Tom",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,Kansas Senate,22,Republican,"Reader, Bob",0,12017A
+GEARY,Smokey Hill Township S22 H68,Kansas Senate,22,Democratic,"Hawk, Tom",45,120170
+GEARY,Smokey Hill Township S22 H68,Kansas Senate,22,Republican,"Reader, Bob",124,120170
+GEARY,Smokey Hill Township Enclave A,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900020
+GEARY,Smokey Hill Township Enclave A,Kansas Senate,17,Republican,"Longbine, Jeff",0,900020
+GEARY,Smokey Hill Township Enclave B,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900030
+GEARY,Smokey Hill Township Enclave B,Kansas Senate,17,Republican,"Longbine, Jeff",0,900030
+GEARY,Smokey Hill Township Enclave C,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900040
+GEARY,Smokey Hill Township Enclave C,Kansas Senate,17,Republican,"Longbine, Jeff",0,900040
+GEARY,Smokey Hill Township Enclave D,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900050
+GEARY,Smokey Hill Township Enclave D,Kansas Senate,17,Republican,"Longbine, Jeff",0,900050
+GEARY,Smokey Hill Township Enclave E,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900060
+GEARY,Smokey Hill Township Enclave E,Kansas Senate,17,Republican,"Longbine, Jeff",0,900060
+GEARY,Smokey Hill Township Enclave F,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900070
+GEARY,Smokey Hill Township Enclave F,Kansas Senate,17,Republican,"Longbine, Jeff",0,900070
+GEARY,Smokey Hill Township Enclave G,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900080
+GEARY,Smokey Hill Township Enclave G,Kansas Senate,17,Republican,"Longbine, Jeff",0,900080
+GEARY,Grandview Township,Kansas Senate,17,Democratic,"Moran, Susan K.",50,900090
+GEARY,Grandview Township,Kansas Senate,17,Republican,"Longbine, Jeff",70,900090
+GEARY,Grandview Township Enclave A,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900100
+GEARY,Grandview Township Enclave A,Kansas Senate,17,Republican,"Longbine, Jeff",0,900100
+GEARY,Junction City Ward 1 Precinct 6 Part 1,Kansas Senate,17,Democratic,"Moran, Susan K.",186,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,Kansas Senate,17,Republican,"Longbine, Jeff",217,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 2,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,Kansas Senate,17,Republican,"Longbine, Jeff",0,900130
+GEARY,Junction City Ward 2 Precinct 4 Part 1,Kansas Senate,17,Democratic,"Moran, Susan K.",87,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,Kansas Senate,17,Republican,"Longbine, Jeff",90,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 2,Kansas Senate,17,Democratic,"Moran, Susan K.",17,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,Kansas Senate,17,Republican,"Longbine, Jeff",31,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 3,Kansas Senate,17,Democratic,"Moran, Susan K.",4,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,Kansas Senate,17,Republican,"Longbine, Jeff",9,900160
+GEARY,Junction City Ward 4 Precinct 1,Kansas Senate,17,Democratic,"Moran, Susan K.",122,900190
+GEARY,Junction City Ward 4 Precinct 1,Kansas Senate,17,Republican,"Longbine, Jeff",68,900190
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,Kansas Senate,17,Republican,"Longbine, Jeff",0,900200
+GEARY,Junction City Ward 4 Precinct 2,Kansas Senate,17,Democratic,"Moran, Susan K.",164,900210
+GEARY,Junction City Ward 4 Precinct 2,Kansas Senate,17,Republican,"Longbine, Jeff",107,900210
+GEARY,Junction City Ward 4 Precinct 2 Exclave,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,Kansas Senate,17,Republican,"Longbine, Jeff",0,900220
+GEARY,Blakely Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+GEARY,Blakely Township,President / Vice President,,Democratic,"Obama, Barack",9,000010
+GEARY,Blakely Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+GEARY,Blakely Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+GEARY,Blakely Township,President / Vice President,,Republican,"Romney, Mitt",48,000010
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Ayers, Avery L",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Barnett, Andre",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Barr, Roseanne C",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Bush, Kent W",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Christensen, Will",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Duncan, Richard A",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Goode, Virgil",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Hoefling, Tom",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Knill, Dennis J",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Reed, Jill A.",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Rogers, Rick L",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Stein, Jill E",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Thorne, Kevin M",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Warner, Gerald L.",0,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,Democratic,"Obama, Barack",21,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,Libertarian,"Johnson, Gary",1,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,Reform,"Baldwin, Chuck",1,00002B
+GEARY,Fort Riley Precinct B,President / Vice President,,Republican,"Romney, Mitt",14,00002B
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Ayers, Avery L",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Barnett, Andre",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Barr, Roseanne C",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Bush, Kent W",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Christensen, Will",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Duncan, Richard A",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Goode, Virgil",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Hoefling, Tom",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Knill, Dennis J",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Reed, Jill A.",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Rogers, Rick L",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Stein, Jill E",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Thorne, Kevin M",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,write - in,"Warner, Gerald L.",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,Democratic,"Obama, Barack",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,Libertarian,"Johnson, Gary",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,Reform,"Baldwin, Chuck",0,00002C
+GEARY,Fort Riley Precinct C,President / Vice President,,Republican,"Romney, Mitt",0,00002C
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Ayers, Avery L",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Barnett, Andre",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Barr, Roseanne C",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Bush, Kent W",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Christensen, Will",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Duncan, Richard A",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Goode, Virgil",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Hoefling, Tom",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Knill, Dennis J",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Reed, Jill A.",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Rogers, Rick L",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Stein, Jill E",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Thorne, Kevin M",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,write - in,"Warner, Gerald L.",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,Democratic,"Obama, Barack",4,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,Libertarian,"Johnson, Gary",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,Reform,"Baldwin, Chuck",0,00002D
+GEARY,Fort Riley Precinct D,President / Vice President,,Republican,"Romney, Mitt",4,00002D
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Ayers, Avery L",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Barnett, Andre",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Barr, Roseanne C",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Bush, Kent W",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Christensen, Will",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Duncan, Richard A",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Goode, Virgil",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Hoefling, Tom",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Knill, Dennis J",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Reed, Jill A.",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Rogers, Rick L",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Stein, Jill E",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Thorne, Kevin M",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,write - in,"Warner, Gerald L.",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,Democratic,"Obama, Barack",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,Libertarian,"Johnson, Gary",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,Reform,"Baldwin, Chuck",0,00002E
+GEARY,Fort Riley Precinct E,President / Vice President,,Republican,"Romney, Mitt",0,00002E
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Ayers, Avery L",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Barnett, Andre",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Barr, Roseanne C",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Bush, Kent W",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Christensen, Will",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Duncan, Richard A",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Goode, Virgil",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Hoefling, Tom",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Knill, Dennis J",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Reed, Jill A.",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Rogers, Rick L",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Stein, Jill E",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Thorne, Kevin M",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,write - in,"Warner, Gerald L.",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,Democratic,"Obama, Barack",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,Libertarian,"Johnson, Gary",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,Reform,"Baldwin, Chuck",0,00002F
+GEARY,Fort Riley Precinct F,President / Vice President,,Republican,"Romney, Mitt",0,00002F
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Ayers, Avery L",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Barnett, Andre",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Barr, Roseanne C",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Bush, Kent W",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Christensen, Will",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Duncan, Richard A",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Goode, Virgil",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Hoefling, Tom",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Knill, Dennis J",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Reed, Jill A.",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Rogers, Rick L",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Stein, Jill E",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Thorne, Kevin M",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,write - in,"Warner, Gerald L.",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,Democratic,"Obama, Barack",2,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,Libertarian,"Johnson, Gary",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,Reform,"Baldwin, Chuck",0,00002G
+GEARY,Fort Riley Precinct G,President / Vice President,,Republican,"Romney, Mitt",5,00002G
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Ayers, Avery L",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Barnett, Andre",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Barr, Roseanne C",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Bush, Kent W",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Christensen, Will",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Duncan, Richard A",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Goode, Virgil",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Hoefling, Tom",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Knill, Dennis J",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Reed, Jill A.",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Rogers, Rick L",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Stein, Jill E",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Thorne, Kevin M",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,write - in,"Warner, Gerald L.",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,Democratic,"Obama, Barack",1,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,Libertarian,"Johnson, Gary",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,Reform,"Baldwin, Chuck",0,00002H
+GEARY,Fort Riley Precinct H,President / Vice President,,Republican,"Romney, Mitt",4,00002H
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Ayers, Avery L",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Barnett, Andre",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Barr, Roseanne C",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Bush, Kent W",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Christensen, Will",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Duncan, Richard A",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Goode, Virgil",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Hoefling, Tom",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Knill, Dennis J",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Reed, Jill A.",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Rogers, Rick L",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Stein, Jill E",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Thorne, Kevin M",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,write - in,"Warner, Gerald L.",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,Democratic,"Obama, Barack",1,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,Libertarian,"Johnson, Gary",1,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,Reform,"Baldwin, Chuck",0,00002I
+GEARY,Fort Riley Precinct I,President / Vice President,,Republican,"Romney, Mitt",4,00002I
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Ayers, Avery L",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Barnett, Andre",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Barr, Roseanne C",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Bush, Kent W",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Christensen, Will",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Duncan, Richard A",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Goode, Virgil",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Hoefling, Tom",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Knill, Dennis J",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Reed, Jill A.",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Rogers, Rick L",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Stein, Jill E",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Thorne, Kevin M",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,write - in,"Warner, Gerald L.",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,Democratic,"Obama, Barack",2,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,Libertarian,"Johnson, Gary",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,Reform,"Baldwin, Chuck",0,00002J
+GEARY,Fort Riley Precinct J,President / Vice President,,Republican,"Romney, Mitt",3,00002J
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Ayers, Avery L",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Barnett, Andre",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Barr, Roseanne C",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Bush, Kent W",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Christensen, Will",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Duncan, Richard A",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Goode, Virgil",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Hoefling, Tom",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Knill, Dennis J",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Reed, Jill A.",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Rogers, Rick L",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Stein, Jill E",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Thorne, Kevin M",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,write - in,"Warner, Gerald L.",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,Democratic,"Obama, Barack",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,Libertarian,"Johnson, Gary",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,Reform,"Baldwin, Chuck",0,00002K
+GEARY,Fort Riley Precinct K,President / Vice President,,Republican,"Romney, Mitt",0,00002K
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Ayers, Avery L",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Barnett, Andre",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Barr, Roseanne C",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Bush, Kent W",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Christensen, Will",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Duncan, Richard A",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Goode, Virgil",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Hoefling, Tom",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Knill, Dennis J",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Reed, Jill A.",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Rogers, Rick L",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Stein, Jill E",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Thorne, Kevin M",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,write - in,"Warner, Gerald L.",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,Democratic,"Obama, Barack",38,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,Libertarian,"Johnson, Gary",1,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,Reform,"Baldwin, Chuck",0,00002M
+GEARY,Fort Riley Precinct M,President / Vice President,,Republican,"Romney, Mitt",42,00002M
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Ayers, Avery L",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Barnett, Andre",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Barr, Roseanne C",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Bush, Kent W",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Christensen, Will",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Duncan, Richard A",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Goode, Virgil",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Hoefling, Tom",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Knill, Dennis J",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Reed, Jill A.",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Rogers, Rick L",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Stein, Jill E",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Thorne, Kevin M",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,write - in,"Warner, Gerald L.",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,Democratic,"Obama, Barack",4,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,Libertarian,"Johnson, Gary",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,Reform,"Baldwin, Chuck",0,00002N
+GEARY,Fort Riley Precinct N,President / Vice President,,Republican,"Romney, Mitt",1,00002N
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Ayers, Avery L",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Barnett, Andre",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Barr, Roseanne C",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Bush, Kent W",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Christensen, Will",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Duncan, Richard A",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Goode, Virgil",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Hoefling, Tom",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Knill, Dennis J",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Reed, Jill A.",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Rogers, Rick L",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Stein, Jill E",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Thorne, Kevin M",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Warner, Gerald L.",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,Democratic,"Obama, Barack",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,Libertarian,"Johnson, Gary",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,Reform,"Baldwin, Chuck",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,Republican,"Romney, Mitt",0,00002O
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Ayers, Avery L",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Barnett, Andre",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Barr, Roseanne C",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Bush, Kent W",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Christensen, Will",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Duncan, Richard A",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Goode, Virgil",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Hoefling, Tom",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Knill, Dennis J",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Reed, Jill A.",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Rogers, Rick L",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Stein, Jill E",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Thorne, Kevin M",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Warner, Gerald L.",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,Democratic,"Obama, Barack",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,Libertarian,"Johnson, Gary",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,Reform,"Baldwin, Chuck",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,Republican,"Romney, Mitt",0,00002P
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Ayers, Avery L",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Barnett, Andre",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Barr, Roseanne C",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Bush, Kent W",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Christensen, Will",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Duncan, Richard A",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Goode, Virgil",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Hoefling, Tom",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Knill, Dennis J",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Reed, Jill A.",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Rogers, Rick L",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Stein, Jill E",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Thorne, Kevin M",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Warner, Gerald L.",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,Democratic,"Obama, Barack",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,Libertarian,"Johnson, Gary",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,Reform,"Baldwin, Chuck",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,Republican,"Romney, Mitt",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Ayers, Avery L",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Barnett, Andre",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Barr, Roseanne C",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Bush, Kent W",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Christensen, Will",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Duncan, Richard A",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Goode, Virgil",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Hoefling, Tom",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Knill, Dennis J",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Reed, Jill A.",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Rogers, Rick L",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Stein, Jill E",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Thorne, Kevin M",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Warner, Gerald L.",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,Democratic,"Obama, Barack",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,Libertarian,"Johnson, Gary",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,Reform,"Baldwin, Chuck",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,Republican,"Romney, Mitt",0,00002R
+GEARY,Wingfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+GEARY,Wingfield Township,President / Vice President,,Democratic,"Obama, Barack",27,000040
+GEARY,Wingfield Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+GEARY,Wingfield Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000040
+GEARY,Wingfield Township,President / Vice President,,Republican,"Romney, Mitt",52,000040
+GEARY,Jackson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+GEARY,Jackson Township,President / Vice President,,Democratic,"Obama, Barack",16,000050
+GEARY,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+GEARY,Jackson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+GEARY,Jackson Township,President / Vice President,,Republican,"Romney, Mitt",25,000050
+GEARY,Jefferson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+GEARY,Jefferson Township,President / Vice President,,Democratic,"Obama, Barack",103,000060
+GEARY,Jefferson Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000060
+GEARY,Jefferson Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000060
+GEARY,Jefferson Township,President / Vice President,,Republican,"Romney, Mitt",264,000060
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",79,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",4,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",74,00007A
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",61,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",61,000080
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",1,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",70,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",172,000090
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Goode, Virgil",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Stein, Jill E",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,Democratic,"Obama, Barack",197,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",3,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",3,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,Republican,"Romney, Mitt",323,000100
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Ayers, Avery L",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Barnett, Andre",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Barr, Roseanne C",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Bush, Kent W",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Christensen, Will",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Duncan, Richard A",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Goode, Virgil",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Knill, Dennis J",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Reed, Jill A.",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Rogers, Rick L",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Stein, Jill E",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Thorne, Kevin M",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Warner, Gerald L.",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,Democratic,"Obama, Barack",246,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,Libertarian,"Johnson, Gary",9,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,Reform,"Baldwin, Chuck",1,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,Republican,"Romney, Mitt",269,00013A
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",44,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",39,000140
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",131,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",5,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",152,000150
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",146,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",2,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",170,00016A
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",86,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",49,000180
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",187,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",7,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",182,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Ayers, Avery L",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Barnett, Andre",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Barr, Roseanne C",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Bush, Kent W",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Christensen, Will",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Duncan, Richard A",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Goode, Virgil",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Hoefling, Tom",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Knill, Dennis J",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Reed, Jill A.",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Rogers, Rick L",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Stein, Jill E",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Thorne, Kevin M",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Warner, Gerald L.",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,Democratic,"Obama, Barack",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,Libertarian,"Johnson, Gary",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,Reform,"Baldwin, Chuck",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,Republican,"Romney, Mitt",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Goode, Virgil",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Stein, Jill E",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,Democratic,"Obama, Barack",76,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",2,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",1,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,Republican,"Romney, Mitt",32,000230
+GEARY,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+GEARY,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",32,000240
+GEARY,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000240
+GEARY,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000240
+GEARY,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",59,000240
+GEARY,Lyon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Stein, Jill E",1,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+GEARY,Lyon Township,President / Vice President,,Democratic,"Obama, Barack",22,000250
+GEARY,Lyon Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+GEARY,Lyon Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+GEARY,Lyon Township,President / Vice President,,Republican,"Romney, Mitt",144,000250
+GEARY,Marshall Field,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Barnett, Andre",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Bush, Kent W",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Christensen, Will",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Goode, Virgil",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Stein, Jill E",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+GEARY,Marshall Field,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+GEARY,Marshall Field,President / Vice President,,Democratic,"Obama, Barack",0,000260
+GEARY,Marshall Field,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+GEARY,Marshall Field,President / Vice President,,Reform,"Baldwin, Chuck",0,000260
+GEARY,Marshall Field,President / Vice President,,Republican,"Romney, Mitt",0,000260
+GEARY,Milford Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Barnett, Andre",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Bush, Kent W",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Christensen, Will",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Goode, Virgil",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Hoefling, Tom",1,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Stein, Jill E",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+GEARY,Milford Township,President / Vice President,,Democratic,"Obama, Barack",210,000270
+GEARY,Milford Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000270
+GEARY,Milford Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000270
+GEARY,Milford Township,President / Vice President,,Republican,"Romney, Mitt",520,000270
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Ayers, Avery L",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Barnett, Andre",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Bush, Kent W",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Christensen, Will",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Duncan, Richard A",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Goode, Virgil",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Hoefling, Tom",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Knill, Dennis J",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Reed, Jill A.",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Rogers, Rick L",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Stein, Jill E",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,Democratic,"Obama, Barack",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12002A
+GEARY,Fort Riley Precinct A S17 A,President / Vice President,,Republican,"Romney, Mitt",0,12002A
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Barnett, Andre",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Bush, Kent W",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Christensen, Will",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Goode, Virgil",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Stein, Jill E",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,Democratic,"Obama, Barack",30,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+GEARY, Fort Riley Precinct A S17,President / Vice President,,Republican,"Romney, Mitt",30,120020
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Barnett, Andre",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Bush, Kent W",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Christensen, Will",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Goode, Virgil",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Stein, Jill E",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,Democratic,"Obama, Barack",19,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,Libertarian,"Johnson, Gary",2,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+GEARY,Fort Riley Precinct A S22,President / Vice President,,Republican,"Romney, Mitt",19,120030
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Barnett, Andre",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Bush, Kent W",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Christensen, Will",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Goode, Virgil",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Stein, Jill E",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,Democratic,"Obama, Barack",7,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,Libertarian,"Johnson, Gary",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,Reform,"Baldwin, Chuck",0,120040
+GEARY,Fort Riley Precinct L S17,President / Vice President,,Republican,"Romney, Mitt",5,120040
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Barnett, Andre",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Bush, Kent W",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Christensen, Will",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Goode, Virgil",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Stein, Jill E",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,Democratic,"Obama, Barack",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,Libertarian,"Johnson, Gary",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,Reform,"Baldwin, Chuck",0,120050
+GEARY,Fort Riley Precinct L S22,President / Vice President,,Republican,"Romney, Mitt",0,120050
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Ayers, Avery L",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Barnett, Andre",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Barr, Roseanne C",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Bush, Kent W",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Christensen, Will",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Duncan, Richard A",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Goode, Virgil",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Knill, Dennis J",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Reed, Jill A.",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Rogers, Rick L",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Stein, Jill E",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Thorne, Kevin M",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,write - in,"Warner, Gerald L.",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,Democratic,"Obama, Barack",37,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,Libertarian,"Johnson, Gary",0,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,Reform,"Baldwin, Chuck",1,120060
+GEARY,Junction City Ward 1 Precinct 5 H65,President / Vice President,,Republican,"Romney, Mitt",50,120060
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Ayers, Avery L",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Barnett, Andre",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Barr, Roseanne C",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Bush, Kent W",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Christensen, Will",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Duncan, Richard A",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Goode, Virgil",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Knill, Dennis J",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Reed, Jill A.",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Rogers, Rick L",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Stein, Jill E",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Thorne, Kevin M",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,write - in,"Warner, Gerald L.",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,Democratic,"Obama, Barack",148,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,Libertarian,"Johnson, Gary",5,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,Reform,"Baldwin, Chuck",0,120070
+GEARY,Junction City Ward 1 Precinct 5 H68,President / Vice President,,Republican,"Romney, Mitt",167,120070
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Ayers, Avery L",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Barnett, Andre",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Barr, Roseanne C",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Bush, Kent W",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Christensen, Will",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Duncan, Richard A",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Goode, Virgil",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Knill, Dennis J",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Reed, Jill A.",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Rogers, Rick L",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Stein, Jill E",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Thorne, Kevin M",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,write - in,"Warner, Gerald L.",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,Democratic,"Obama, Barack",93,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,Libertarian,"Johnson, Gary",1,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,Reform,"Baldwin, Chuck",0,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,President / Vice President,,Republican,"Romney, Mitt",88,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Ayers, Avery L",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Barnett, Andre",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Barr, Roseanne C",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Bush, Kent W",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Christensen, Will",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Duncan, Richard A",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Goode, Virgil",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Knill, Dennis J",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Reed, Jill A.",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Rogers, Rick L",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Stein, Jill E",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Thorne, Kevin M",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,write - in,"Warner, Gerald L.",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,Democratic,"Obama, Barack",23,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,Libertarian,"Johnson, Gary",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,Reform,"Baldwin, Chuck",0,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,President / Vice President,,Republican,"Romney, Mitt",42,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Ayers, Avery L",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Barnett, Andre",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Barr, Roseanne C",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Bush, Kent W",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Christensen, Will",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Duncan, Richard A",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Goode, Virgil",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Hoefling, Tom",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Knill, Dennis J",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Reed, Jill A.",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Rogers, Rick L",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Stein, Jill E",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Thorne, Kevin M",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,write - in,"Warner, Gerald L.",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,Democratic,"Obama, Barack",113,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,Libertarian,"Johnson, Gary",1,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,Reform,"Baldwin, Chuck",0,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,President / Vice President,,Republican,"Romney, Mitt",138,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Ayers, Avery L",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Barnett, Andre",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Bush, Kent W",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Christensen, Will",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Duncan, Richard A",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Goode, Virgil",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Hoefling, Tom",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Knill, Dennis J",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Reed, Jill A.",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Rogers, Rick L",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Stein, Jill E",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,Democratic,"Obama, Barack",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,President / Vice President,,Republican,"Romney, Mitt",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Ayers, Avery L",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Barnett, Andre",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Barr, Roseanne C",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Bush, Kent W",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Christensen, Will",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Duncan, Richard A",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Goode, Virgil",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Hoefling, Tom",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Knill, Dennis J",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Reed, Jill A.",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Rogers, Rick L",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Stein, Jill E",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Thorne, Kevin M",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,write - in,"Warner, Gerald L.",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,Democratic,"Obama, Barack",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,Libertarian,"Johnson, Gary",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,Reform,"Baldwin, Chuck",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,President / Vice President,,Republican,"Romney, Mitt",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Ayers, Avery L",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Barnett, Andre",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Barr, Roseanne C",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Bush, Kent W",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Christensen, Will",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Duncan, Richard A",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Goode, Virgil",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Hoefling, Tom",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Knill, Dennis J",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Reed, Jill A.",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Rogers, Rick L",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Stein, Jill E",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Thorne, Kevin M",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,write - in,"Warner, Gerald L.",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,Democratic,"Obama, Barack",22,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,Libertarian,"Johnson, Gary",1,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,Reform,"Baldwin, Chuck",0,120110
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,President / Vice President,,Republican,"Romney, Mitt",37,120110
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Ayers, Avery L",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Barnett, Andre",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Barr, Roseanne C",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Bush, Kent W",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Christensen, Will",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Duncan, Richard A",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Goode, Virgil",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Hoefling, Tom",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Knill, Dennis J",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Reed, Jill A.",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Rogers, Rick L",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Stein, Jill E",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Thorne, Kevin M",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,write - in,"Warner, Gerald L.",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,Democratic,"Obama, Barack",261,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,Libertarian,"Johnson, Gary",4,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,Reform,"Baldwin, Chuck",0,120120
+GEARY,Junction City Ward 4 Precinct 3 H65,President / Vice President,,Republican,"Romney, Mitt",161,120120
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Ayers, Avery L",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Barnett, Andre",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Barr, Roseanne C",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Bush, Kent W",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Christensen, Will",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Duncan, Richard A",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Goode, Virgil",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Hoefling, Tom",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Knill, Dennis J",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Reed, Jill A.",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Rogers, Rick L",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Stein, Jill E",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Thorne, Kevin M",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,write - in,"Warner, Gerald L.",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,Democratic,"Obama, Barack",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,Libertarian,"Johnson, Gary",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,Reform,"Baldwin, Chuck",0,120130
+GEARY,Junction City Ward 4 Precinct 3 H68,President / Vice President,,Republican,"Romney, Mitt",0,120130
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Ayers, Avery L",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Barnett, Andre",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Barr, Roseanne C",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Bush, Kent W",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Christensen, Will",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Duncan, Richard A",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Goode, Virgil",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Hoefling, Tom",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Knill, Dennis J",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Reed, Jill A.",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Rogers, Rick L",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Stein, Jill E",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Thorne, Kevin M",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,write - in,"Warner, Gerald L.",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,Democratic,"Obama, Barack",4,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,Libertarian,"Johnson, Gary",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,Reform,"Baldwin, Chuck",0,120140
+GEARY,Smokey Hill Township S17 H65,President / Vice President,,Republican,"Romney, Mitt",0,120140
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Ayers, Avery L",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Barnett, Andre",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Bush, Kent W",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Christensen, Will",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Duncan, Richard A",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Goode, Virgil",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Hoefling, Tom",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Knill, Dennis J",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Reed, Jill A.",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Rogers, Rick L",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Stein, Jill E",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,Democratic,"Obama, Barack",21,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12015A
+GEARY,Smokey Hill Township S17 H68 A,President / Vice President,,Republican,"Romney, Mitt",72,12015A
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Ayers, Avery L",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Barnett, Andre",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Barr, Roseanne C",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Bush, Kent W",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Christensen, Will",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Duncan, Richard A",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Goode, Virgil",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Hoefling, Tom",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Knill, Dennis J",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Reed, Jill A.",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Rogers, Rick L",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Stein, Jill E",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Thorne, Kevin M",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,write - in,"Warner, Gerald L.",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,Democratic,"Obama, Barack",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,Libertarian,"Johnson, Gary",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,Reform,"Baldwin, Chuck",0,12015B
+GEARY,Smokey Hill Township S17 H68 B,President / Vice President,,Republican,"Romney, Mitt",0,12015B
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Ayers, Avery L",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Barnett, Andre",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Barr, Roseanne C",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Bush, Kent W",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Christensen, Will",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Duncan, Richard A",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Goode, Virgil",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Hoefling, Tom",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Knill, Dennis J",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Reed, Jill A.",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Rogers, Rick L",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Stein, Jill E",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Thorne, Kevin M",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,write - in,"Warner, Gerald L.",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,Democratic,"Obama, Barack",3,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,Libertarian,"Johnson, Gary",1,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,Reform,"Baldwin, Chuck",0,120150
+GEARY,Smokey Hill Township S17 H68,President / Vice President,,Republican,"Romney, Mitt",22,120150
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Ayers, Avery L",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Barnett, Andre",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Barr, Roseanne C",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Bush, Kent W",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Christensen, Will",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Duncan, Richard A",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Goode, Virgil",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Hoefling, Tom",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Knill, Dennis J",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Reed, Jill A.",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Rogers, Rick L",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Stein, Jill E",1,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Thorne, Kevin M",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,write - in,"Warner, Gerald L.",0,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,Democratic,"Obama, Barack",25,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,Libertarian,"Johnson, Gary",2,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,Reform,"Baldwin, Chuck",2,120160
+GEARY,Smokey  Hill Township S22 H65,President / Vice President,,Republican,"Romney, Mitt",58,120160
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Ayers, Avery L",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Barnett, Andre",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Bush, Kent W",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Christensen, Will",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Duncan, Richard A",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Goode, Virgil",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Hoefling, Tom",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Knill, Dennis J",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Reed, Jill A.",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Rogers, Rick L",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Stein, Jill E",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,Democratic,"Obama, Barack",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12017A
+GEARY,Smokey Hill Township S22 H68 A,President / Vice President,,Republican,"Romney, Mitt",0,12017A
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Ayers, Avery L",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Barnett, Andre",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Barr, Roseanne C",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Bush, Kent W",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Christensen, Will",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Duncan, Richard A",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Goode, Virgil",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Hoefling, Tom",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Knill, Dennis J",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Reed, Jill A.",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Rogers, Rick L",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Stein, Jill E",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Thorne, Kevin M",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,write - in,"Warner, Gerald L.",0,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,Democratic,"Obama, Barack",31,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,Libertarian,"Johnson, Gary",1,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,Reform,"Baldwin, Chuck",1,120170
+GEARY,Smokey Hill Township S22 H68,President / Vice President,,Republican,"Romney, Mitt",151,120170
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Barnett, Andre",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Bush, Kent W",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Christensen, Will",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Goode, Virgil",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Stein, Jill E",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,Democratic,"Obama, Barack",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+GEARY,Smokey Hill Township Enclave A,President / Vice President,,Republican,"Romney, Mitt",0,900020
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Barnett, Andre",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Bush, Kent W",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Christensen, Will",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Goode, Virgil",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Stein, Jill E",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,Democratic,"Obama, Barack",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+GEARY,Smokey Hill Township Enclave B,President / Vice President,,Republican,"Romney, Mitt",0,900030
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Barnett, Andre",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Bush, Kent W",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Christensen, Will",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Goode, Virgil",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Stein, Jill E",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,Democratic,"Obama, Barack",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+GEARY,Smokey Hill Township Enclave C,President / Vice President,,Republican,"Romney, Mitt",0,900040
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Ayers, Avery L",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Barnett, Andre",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Barr, Roseanne C",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Bush, Kent W",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Christensen, Will",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Duncan, Richard A",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Goode, Virgil",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Knill, Dennis J",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Reed, Jill A.",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Rogers, Rick L",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Stein, Jill E",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Thorne, Kevin M",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,write - in,"Warner, Gerald L.",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,Democratic,"Obama, Barack",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,Reform,"Baldwin, Chuck",0,900050
+GEARY,Smokey Hill Township Enclave D,President / Vice President,,Republican,"Romney, Mitt",0,900050
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Ayers, Avery L",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Barnett, Andre",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Barr, Roseanne C",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Bush, Kent W",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Christensen, Will",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Duncan, Richard A",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Goode, Virgil",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Knill, Dennis J",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Reed, Jill A.",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Rogers, Rick L",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Stein, Jill E",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Thorne, Kevin M",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,write - in,"Warner, Gerald L.",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,Democratic,"Obama, Barack",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,Reform,"Baldwin, Chuck",0,900060
+GEARY,Smokey Hill Township Enclave E,President / Vice President,,Republican,"Romney, Mitt",0,900060
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Ayers, Avery L",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Barnett, Andre",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Barr, Roseanne C",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Bush, Kent W",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Christensen, Will",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Duncan, Richard A",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Goode, Virgil",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Hoefling, Tom",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Knill, Dennis J",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Reed, Jill A.",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Rogers, Rick L",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Stein, Jill E",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Thorne, Kevin M",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,write - in,"Warner, Gerald L.",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,Democratic,"Obama, Barack",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,Libertarian,"Johnson, Gary",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,Reform,"Baldwin, Chuck",0,900070
+GEARY,Smokey Hill Township Enclave F,President / Vice President,,Republican,"Romney, Mitt",0,900070
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Ayers, Avery L",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Barnett, Andre",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Barr, Roseanne C",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Bush, Kent W",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Christensen, Will",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Duncan, Richard A",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Goode, Virgil",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Hoefling, Tom",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Knill, Dennis J",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Reed, Jill A.",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Rogers, Rick L",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Stein, Jill E",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Thorne, Kevin M",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,write - in,"Warner, Gerald L.",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,Democratic,"Obama, Barack",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,Libertarian,"Johnson, Gary",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,Reform,"Baldwin, Chuck",0,900080
+GEARY,Smokey Hill Township Enclave G,President / Vice President,,Republican,"Romney, Mitt",0,900080
+GEARY,Grandview Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Ayers, Avery L",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Barnett, Andre",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Barr, Roseanne C",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Bush, Kent W",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Christensen, Will",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Duncan, Richard A",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Goode, Virgil",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Hoefling, Tom",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Knill, Dennis J",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Reed, Jill A.",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Rogers, Rick L",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Stein, Jill E",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Thorne, Kevin M",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900090
+GEARY,Grandview Township,President / Vice President,,write - in,"Warner, Gerald L.",0,900090
+GEARY,Grandview Township,President / Vice President,,Democratic,"Obama, Barack",48,900090
+GEARY,Grandview Township,President / Vice President,,Libertarian,"Johnson, Gary",5,900090
+GEARY,Grandview Township,President / Vice President,,Reform,"Baldwin, Chuck",0,900090
+GEARY,Grandview Township,President / Vice President,,Republican,"Romney, Mitt",79,900090
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Ayers, Avery L",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Barnett, Andre",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Bush, Kent W",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Christensen, Will",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Duncan, Richard A",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Goode, Virgil",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Knill, Dennis J",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Reed, Jill A.",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Rogers, Rick L",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Stein, Jill E",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,Democratic,"Obama, Barack",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,Republican,"Romney, Mitt",0,900100
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Ayers, Avery L",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Barnett, Andre",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Bush, Kent W",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Christensen, Will",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Duncan, Richard A",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Goode, Virgil",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Hoefling, Tom",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Knill, Dennis J",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Reed, Jill A.",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Rogers, Rick L",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Stein, Jill E",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,Democratic,"Obama, Barack",209,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,Libertarian,"Johnson, Gary",6,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,Reform,"Baldwin, Chuck",1,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 1,President / Vice President,,Republican,"Romney, Mitt",221,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Ayers, Avery L",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Barnett, Andre",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Bush, Kent W",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Christensen, Will",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Duncan, Richard A",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Goode, Virgil",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Knill, Dennis J",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Reed, Jill A.",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Rogers, Rick L",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Stein, Jill E",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,Democratic,"Obama, Barack",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900130
+GEARY,Junction City Ward 1 Precinct 6 Part 2,President / Vice President,,Republican,"Romney, Mitt",0,900130
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Ayers, Avery L",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Barnett, Andre",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Bush, Kent W",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Christensen, Will",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Duncan, Richard A",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Goode, Virgil",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Hoefling, Tom",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Knill, Dennis J",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Reed, Jill A.",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Rogers, Rick L",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Stein, Jill E",1,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,Democratic,"Obama, Barack",96,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 1,President / Vice President,,Republican,"Romney, Mitt",93,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Ayers, Avery L",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Barnett, Andre",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Bush, Kent W",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Christensen, Will",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Duncan, Richard A",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Goode, Virgil",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Knill, Dennis J",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Reed, Jill A.",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Rogers, Rick L",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Stein, Jill E",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,Democratic,"Obama, Barack",20,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 2,President / Vice President,,Republican,"Romney, Mitt",31,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Ayers, Avery L",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Barnett, Andre",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Barr, Roseanne C",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Bush, Kent W",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Christensen, Will",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Duncan, Richard A",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Goode, Virgil",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Hoefling, Tom",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Knill, Dennis J",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Reed, Jill A.",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Rogers, Rick L",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Stein, Jill E",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Thorne, Kevin M",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,write - in,"Warner, Gerald L.",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,Democratic,"Obama, Barack",4,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,Libertarian,"Johnson, Gary",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,Reform,"Baldwin, Chuck",0,900160
+GEARY,Junction City Ward 2 Precinct 4 Part 3,President / Vice President,,Republican,"Romney, Mitt",9,900160
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",1,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",118,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",5,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",78,900190
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900200
+GEARY,Junction City Ward 4 Precinct 1 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900200
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",1,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",185,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",5,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",109,900210
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900220
+GEARY,Junction City Ward 4 Precinct 2 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900220
+GEARY,Blakely Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000010
+GEARY,Fort Riley Precinct B,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,00002B
+GEARY,Fort Riley Precinct C,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00002C
+GEARY,Fort Riley Precinct D,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,00002D
+GEARY,Fort Riley Precinct E,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00002E
+GEARY,Fort Riley Precinct F,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00002F
+GEARY,Fort Riley Precinct G,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,00002G
+GEARY,Fort Riley Precinct H,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,00002H
+GEARY,Fort Riley Precinct I,United States House of Representatives,1,Republican,"Huelskamp, Tim",2,00002I
+GEARY,Fort Riley Precinct J,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,00002J
+GEARY,Fort Riley Precinct K,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00002K
+GEARY,Fort Riley Precinct M,United States House of Representatives,1,Republican,"Huelskamp, Tim",56,00002M
+GEARY,Fort Riley Precinct N,United States House of Representatives,1,Republican,"Huelskamp, Tim",2,00002N
+GEARY,Fort Riley Milford Township Block 401,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00002O
+GEARY,Fort Riley Milford Township Block 501,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00002P
+GEARY,Fort Riley Milford Township Block 601,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00002R
+GEARY,Wingfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",63,000040
+GEARY,Jackson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000050
+GEARY,Jefferson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",292,000060
+GEARY,Junction City Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",104,00007A
+GEARY,Junction City Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",86,000080
+GEARY,Junction City Ward 1 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",191,000090
+GEARY,Junction City Ward 1 Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",379,000100
+GEARY,Junction City Ward 1 Precinct 7,United States House of Representatives,1,Republican,"Huelskamp, Tim",373,00013A
+GEARY,Junction City Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",59,000140
+GEARY,Junction City Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",200,000150
+GEARY,Junction City Ward 2 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",241,00016A
+GEARY,Junction City Ward 3 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",92,000180
+GEARY,Junction City Ward 3 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",268,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",59,000230
+GEARY,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",72,000240
+GEARY,Lyon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",148,000250
+GEARY,Marshall Field,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000260
+GEARY,Milford Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",594,000270
+GEARY,Fort Riley Precinct A S17 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,12002A
+GEARY, Fort Riley Precinct A S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,120020
+GEARY,Fort Riley Precinct A S22,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,120030
+GEARY,Fort Riley Precinct L S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,120040
+GEARY,Fort Riley Precinct L S22,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120050
+GEARY,Junction City Ward 1 Precinct 5 H65,United States House of Representatives,1,Republican,"Huelskamp, Tim",61,120060
+GEARY,Junction City Ward 1 Precinct 5 H68,United States House of Representatives,1,Republican,"Huelskamp, Tim",224,120070
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",134,120080
+GEARY,Junction City Ward 2 Precinct 5 Part 1 S22,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,120090
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",190,120100
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,12011A
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22 B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,12011B
+GEARY,Junction City Ward 2 Precinct 5 Part 2 S22,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,120110
+GEARY,Junction City Ward 4 Precinct 3 H65,United States House of Representatives,1,Republican,"Huelskamp, Tim",241,120120
+GEARY,Junction City Ward 4 Precinct 3 H68,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120130
+GEARY,Smokey Hill Township S17 H65,United States House of Representatives,1,Republican,"Huelskamp, Tim",1,120140
+GEARY,Smokey Hill Township S17 H68 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",77,12015A
+GEARY,Smokey Hill Township S17 H68 B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,12015B
+GEARY,Smokey Hill Township S17 H68,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,120150
+GEARY,Smokey  Hill Township S22 H65,United States House of Representatives,1,Republican,"Huelskamp, Tim",69,120160
+GEARY,Smokey Hill Township S22 H68 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,12017A
+GEARY,Smokey Hill Township S22 H68,United States House of Representatives,1,Republican,"Huelskamp, Tim",151,120170
+GEARY,Smokey Hill Township Enclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+GEARY,Smokey Hill Township Enclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900030
+GEARY,Smokey Hill Township Enclave C,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900040
+GEARY,Smokey Hill Township Enclave D,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900050
+GEARY,Smokey Hill Township Enclave E,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900060
+GEARY,Smokey Hill Township Enclave F,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900070
+GEARY,Smokey Hill Township Enclave G,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900080
+GEARY,Grandview Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",92,900090
+GEARY,Grandview Township Enclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900100
+GEARY,Junction City Ward 1 Precinct 6 Part 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",308,900120
+GEARY,Junction City Ward 1 Precinct 6 Part 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900130
+GEARY,Junction City Ward 2 Precinct 4 Part 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",131,900140
+GEARY,Junction City Ward 2 Precinct 4 Part 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,900150
+GEARY,Junction City Ward 2 Precinct 4 Part 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,900160
+GEARY,Junction City Ward 4 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",131,900190
+GEARY,Junction City Ward 4 Precinct 1 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900200
+GEARY,Junction City Ward 4 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",169,900210
+GEARY,Junction City Ward 4 Precinct 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900220

--- a/2012/20121106__ks__general__gove__precinct.csv
+++ b/2012/20121106__ks__general__gove__precinct.csv
@@ -1,0 +1,217 @@
+county,precinct,office,district,party,candidate,votes,vtd
+GOVE,Baker Township,Kansas House of Representatives,118,Republican,"Hineman, Don",562,000010
+GOVE,Gaeland Township,Kansas House of Representatives,118,Republican,"Hineman, Don",19,000020
+GOVE,Gove Township,Kansas House of Representatives,118,Republican,"Hineman, Don",89,000030
+GOVE,Grainfield Township,Kansas House of Representatives,118,Republican,"Hineman, Don",169,000040
+GOVE,Grinnell Township,Kansas House of Representatives,118,Republican,"Hineman, Don",192,000050
+GOVE,Jerome Township,Kansas House of Representatives,118,Republican,"Hineman, Don",67,000060
+GOVE,Larrabee Township,Kansas House of Representatives,118,Republican,"Hineman, Don",36,000070
+GOVE,Lewis Township,Kansas House of Representatives,118,Republican,"Hineman, Don",6,000080
+GOVE,Payne Township,Kansas House of Representatives,118,Republican,"Hineman, Don",82,000090
+GOVE,Baker Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",188,000010
+GOVE,Baker Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",431,000010
+GOVE,Gaeland Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000020
+GOVE,Gaeland Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",20,000020
+GOVE,Gove Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",29,000030
+GOVE,Gove Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",76,000030
+GOVE,Grainfield Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",64,000040
+GOVE,Grainfield Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",130,000040
+GOVE,Grinnell Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",71,000050
+GOVE,Grinnell Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",144,000050
+GOVE,Jerome Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",11,000060
+GOVE,Jerome Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",62,000060
+GOVE,Larrabee Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",5,000070
+GOVE,Larrabee Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",32,000070
+GOVE,Lewis Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",2,000080
+GOVE,Lewis Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",4,000080
+GOVE,Payne Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",26,000090
+GOVE,Payne Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",62,000090
+GOVE,Baker Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+GOVE,Baker Township,President / Vice President,,Democratic,"Obama, Barack",86,000010
+GOVE,Baker Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000010
+GOVE,Baker Township,President / Vice President,,Reform,"Baldwin, Chuck",9,000010
+GOVE,Baker Township,President / Vice President,,Republican,"Romney, Mitt",528,000010
+GOVE,Gaeland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+GOVE,Gaeland Township,President / Vice President,,Democratic,"Obama, Barack",2,000020
+GOVE,Gaeland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+GOVE,Gaeland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+GOVE,Gaeland Township,President / Vice President,,Republican,"Romney, Mitt",22,000020
+GOVE,Gove Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+GOVE,Gove Township,President / Vice President,,Democratic,"Obama, Barack",15,000030
+GOVE,Gove Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000030
+GOVE,Gove Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+GOVE,Gove Township,President / Vice President,,Republican,"Romney, Mitt",80,000030
+GOVE,Grainfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+GOVE,Grainfield Township,President / Vice President,,Democratic,"Obama, Barack",28,000040
+GOVE,Grainfield Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000040
+GOVE,Grainfield Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000040
+GOVE,Grainfield Township,President / Vice President,,Republican,"Romney, Mitt",165,000040
+GOVE,Grinnell Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+GOVE,Grinnell Township,President / Vice President,,Democratic,"Obama, Barack",22,000050
+GOVE,Grinnell Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000050
+GOVE,Grinnell Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000050
+GOVE,Grinnell Township,President / Vice President,,Republican,"Romney, Mitt",188,000050
+GOVE,Jerome Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+GOVE,Jerome Township,President / Vice President,,Democratic,"Obama, Barack",9,000060
+GOVE,Jerome Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+GOVE,Jerome Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+GOVE,Jerome Township,President / Vice President,,Republican,"Romney, Mitt",65,000060
+GOVE,Larrabee Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+GOVE,Larrabee Township,President / Vice President,,Democratic,"Obama, Barack",2,000070
+GOVE,Larrabee Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+GOVE,Larrabee Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+GOVE,Larrabee Township,President / Vice President,,Republican,"Romney, Mitt",35,000070
+GOVE,Lewis Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+GOVE,Lewis Township,President / Vice President,,Democratic,"Obama, Barack",2,000080
+GOVE,Lewis Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+GOVE,Lewis Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+GOVE,Lewis Township,President / Vice President,,Republican,"Romney, Mitt",5,000080
+GOVE,Payne Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+GOVE,Payne Township,President / Vice President,,Democratic,"Obama, Barack",10,000090
+GOVE,Payne Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+GOVE,Payne Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+GOVE,Payne Township,President / Vice President,,Republican,"Romney, Mitt",80,000090
+GOVE,Baker Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",533,000010
+GOVE,Gaeland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000020
+GOVE,Gove Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",93,000030
+GOVE,Grainfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",165,000040
+GOVE,Grinnell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",187,000050
+GOVE,Jerome Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",62,000060
+GOVE,Larrabee Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000070
+GOVE,Lewis Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,000080
+GOVE,Payne Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",80,000090

--- a/2012/20121106__ks__general__graham__precinct.csv
+++ b/2012/20121106__ks__general__graham__precinct.csv
@@ -1,0 +1,469 @@
+county,precinct,office,district,party,candidate,votes,vtd
+GRAHAM,Allodium Township,Kansas House of Representatives,118,Republican,"Hineman, Don",15,000010
+GRAHAM,Bogue City,Kansas House of Representatives,118,Republican,"Hineman, Don",0,000020
+GRAHAM,Bryant Township,Kansas House of Representatives,118,Republican,"Hineman, Don",27,000030
+GRAHAM,Gettysburg Township,Kansas House of Representatives,118,Republican,"Hineman, Don",35,000040
+GRAHAM,Graham Township,Kansas House of Representatives,118,Republican,"Hineman, Don",22,000050
+GRAHAM,Happy Township,Kansas House of Representatives,118,Republican,"Hineman, Don",22,000060
+GRAHAM,Indiana Township,Kansas House of Representatives,118,Republican,"Hineman, Don",12,000100
+GRAHAM,Millbrook Township,Kansas House of Representatives,118,Republican,"Hineman, Don",63,000110
+GRAHAM,Morlan Township,Kansas House of Representatives,118,Republican,"Hineman, Don",39,000120
+GRAHAM,Morland City,Kansas House of Representatives,118,Republican,"Hineman, Don",0,000130
+GRAHAM,Pioneer Township,Kansas House of Representatives,118,Republican,"Hineman, Don",11,000150
+GRAHAM,Solomon Township,Kansas House of Representatives,118,Republican,"Hineman, Don",89,000160
+GRAHAM,Wildhorse Township,Kansas House of Representatives,118,Republican,"Hineman, Don",79,000170
+GRAHAM,Hill City Precinct 1 H110,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",26,120020
+GRAHAM,Hill City Precinct 1 H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",83,120020
+GRAHAM,Hill City Precinct 1 H118,Kansas House of Representatives,118,Republican,"Hineman, Don",3,120030
+GRAHAM,Hill City Precinct 2 H110,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",128,120040
+GRAHAM,Hill City Precinct 2 H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",360,120040
+GRAHAM,Hill City Precinct 2 H118,Kansas House of Representatives,118,Republican,"Hineman, Don",2,120050
+GRAHAM,Hill City Precinct 3 H110,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",27,120060
+GRAHAM,Hill City Precinct 3 H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",130,120060
+GRAHAM,Hill City Precinct 3 H118,Kansas House of Representatives,118,Republican,"Hineman, Don",26,120070
+GRAHAM,Nicodemus Township  H110,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",3,120080
+GRAHAM,Nicodemus Township  H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",8,120080
+GRAHAM,Nicodemus Township H118,Kansas House of Representatives,118,Republican,"Hineman, Don",9,120090
+GRAHAM,Allodium Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",1,000010
+GRAHAM,Allodium Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",15,000010
+GRAHAM,Bogue City,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,000020
+GRAHAM,Bogue City,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,000020
+GRAHAM,Bryant Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000030
+GRAHAM,Bryant Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",34,000030
+GRAHAM,Gettysburg Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",6,000040
+GRAHAM,Gettysburg Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",37,000040
+GRAHAM,Graham Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000050
+GRAHAM,Graham Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",22,000050
+GRAHAM,Happy Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",7,000060
+GRAHAM,Happy Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",20,000060
+GRAHAM,Indiana Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",3,000100
+GRAHAM,Indiana Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",11,000100
+GRAHAM,Millbrook Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",13,000110
+GRAHAM,Millbrook Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",57,000110
+GRAHAM,Morlan Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",6,000120
+GRAHAM,Morlan Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",37,000120
+GRAHAM,Morland City,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,000130
+GRAHAM,Morland City,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,000130
+GRAHAM,Pioneer Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",6,000150
+GRAHAM,Pioneer Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",10,000150
+GRAHAM,Solomon Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",16,000160
+GRAHAM,Solomon Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",83,000160
+GRAHAM,Wildhorse Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",34,000170
+GRAHAM,Wildhorse Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",79,000170
+GRAHAM,Hill City Precinct 1 H110,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",30,120020
+GRAHAM,Hill City Precinct 1 H110,Kansas Senate,40,Republican,"Ostmeyer, Ralph",77,120020
+GRAHAM,Hill City Precinct 1 H118,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",1,120030
+GRAHAM,Hill City Precinct 1 H118,Kansas Senate,40,Republican,"Ostmeyer, Ralph",6,120030
+GRAHAM,Hill City Precinct 2 H110,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",127,120040
+GRAHAM,Hill City Precinct 2 H110,Kansas Senate,40,Republican,"Ostmeyer, Ralph",345,120040
+GRAHAM,Hill City Precinct 2 H118,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",3,120050
+GRAHAM,Hill City Precinct 2 H118,Kansas Senate,40,Republican,"Ostmeyer, Ralph",2,120050
+GRAHAM,Hill City Precinct 3 H110,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",27,120060
+GRAHAM,Hill City Precinct 3 H110,Kansas Senate,40,Republican,"Ostmeyer, Ralph",128,120060
+GRAHAM,Hill City Precinct 3 H118,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",8,120070
+GRAHAM,Hill City Precinct 3 H118,Kansas Senate,40,Republican,"Ostmeyer, Ralph",24,120070
+GRAHAM,Nicodemus Township  H110,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,120080
+GRAHAM,Nicodemus Township  H110,Kansas Senate,40,Republican,"Ostmeyer, Ralph",7,120080
+GRAHAM,Nicodemus Township H118,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,120090
+GRAHAM,Nicodemus Township H118,Kansas Senate,40,Republican,"Ostmeyer, Ralph",8,120090
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+GRAHAM,Allodium Township,President / Vice President,,Democratic,"Obama, Barack",0,000010
+GRAHAM,Allodium Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+GRAHAM,Allodium Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+GRAHAM,Allodium Township,President / Vice President,,Republican,"Romney, Mitt",17,000010
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+GRAHAM,Bryant Township,President / Vice President,,Democratic,"Obama, Barack",3,000030
+GRAHAM,Bryant Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+GRAHAM,Bryant Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+GRAHAM,Bryant Township,President / Vice President,,Republican,"Romney, Mitt",36,000030
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,Democratic,"Obama, Barack",2,000040
+GRAHAM,Gettysburg Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,Republican,"Romney, Mitt",41,000040
+GRAHAM,Graham Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+GRAHAM,Graham Township,President / Vice President,,Democratic,"Obama, Barack",3,000050
+GRAHAM,Graham Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000050
+GRAHAM,Graham Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+GRAHAM,Graham Township,President / Vice President,,Republican,"Romney, Mitt",21,000050
+GRAHAM,Happy Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+GRAHAM,Happy Township,President / Vice President,,Democratic,"Obama, Barack",3,000060
+GRAHAM,Happy Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+GRAHAM,Happy Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+GRAHAM,Happy Township,President / Vice President,,Republican,"Romney, Mitt",24,000060
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+GRAHAM,Indiana Township,President / Vice President,,Democratic,"Obama, Barack",1,000100
+GRAHAM,Indiana Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+GRAHAM,Indiana Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+GRAHAM,Indiana Township,President / Vice President,,Republican,"Romney, Mitt",13,000100
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Stein, Jill E",1,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,Democratic,"Obama, Barack",10,000110
+GRAHAM,Millbrook Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+GRAHAM,Millbrook Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,Republican,"Romney, Mitt",58,000110
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+GRAHAM,Morlan Township,President / Vice President,,Democratic,"Obama, Barack",3,000120
+GRAHAM,Morlan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+GRAHAM,Morlan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+GRAHAM,Morlan Township,President / Vice President,,Republican,"Romney, Mitt",41,000120
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,Democratic,"Obama, Barack",2,000150
+GRAHAM,Pioneer Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,Republican,"Romney, Mitt",13,000150
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+GRAHAM,Solomon Township,President / Vice President,,Democratic,"Obama, Barack",8,000160
+GRAHAM,Solomon Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+GRAHAM,Solomon Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000160
+GRAHAM,Solomon Township,President / Vice President,,Republican,"Romney, Mitt",91,000160
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,Democratic,"Obama, Barack",25,000170
+GRAHAM,Wildhorse Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000170
+GRAHAM,Wildhorse Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000170
+GRAHAM,Wildhorse Township,President / Vice President,,Republican,"Romney, Mitt",84,000170
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Barnett, Andre",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Bush, Kent W",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Christensen, Will",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Goode, Virgil",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Stein, Jill E",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,Democratic,"Obama, Barack",25,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,Libertarian,"Johnson, Gary",4,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,Republican,"Romney, Mitt",79,120020
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Barnett, Andre",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Bush, Kent W",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Christensen, Will",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Goode, Virgil",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Stein, Jill E",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,Democratic,"Obama, Barack",1,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,Republican,"Romney, Mitt",6,120030
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Barnett, Andre",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Bush, Kent W",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Christensen, Will",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Goode, Virgil",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Stein, Jill E",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,Democratic,"Obama, Barack",118,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,Libertarian,"Johnson, Gary",5,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,Reform,"Baldwin, Chuck",8,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,Republican,"Romney, Mitt",361,120040
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Barnett, Andre",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Bush, Kent W",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Christensen, Will",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Goode, Virgil",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Stein, Jill E",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,Democratic,"Obama, Barack",1,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,Libertarian,"Johnson, Gary",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,Reform,"Baldwin, Chuck",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,Republican,"Romney, Mitt",4,120050
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Ayers, Avery L",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Barnett, Andre",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Barr, Roseanne C",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Bush, Kent W",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Christensen, Will",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Duncan, Richard A",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Goode, Virgil",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Knill, Dennis J",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Reed, Jill A.",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Rogers, Rick L",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Stein, Jill E",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Thorne, Kevin M",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Warner, Gerald L.",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,Democratic,"Obama, Barack",34,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,Libertarian,"Johnson, Gary",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,Reform,"Baldwin, Chuck",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,Republican,"Romney, Mitt",128,120060
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Ayers, Avery L",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Barnett, Andre",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Barr, Roseanne C",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Bush, Kent W",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Christensen, Will",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Duncan, Richard A",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Goode, Virgil",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Knill, Dennis J",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Reed, Jill A.",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Rogers, Rick L",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Stein, Jill E",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Thorne, Kevin M",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Warner, Gerald L.",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,Democratic,"Obama, Barack",4,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,Libertarian,"Johnson, Gary",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,Reform,"Baldwin, Chuck",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,Republican,"Romney, Mitt",27,120070
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Ayers, Avery L",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Barnett, Andre",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Barr, Roseanne C",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Bush, Kent W",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Christensen, Will",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Duncan, Richard A",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Goode, Virgil",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Knill, Dennis J",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Reed, Jill A.",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Rogers, Rick L",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Stein, Jill E",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Thorne, Kevin M",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Warner, Gerald L.",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,Democratic,"Obama, Barack",5,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,Libertarian,"Johnson, Gary",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,Reform,"Baldwin, Chuck",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,Republican,"Romney, Mitt",6,120080
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Ayers, Avery L",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Barnett, Andre",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Barr, Roseanne C",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Bush, Kent W",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Christensen, Will",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Duncan, Richard A",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Goode, Virgil",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Knill, Dennis J",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Reed, Jill A.",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Rogers, Rick L",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Stein, Jill E",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Thorne, Kevin M",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Warner, Gerald L.",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,Democratic,"Obama, Barack",8,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,Libertarian,"Johnson, Gary",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,Reform,"Baldwin, Chuck",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,Republican,"Romney, Mitt",6,120090
+GRAHAM,Allodium Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000010
+GRAHAM,Bogue City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000020
+GRAHAM,Bryant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000030
+GRAHAM,Gettysburg Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000040
+GRAHAM,Graham Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000050
+GRAHAM,Happy Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000060
+GRAHAM,Indiana Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000100
+GRAHAM,Millbrook Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,000110
+GRAHAM,Morlan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",41,000120
+GRAHAM,Morland City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000130
+GRAHAM,Pioneer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000150
+GRAHAM,Solomon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",95,000160
+GRAHAM,Wildhorse Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",90,000170
+GRAHAM,Hill City Precinct 1 H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",85,120020
+GRAHAM,Hill City Precinct 1 H118,United States House of Representatives,1,Republican,"Huelskamp, Tim",6,120030
+GRAHAM,Hill City Precinct 2 H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",385,120040
+GRAHAM,Hill City Precinct 2 H118,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,120050
+GRAHAM,Hill City Precinct 3 H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",127,120060
+GRAHAM,Hill City Precinct 3 H118,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,120070
+GRAHAM,Nicodemus Township  H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,120080
+GRAHAM,Nicodemus Township H118,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,120090

--- a/2012/20121106__ks__general__grant__precinct.csv
+++ b/2012/20121106__ks__general__grant__precinct.csv
@@ -1,0 +1,139 @@
+county,precinct,office,district,party,candidate,votes,vtd
+GRANT,Ulysses Ward 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",273,000020
+GRANT,Ulysses Ward 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",625,00003A
+GRANT,Ulysses Ward 2 Exclave,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",0,00003B
+GRANT,Ulysses Ward 3,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",648,000040
+GRANT,Precinct 4 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",0,120020
+GRANT,Precinct 4 H124,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",420,120030
+GRANT,Ulysses Ward 1,Kansas Senate,39,Republican,"Powell, Larry R.",263,000020
+GRANT,Ulysses Ward 2,Kansas Senate,39,Republican,"Powell, Larry R.",582,00003A
+GRANT,Ulysses Ward 2 Exclave,Kansas Senate,39,Republican,"Powell, Larry R.",0,00003B
+GRANT,Ulysses Ward 3,Kansas Senate,39,Republican,"Powell, Larry R.",598,000040
+GRANT,Precinct 4 H122,Kansas Senate,39,Republican,"Powell, Larry R.",0,120020
+GRANT,Precinct 4 H124,Kansas Senate,39,Republican,"Powell, Larry R.",400,120030
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Goode, Virgil",1,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Stein, Jill E",1,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,Democratic,"Obama, Barack",88,000020
+GRANT,Ulysses Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000020
+GRANT,Ulysses Ward 1,President / Vice President,,Republican,"Romney, Mitt",224,000020
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,Democratic,"Obama, Barack",142,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",6,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",3,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,Republican,"Romney, Mitt",581,00003A
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00003B
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,Democratic,"Obama, Barack",150,000040
+GRANT,Ulysses Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",10,000040
+GRANT,Ulysses Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",6,000040
+GRANT,Ulysses Ward 3,President / Vice President,,Republican,"Romney, Mitt",609,000040
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Barnett, Andre",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Bush, Kent W",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Christensen, Will",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Goode, Virgil",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Stein, Jill E",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,Democratic,"Obama, Barack",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,Republican,"Romney, Mitt",0,120020
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Barnett, Andre",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Bush, Kent W",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Christensen, Will",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Goode, Virgil",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Stein, Jill E",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,Democratic,"Obama, Barack",76,120030
+GRANT,Precinct 4 H124,President / Vice President,,Libertarian,"Johnson, Gary",9,120030
+GRANT,Precinct 4 H124,President / Vice President,,Reform,"Baldwin, Chuck",1,120030
+GRANT,Precinct 4 H124,President / Vice President,,Republican,"Romney, Mitt",397,120030
+GRANT,Ulysses Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",262,000020
+GRANT,Ulysses Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",607,00003A
+GRANT,Ulysses Ward 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00003B
+GRANT,Ulysses Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",638,000040
+GRANT,Precinct 4 H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120020
+GRANT,Precinct 4 H124,United States House of Representatives,1,Republican,"Huelskamp, Tim",411,120030

--- a/2012/20121106__ks__general__gray__precinct.csv
+++ b/2012/20121106__ks__general__gray__precinct.csv
@@ -1,0 +1,201 @@
+county,precinct,office,district,party,candidate,votes,vtd
+GRAY,Copeland Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",14,000020
+GRAY,Copeland Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",122,000020
+GRAY,East Hess Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",32,000030
+GRAY,East Hess Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",90,000030
+GRAY,Foote Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",10,000040
+GRAY,Foote Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",36,000040
+GRAY,Ingalls Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",35,000050
+GRAY,Ingalls Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",157,000050
+GRAY,Logan Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",12,000060
+GRAY,Logan Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",72,000060
+GRAY,Montezuma Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",43,000070
+GRAY,Montezuma Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",283,000070
+GRAY,Cimarron Township Precinct 1,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",53,500010
+GRAY,Cimarron Township Precinct 1,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",214,500010
+GRAY,Cimarron Township Precinct 2,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",117,500020
+GRAY,Cimarron Township Precinct 2,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",562,500020
+GRAY,Copeland Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",15,000020
+GRAY,Copeland Township,Kansas Senate,38,Republican,"Love, Garrett",127,000020
+GRAY,East Hess Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",19,000030
+GRAY,East Hess Township,Kansas Senate,38,Republican,"Love, Garrett",108,000030
+GRAY,Foote Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",3,000040
+GRAY,Foote Township,Kansas Senate,38,Republican,"Love, Garrett",43,000040
+GRAY,Ingalls Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",30,000050
+GRAY,Ingalls Township,Kansas Senate,38,Republican,"Love, Garrett",168,000050
+GRAY,Logan Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",9,000060
+GRAY,Logan Township,Kansas Senate,38,Republican,"Love, Garrett",75,000060
+GRAY,Montezuma Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",53,000070
+GRAY,Montezuma Township,Kansas Senate,38,Republican,"Love, Garrett",287,000070
+GRAY,Cimarron Township Precinct 1,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",47,500010
+GRAY,Cimarron Township Precinct 1,Kansas Senate,38,Republican,"Love, Garrett",230,500010
+GRAY,Cimarron Township Precinct 2,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",97,500020
+GRAY,Cimarron Township Precinct 2,Kansas Senate,38,Republican,"Love, Garrett",623,500020
+GRAY,Copeland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+GRAY,Copeland Township,President / Vice President,,Democratic,"Obama, Barack",15,000020
+GRAY,Copeland Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+GRAY,Copeland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+GRAY,Copeland Township,President / Vice President,,Republican,"Romney, Mitt",127,000020
+GRAY,East Hess Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+GRAY,East Hess Township,President / Vice President,,Democratic,"Obama, Barack",32,000030
+GRAY,East Hess Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+GRAY,East Hess Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+GRAY,East Hess Township,President / Vice President,,Republican,"Romney, Mitt",93,000030
+GRAY,Foote Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+GRAY,Foote Township,President / Vice President,,Democratic,"Obama, Barack",7,000040
+GRAY,Foote Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+GRAY,Foote Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+GRAY,Foote Township,President / Vice President,,Republican,"Romney, Mitt",42,000040
+GRAY,Ingalls Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+GRAY,Ingalls Township,President / Vice President,,Democratic,"Obama, Barack",35,000050
+GRAY,Ingalls Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+GRAY,Ingalls Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+GRAY,Ingalls Township,President / Vice President,,Republican,"Romney, Mitt",158,000050
+GRAY,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+GRAY,Logan Township,President / Vice President,,Democratic,"Obama, Barack",9,000060
+GRAY,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+GRAY,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+GRAY,Logan Township,President / Vice President,,Republican,"Romney, Mitt",78,000060
+GRAY,Montezuma Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+GRAY,Montezuma Township,President / Vice President,,Democratic,"Obama, Barack",49,000070
+GRAY,Montezuma Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000070
+GRAY,Montezuma Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000070
+GRAY,Montezuma Township,President / Vice President,,Republican,"Romney, Mitt",290,000070
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",1,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,Democratic,"Obama, Barack",57,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",6,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,Republican,"Romney, Mitt",211,500010
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",1,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,Democratic,"Obama, Barack",120,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",3,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,Republican,"Romney, Mitt",604,500020
+GRAY,Copeland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",119,000020
+GRAY,East Hess Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",110,000030
+GRAY,Foote Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000040
+GRAY,Ingalls Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",180,000050
+GRAY,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",78,000060
+GRAY,Montezuma Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",276,000070
+GRAY,Cimarron Township Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",233,500010
+GRAY,Cimarron Township Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",611,500020

--- a/2012/20121106__ks__general__greeley__precinct.csv
+++ b/2012/20121106__ks__general__greeley__precinct.csv
@@ -1,0 +1,70 @@
+county,precinct,office,district,party,candidate,votes,vtd
+GREELEY,Tribune Precinct 1,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",349,000010
+GREELEY,Tribune Precinct 2,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",148,000020
+GREELEY,Tribune Precinct 3,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",49,000030
+GREELEY,Tribune Precinct 1,Kansas Senate,39,Republican,"Powell, Larry R.",314,000010
+GREELEY,Tribune Precinct 2,Kansas Senate,39,Republican,"Powell, Larry R.",156,000020
+GREELEY,Tribune Precinct 3,Kansas Senate,39,Republican,"Powell, Larry R.",45,000030
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,Democratic,"Obama, Barack",76,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,Republican,"Romney, Mitt",329,000010
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,Democratic,"Obama, Barack",29,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,Republican,"Romney, Mitt",169,000020
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,Democratic,"Obama, Barack",8,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,Republican,"Romney, Mitt",45,000030
+GREELEY,Tribune Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",320,000010
+GREELEY,Tribune Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",169,000020
+GREELEY,Tribune Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000030

--- a/2012/20121106__ks__general__greenwood__precinct.csv
+++ b/2012/20121106__ks__general__greenwood__precinct.csv
@@ -1,0 +1,541 @@
+county,precinct,office,district,party,candidate,votes,vtd
+GREENWOOD,Bachelor Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",74,000010
+GREENWOOD,Eureka Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",145,000020
+GREENWOOD,Eureka Ward 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",228,000030
+GREENWOOD,Eureka Ward 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",160,000040
+GREENWOOD,Eureka Ward 3,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",211,000050
+GREENWOOD,Fall River Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",59,000060
+GREENWOOD,Janesville Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",130,000070
+GREENWOOD,Lane Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",24,000080
+GREENWOOD,Madison Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",322,000090
+GREENWOOD,Otter Creek Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",35,000100
+GREENWOOD,Pleasant Grove Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",18,000110
+GREENWOOD,Quincy Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",33,000120
+GREENWOOD,Salem Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",7,000130
+GREENWOOD,Salt Springs Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",88,000140
+GREENWOOD,Shell Rock Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",57,000150
+GREENWOOD,Spring Creek Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",33,000170
+GREENWOOD,Twin Grove Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",159,000180
+GREENWOOD,South Salem Township C01,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",31,200010
+GREENWOOD,South Salem Township C04,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,200020
+GREENWOOD,Eureka Airport,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,900020
+GREENWOOD,Eureka Ward 2,Kansas Senate,14,Democratic,"Fuson, Eden",28,000040
+GREENWOOD,Eureka Ward 2,Kansas Senate,14,Republican,"Knox, Forrest J.",60,000040
+GREENWOOD,Eureka Ward 3,Kansas Senate,14,Democratic,"Fuson, Eden",71,000050
+GREENWOOD,Eureka Ward 3,Kansas Senate,14,Republican,"Knox, Forrest J.",166,000050
+GREENWOOD,Fall River Township,Kansas Senate,14,Democratic,"Fuson, Eden",17,000060
+GREENWOOD,Fall River Township,Kansas Senate,14,Republican,"Knox, Forrest J.",52,000060
+GREENWOOD,Janesville Township,Kansas Senate,14,Democratic,"Fuson, Eden",26,000070
+GREENWOOD,Janesville Township,Kansas Senate,14,Republican,"Knox, Forrest J.",135,000070
+GREENWOOD,Lane Township,Kansas Senate,14,Democratic,"Fuson, Eden",10,000080
+GREENWOOD,Lane Township,Kansas Senate,14,Republican,"Knox, Forrest J.",24,000080
+GREENWOOD,Madison Township,Kansas Senate,14,Democratic,"Fuson, Eden",87,000090
+GREENWOOD,Madison Township,Kansas Senate,14,Republican,"Knox, Forrest J.",291,000090
+GREENWOOD,Otter Creek Township,Kansas Senate,14,Democratic,"Fuson, Eden",18,000100
+GREENWOOD,Otter Creek Township,Kansas Senate,14,Republican,"Knox, Forrest J.",32,000100
+GREENWOOD,Pleasant Grove Township,Kansas Senate,14,Democratic,"Fuson, Eden",4,000110
+GREENWOOD,Pleasant Grove Township,Kansas Senate,14,Republican,"Knox, Forrest J.",16,000110
+GREENWOOD,Quincy Township,Kansas Senate,14,Democratic,"Fuson, Eden",9,000120
+GREENWOOD,Quincy Township,Kansas Senate,14,Republican,"Knox, Forrest J.",39,000120
+GREENWOOD,Salem Township,Kansas Senate,14,Democratic,"Fuson, Eden",3,000130
+GREENWOOD,Salem Township,Kansas Senate,14,Republican,"Knox, Forrest J.",5,000130
+GREENWOOD,Salt Springs Township,Kansas Senate,14,Democratic,"Fuson, Eden",37,000140
+GREENWOOD,Salt Springs Township,Kansas Senate,14,Republican,"Knox, Forrest J.",72,000140
+GREENWOOD,Shell Rock Township,Kansas Senate,14,Democratic,"Fuson, Eden",6,000150
+GREENWOOD,Shell Rock Township,Kansas Senate,14,Republican,"Knox, Forrest J.",60,000150
+GREENWOOD,Spring Creek Township,Kansas Senate,14,Democratic,"Fuson, Eden",9,000170
+GREENWOOD,Spring Creek Township,Kansas Senate,14,Republican,"Knox, Forrest J.",31,000170
+GREENWOOD,Twin Grove Township,Kansas Senate,14,Democratic,"Fuson, Eden",26,000180
+GREENWOOD,Twin Grove Township,Kansas Senate,14,Republican,"Knox, Forrest J.",64,000180
+GREENWOOD,South Salem Township C01,Kansas Senate,14,Democratic,"Fuson, Eden",8,200010
+GREENWOOD,South Salem Township C01,Kansas Senate,14,Republican,"Knox, Forrest J.",26,200010
+GREENWOOD,South Salem Township C04,Kansas Senate,14,Democratic,"Fuson, Eden",0,200020
+GREENWOOD,South Salem Township C04,Kansas Senate,14,Republican,"Knox, Forrest J.",0,200020
+GREENWOOD,Eureka Airport,Kansas Senate,14,Democratic,"Fuson, Eden",0,900010
+GREENWOOD,Eureka Airport,Kansas Senate,14,Republican,"Knox, Forrest J.",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,Kansas Senate,14,Democratic,"Fuson, Eden",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,Kansas Senate,14,Republican,"Knox, Forrest J.",0,900020
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,Democratic,"Obama, Barack",21,000010
+GREENWOOD,Bachelor Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,Republican,"Romney, Mitt",67,000010
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,Democratic,"Obama, Barack",37,000020
+GREENWOOD,Eureka Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000020
+GREENWOOD,Eureka Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,Republican,"Romney, Mitt",126,000020
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,Democratic,"Obama, Barack",57,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",6,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,Republican,"Romney, Mitt",195,000030
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,Democratic,"Obama, Barack",35,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,Republican,"Romney, Mitt",145,000040
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,Democratic,"Obama, Barack",62,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",5,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",3,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,Republican,"Romney, Mitt",170,000050
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,Democratic,"Obama, Barack",17,000060
+GREENWOOD,Fall River Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+GREENWOOD,Fall River Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+GREENWOOD,Fall River Township,President / Vice President,,Republican,"Romney, Mitt",50,000060
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,Democratic,"Obama, Barack",31,000070
+GREENWOOD,Janesville Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+GREENWOOD,Janesville Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,Republican,"Romney, Mitt",128,000070
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+GREENWOOD,Lane Township,President / Vice President,,Democratic,"Obama, Barack",8,000080
+GREENWOOD,Lane Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+GREENWOOD,Lane Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+GREENWOOD,Lane Township,President / Vice President,,Republican,"Romney, Mitt",24,000080
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+GREENWOOD,Madison Township,President / Vice President,,Democratic,"Obama, Barack",90,000090
+GREENWOOD,Madison Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000090
+GREENWOOD,Madison Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+GREENWOOD,Madison Township,President / Vice President,,Republican,"Romney, Mitt",285,000090
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,Democratic,"Obama, Barack",16,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,Republican,"Romney, Mitt",33,000100
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,Democratic,"Obama, Barack",3,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,Republican,"Romney, Mitt",16,000110
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,Democratic,"Obama, Barack",10,000120
+GREENWOOD,Quincy Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000120
+GREENWOOD,Quincy Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,Republican,"Romney, Mitt",36,000120
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+GREENWOOD,Salem Township,President / Vice President,,Democratic,"Obama, Barack",1,000130
+GREENWOOD,Salem Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+GREENWOOD,Salem Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+GREENWOOD,Salem Township,President / Vice President,,Republican,"Romney, Mitt",7,000130
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,Democratic,"Obama, Barack",40,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,Republican,"Romney, Mitt",70,000140
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,Democratic,"Obama, Barack",5,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,Republican,"Romney, Mitt",59,000150
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,Democratic,"Obama, Barack",11,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,Republican,"Romney, Mitt",31,000170
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,Democratic,"Obama, Barack",34,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,Republican,"Romney, Mitt",148,000180
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Ayers, Avery L",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Barnett, Andre",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Barr, Roseanne C",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Bush, Kent W",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Christensen, Will",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Duncan, Richard A",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Goode, Virgil",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Hoefling, Tom",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Knill, Dennis J",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Reed, Jill A.",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Rogers, Rick L",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Stein, Jill E",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Thorne, Kevin M",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Warner, Gerald L.",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,Democratic,"Obama, Barack",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,Libertarian,"Johnson, Gary",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,Reform,"Baldwin, Chuck",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,Republican,"Romney, Mitt",0,200010
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Ayers, Avery L",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Barnett, Andre",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Barr, Roseanne C",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Bush, Kent W",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Christensen, Will",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Duncan, Richard A",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Goode, Virgil",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Hoefling, Tom",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Knill, Dennis J",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Reed, Jill A.",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Rogers, Rick L",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Stein, Jill E",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Thorne, Kevin M",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Warner, Gerald L.",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,Democratic,"Obama, Barack",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,Libertarian,"Johnson, Gary",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,Reform,"Baldwin, Chuck",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,Republican,"Romney, Mitt",0,200020
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Barnett, Andre",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Bush, Kent W",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Christensen, Will",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Goode, Virgil",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Stein, Jill E",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,Democratic,"Obama, Barack",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,Republican,"Romney, Mitt",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900020
+GREENWOOD,Bachelor Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",13,000010
+GREENWOOD,Bachelor Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000010
+GREENWOOD,Bachelor Township,United States House of Representatives,4,Republican,"Pompeo, Mike",71,000010
+GREENWOOD,Eureka Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",27,000020
+GREENWOOD,Eureka Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",9,000020
+GREENWOOD,Eureka Township,United States House of Representatives,4,Republican,"Pompeo, Mike",126,000020
+GREENWOOD,Eureka Ward 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",42,000030
+GREENWOOD,Eureka Ward 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",23,000030
+GREENWOOD,Eureka Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",191,000030
+GREENWOOD,Eureka Ward 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",35,000040
+GREENWOOD,Eureka Ward 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",9,000040
+GREENWOOD,Eureka Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",136,000040
+GREENWOOD,Eureka Ward 3,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",49,000050
+GREENWOOD,Eureka Ward 3,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",19,000050
+GREENWOOD,Eureka Ward 3,United States House of Representatives,4,Republican,"Pompeo, Mike",166,000050
+GREENWOOD,Fall River Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",19,000060
+GREENWOOD,Fall River Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",7,000060
+GREENWOOD,Fall River Township,United States House of Representatives,4,Republican,"Pompeo, Mike",42,000060
+GREENWOOD,Janesville Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",25,000070
+GREENWOOD,Janesville Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,000070
+GREENWOOD,Janesville Township,United States House of Representatives,4,Republican,"Pompeo, Mike",134,000070
+GREENWOOD,Lane Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",11,000080
+GREENWOOD,Lane Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000080
+GREENWOOD,Lane Township,United States House of Representatives,4,Republican,"Pompeo, Mike",23,000080
+GREENWOOD,Madison Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",84,000090
+GREENWOOD,Madison Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",27,000090
+GREENWOOD,Madison Township,United States House of Representatives,4,Republican,"Pompeo, Mike",272,000090
+GREENWOOD,Otter Creek Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",14,000100
+GREENWOOD,Otter Creek Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,000100
+GREENWOOD,Otter Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",31,000100
+GREENWOOD,Pleasant Grove Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",3,000110
+GREENWOOD,Pleasant Grove Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000110
+GREENWOOD,Pleasant Grove Township,United States House of Representatives,4,Republican,"Pompeo, Mike",17,000110
+GREENWOOD,Quincy Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",8,000120
+GREENWOOD,Quincy Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000120
+GREENWOOD,Quincy Township,United States House of Representatives,4,Republican,"Pompeo, Mike",36,000120
+GREENWOOD,Salem Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",1,000130
+GREENWOOD,Salem Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000130
+GREENWOOD,Salem Township,United States House of Representatives,4,Republican,"Pompeo, Mike",6,000130
+GREENWOOD,Salt Springs Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",31,000140
+GREENWOOD,Salt Springs Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",10,000140
+GREENWOOD,Salt Springs Township,United States House of Representatives,4,Republican,"Pompeo, Mike",67,000140
+GREENWOOD,Shell Rock Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000150
+GREENWOOD,Shell Rock Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",7,000150
+GREENWOOD,Shell Rock Township,United States House of Representatives,4,Republican,"Pompeo, Mike",56,000150
+GREENWOOD,Spring Creek Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",5,000170
+GREENWOOD,Spring Creek Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,000170
+GREENWOOD,Spring Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",29,000170
+GREENWOOD,Twin Grove Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",39,000180
+GREENWOOD,Twin Grove Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000180
+GREENWOOD,Twin Grove Township,United States House of Representatives,4,Republican,"Pompeo, Mike",139,000180
+GREENWOOD,South Salem Township C01,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",4,200010
+GREENWOOD,South Salem Township C01,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,200010
+GREENWOOD,South Salem Township C01,United States House of Representatives,4,Republican,"Pompeo, Mike",29,200010
+GREENWOOD,South Salem Township C04,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,200020
+GREENWOOD,South Salem Township C04,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,200020
+GREENWOOD,South Salem Township C04,United States House of Representatives,4,Republican,"Pompeo, Mike",0,200020
+GREENWOOD,Eureka Airport,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900010
+GREENWOOD,Eureka Airport,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900010
+GREENWOOD,Eureka Airport,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900020

--- a/2012/20121106__ks__general__hamilton__precinct.csv
+++ b/2012/20121106__ks__general__hamilton__precinct.csv
@@ -1,0 +1,277 @@
+county,precinct,office,district,party,candidate,votes,vtd
+HAMILTON,Bear Creek Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",21,000010
+HAMILTON,Coolidge Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",33,000020
+HAMILTON,Kendall Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",30,000030
+HAMILTON,Lamont Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",38,000040
+HAMILTON,Liberty Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",14,000050
+HAMILTON,Medway Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",21,000060
+HAMILTON,Richland Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",14,000070
+HAMILTON,Syracuse 1,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",162,000080
+HAMILTON,Syracuse 2,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",96,000090
+HAMILTON,Syracuse 3,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",103,000100
+HAMILTON,Syracuse 4,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",52,120010
+HAMILTON,Syracuse 5,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",157,120020
+HAMILTON,Bear Creek Township,Kansas Senate,39,Republican,"Powell, Larry R.",20,000010
+HAMILTON,Coolidge Township,Kansas Senate,39,Republican,"Powell, Larry R.",38,000020
+HAMILTON,Kendall Township,Kansas Senate,39,Republican,"Powell, Larry R.",29,000030
+HAMILTON,Lamont Township,Kansas Senate,39,Republican,"Powell, Larry R.",38,000040
+HAMILTON,Liberty Township,Kansas Senate,39,Republican,"Powell, Larry R.",13,000050
+HAMILTON,Medway Township,Kansas Senate,39,Republican,"Powell, Larry R.",20,000060
+HAMILTON,Richland Township,Kansas Senate,39,Republican,"Powell, Larry R.",12,000070
+HAMILTON,Syracuse 1,Kansas Senate,39,Republican,"Powell, Larry R.",148,000080
+HAMILTON,Syracuse 2,Kansas Senate,39,Republican,"Powell, Larry R.",95,000090
+HAMILTON,Syracuse 3,Kansas Senate,39,Republican,"Powell, Larry R.",101,000100
+HAMILTON,Syracuse 4,Kansas Senate,39,Republican,"Powell, Larry R.",56,120010
+HAMILTON,Syracuse 5,Kansas Senate,39,Republican,"Powell, Larry R.",146,120020
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,Democratic,"Obama, Barack",2,000010
+HAMILTON,Bear Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+HAMILTON,Bear Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,Republican,"Romney, Mitt",21,000010
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,Democratic,"Obama, Barack",7,000020
+HAMILTON,Coolidge Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,Republican,"Romney, Mitt",37,000020
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+HAMILTON,Kendall Township,President / Vice President,,Democratic,"Obama, Barack",5,000030
+HAMILTON,Kendall Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000030
+HAMILTON,Kendall Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+HAMILTON,Kendall Township,President / Vice President,,Republican,"Romney, Mitt",32,000030
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+HAMILTON,Lamont Township,President / Vice President,,Democratic,"Obama, Barack",4,000040
+HAMILTON,Lamont Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+HAMILTON,Lamont Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+HAMILTON,Lamont Township,President / Vice President,,Republican,"Romney, Mitt",39,000040
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+HAMILTON,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",3,000050
+HAMILTON,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+HAMILTON,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+HAMILTON,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",12,000050
+HAMILTON,Medway Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+HAMILTON,Medway Township,President / Vice President,,Democratic,"Obama, Barack",4,000060
+HAMILTON,Medway Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+HAMILTON,Medway Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+HAMILTON,Medway Township,President / Vice President,,Republican,"Romney, Mitt",19,000060
+HAMILTON,Richland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+HAMILTON,Richland Township,President / Vice President,,Democratic,"Obama, Barack",2,000070
+HAMILTON,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+HAMILTON,Richland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+HAMILTON,Richland Township,President / Vice President,,Republican,"Romney, Mitt",10,000070
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Barnett, Andre",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Bush, Kent W",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Christensen, Will",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Goode, Virgil",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Stein, Jill E",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,Democratic,"Obama, Barack",46,000080
+HAMILTON,Syracuse 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000080
+HAMILTON,Syracuse 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,Republican,"Romney, Mitt",141,000080
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Barnett, Andre",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Bush, Kent W",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Christensen, Will",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Goode, Virgil",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Stein, Jill E",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,Democratic,"Obama, Barack",18,000090
+HAMILTON,Syracuse 2,President / Vice President,,Libertarian,"Johnson, Gary",2,000090
+HAMILTON,Syracuse 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+HAMILTON,Syracuse 2,President / Vice President,,Republican,"Romney, Mitt",93,000090
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Barnett, Andre",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Bush, Kent W",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Christensen, Will",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Goode, Virgil",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Stein, Jill E",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,Democratic,"Obama, Barack",29,000100
+HAMILTON,Syracuse 3,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,Reform,"Baldwin, Chuck",2,000100
+HAMILTON,Syracuse 3,President / Vice President,,Republican,"Romney, Mitt",93,000100
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Ayers, Avery L",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Barnett, Andre",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Barr, Roseanne C",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Bush, Kent W",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Christensen, Will",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Duncan, Richard A",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Goode, Virgil",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Hoefling, Tom",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Knill, Dennis J",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Reed, Jill A.",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Rogers, Rick L",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Stein, Jill E",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Thorne, Kevin M",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Warner, Gerald L.",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,Democratic,"Obama, Barack",11,120010
+HAMILTON,Syracuse 4,President / Vice President,,Libertarian,"Johnson, Gary",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,Reform,"Baldwin, Chuck",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,Republican,"Romney, Mitt",52,120010
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Barnett, Andre",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Bush, Kent W",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Christensen, Will",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Goode, Virgil",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Stein, Jill E",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,Democratic,"Obama, Barack",32,120020
+HAMILTON,Syracuse 5,President / Vice President,,Libertarian,"Johnson, Gary",4,120020
+HAMILTON,Syracuse 5,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,Republican,"Romney, Mitt",144,120020
+HAMILTON,Bear Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000010
+HAMILTON,Coolidge Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",42,000020
+HAMILTON,Kendall Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000030
+HAMILTON,Lamont Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000040
+HAMILTON,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000050
+HAMILTON,Medway Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000060
+HAMILTON,Richland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000070
+HAMILTON,Syracuse 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",148,000080
+HAMILTON,Syracuse 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",96,000090
+HAMILTON,Syracuse 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",105,000100
+HAMILTON,Syracuse 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",54,120010
+HAMILTON,Syracuse 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",145,120020

--- a/2012/20121106__ks__general__harper__precinct.csv
+++ b/2012/20121106__ks__general__harper__precinct.csv
@@ -1,0 +1,573 @@
+county,precinct,office,district,party,candidate,votes,vtd
+HARPER,Anthony Ward 1,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",153,000010
+HARPER,Anthony Ward 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",256,000010
+HARPER,Anthony Ward 2,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",88,000020
+HARPER,Anthony Ward 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",125,000020
+HARPER,Anthony Ward 3,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",20,000030
+HARPER,Anthony Ward 3,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",54,000030
+HARPER,Anthony Ward 4,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",52,000040
+HARPER,Anthony Ward 4,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",90,000040
+HARPER,Harper Ward 1,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",100,000050
+HARPER,Harper Ward 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",138,000050
+HARPER,Harper Ward 2,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",118,000060
+HARPER,Harper Ward 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",169,000060
+HARPER,Township 1,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",113,000070
+HARPER,Township 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",279,000070
+HARPER,Township 2,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",8,000080
+HARPER,Township 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",43,000080
+HARPER,Township 4,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",33,000100
+HARPER,Township 4,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",41,000100
+HARPER,Township 3 East,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",22,800010
+HARPER,Township 3 East,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",34,800010
+HARPER,Township 3 West,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",22,800020
+HARPER,Township 3 West,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",60,800020
+HARPER,Township 5 East,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",56,800030
+HARPER,Township 5 East,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",91,800030
+HARPER,Township 5 West,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",14,800040
+HARPER,Township 5 West,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",28,800040
+HARPER,Township 6 East,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",31,800050
+HARPER,Township 6 East,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",63,800050
+HARPER,Township 6 West,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",7,800060
+HARPER,Township 6 West,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",26,800060
+HARPER,Anthony Ward 2 Exclave 1,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",0,900010
+HARPER,Anthony Ward 2 Exclave 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,900010
+HARPER,Anthony Ward 2 Exclave 2,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",0,900020
+HARPER,Anthony Ward 2 Exclave 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,900020
+HARPER,Anthony Ward 3 Exclave 1,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",0,900030
+HARPER,Anthony Ward 3 Exclave 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,900030
+HARPER,Anthony Ward 3 Exclave 2,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",0,900040
+HARPER,Anthony Ward 3 Exclave 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,900040
+HARPER,Anthony Ward 4 Exclave 1,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",0,900050
+HARPER,Anthony Ward 4 Exclave 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,900050
+HARPER,Harper Ward 1 Exclave 1,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",0,900060
+HARPER,Harper Ward 1 Exclave 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,900060
+HARPER,Township 5 West Enclave,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",0,900070
+HARPER,Township 5 West Enclave,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,900070
+HARPER,Anthony Ward 1,Kansas Senate,32,Republican,"Abrams, Steve E",347,000010
+HARPER,Anthony Ward 2,Kansas Senate,32,Republican,"Abrams, Steve E",173,000020
+HARPER,Anthony Ward 3,Kansas Senate,32,Republican,"Abrams, Steve E",67,000030
+HARPER,Anthony Ward 4,Kansas Senate,32,Republican,"Abrams, Steve E",112,000040
+HARPER,Harper Ward 1,Kansas Senate,32,Republican,"Abrams, Steve E",200,000050
+HARPER,Harper Ward 2,Kansas Senate,32,Republican,"Abrams, Steve E",221,000060
+HARPER,Township 1,Kansas Senate,32,Republican,"Abrams, Steve E",316,000070
+HARPER,Township 2,Kansas Senate,32,Republican,"Abrams, Steve E",45,000080
+HARPER,Township 4,Kansas Senate,32,Republican,"Abrams, Steve E",54,000100
+HARPER,Township 3 East,Kansas Senate,32,Republican,"Abrams, Steve E",44,800010
+HARPER,Township 3 West,Kansas Senate,32,Republican,"Abrams, Steve E",69,800020
+HARPER,Township 5 East,Kansas Senate,32,Republican,"Abrams, Steve E",115,800030
+HARPER,Township 5 West,Kansas Senate,32,Republican,"Abrams, Steve E",36,800040
+HARPER,Township 6 East,Kansas Senate,32,Republican,"Abrams, Steve E",72,800050
+HARPER,Township 6 West,Kansas Senate,32,Republican,"Abrams, Steve E",28,800060
+HARPER,Anthony Ward 2 Exclave 1,Kansas Senate,32,Republican,"Abrams, Steve E",0,900010
+HARPER,Anthony Ward 2 Exclave 2,Kansas Senate,32,Republican,"Abrams, Steve E",0,900020
+HARPER,Anthony Ward 3 Exclave 1,Kansas Senate,32,Republican,"Abrams, Steve E",0,900030
+HARPER,Anthony Ward 3 Exclave 2,Kansas Senate,32,Republican,"Abrams, Steve E",0,900040
+HARPER,Anthony Ward 4 Exclave 1,Kansas Senate,32,Republican,"Abrams, Steve E",0,900050
+HARPER,Harper Ward 1 Exclave 1,Kansas Senate,32,Republican,"Abrams, Steve E",0,900060
+HARPER,Township 5 West Enclave,Kansas Senate,32,Republican,"Abrams, Steve E",0,900070
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,Democratic,"Obama, Barack",103,000010
+HARPER,Anthony Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000010
+HARPER,Anthony Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+HARPER,Anthony Ward 1,President / Vice President,,Republican,"Romney, Mitt",309,000010
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,Democratic,"Obama, Barack",45,000020
+HARPER,Anthony Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",9,000020
+HARPER,Anthony Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+HARPER,Anthony Ward 2,President / Vice President,,Republican,"Romney, Mitt",159,000020
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,Democratic,"Obama, Barack",13,000030
+HARPER,Anthony Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+HARPER,Anthony Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+HARPER,Anthony Ward 3,President / Vice President,,Republican,"Romney, Mitt",60,000030
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Stein, Jill E",1,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,Democratic,"Obama, Barack",30,000040
+HARPER,Anthony Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",3,000040
+HARPER,Anthony Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,Republican,"Romney, Mitt",109,000040
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+HARPER,Harper Ward 1,President / Vice President,,Democratic,"Obama, Barack",66,000050
+HARPER,Harper Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000050
+HARPER,Harper Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000050
+HARPER,Harper Ward 1,President / Vice President,,Republican,"Romney, Mitt",171,000050
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+HARPER,Harper Ward 2,President / Vice President,,Democratic,"Obama, Barack",86,000060
+HARPER,Harper Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",7,000060
+HARPER,Harper Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",7,000060
+HARPER,Harper Ward 2,President / Vice President,,Republican,"Romney, Mitt",191,000060
+HARPER,Township 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Barnett, Andre",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Bush, Kent W",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Christensen, Will",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Goode, Virgil",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Stein, Jill E",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+HARPER,Township 1,President / Vice President,,Democratic,"Obama, Barack",91,000070
+HARPER,Township 1,President / Vice President,,Libertarian,"Johnson, Gary",18,000070
+HARPER,Township 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+HARPER,Township 1,President / Vice President,,Republican,"Romney, Mitt",296,000070
+HARPER,Township 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Barnett, Andre",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Bush, Kent W",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Christensen, Will",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Goode, Virgil",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Stein, Jill E",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+HARPER,Township 2,President / Vice President,,Democratic,"Obama, Barack",2,000080
+HARPER,Township 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+HARPER,Township 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+HARPER,Township 2,President / Vice President,,Republican,"Romney, Mitt",50,000080
+HARPER,Township 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Barnett, Andre",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Bush, Kent W",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Christensen, Will",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Goode, Virgil",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Stein, Jill E",2,000100
+HARPER,Township 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+HARPER,Township 4,President / Vice President,,Democratic,"Obama, Barack",27,000100
+HARPER,Township 4,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+HARPER,Township 4,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+HARPER,Township 4,President / Vice President,,Republican,"Romney, Mitt",48,000100
+HARPER,Township 3 East,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Ayers, Avery L",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Barnett, Andre",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Barr, Roseanne C",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Bush, Kent W",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Christensen, Will",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Duncan, Richard A",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Goode, Virgil",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Hoefling, Tom",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Knill, Dennis J",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Reed, Jill A.",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Rogers, Rick L",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Stein, Jill E",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Thorne, Kevin M",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Warner, Gerald L.",0,800010
+HARPER,Township 3 East,President / Vice President,,Democratic,"Obama, Barack",12,800010
+HARPER,Township 3 East,President / Vice President,,Libertarian,"Johnson, Gary",0,800010
+HARPER,Township 3 East,President / Vice President,,Reform,"Baldwin, Chuck",1,800010
+HARPER,Township 3 East,President / Vice President,,Republican,"Romney, Mitt",42,800010
+HARPER,Township 3 West,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Ayers, Avery L",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Barnett, Andre",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Barr, Roseanne C",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Bush, Kent W",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Christensen, Will",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Duncan, Richard A",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Goode, Virgil",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Hoefling, Tom",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Knill, Dennis J",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Reed, Jill A.",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Rogers, Rick L",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Stein, Jill E",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Thorne, Kevin M",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Warner, Gerald L.",0,800020
+HARPER,Township 3 West,President / Vice President,,Democratic,"Obama, Barack",17,800020
+HARPER,Township 3 West,President / Vice President,,Libertarian,"Johnson, Gary",1,800020
+HARPER,Township 3 West,President / Vice President,,Reform,"Baldwin, Chuck",1,800020
+HARPER,Township 3 West,President / Vice President,,Republican,"Romney, Mitt",65,800020
+HARPER,Township 5 East,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Ayers, Avery L",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Barnett, Andre",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Barr, Roseanne C",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Bush, Kent W",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Christensen, Will",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Duncan, Richard A",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Goode, Virgil",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Hoefling, Tom",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Knill, Dennis J",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Reed, Jill A.",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Rogers, Rick L",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Stein, Jill E",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Thorne, Kevin M",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Warner, Gerald L.",0,800030
+HARPER,Township 5 East,President / Vice President,,Democratic,"Obama, Barack",27,800030
+HARPER,Township 5 East,President / Vice President,,Libertarian,"Johnson, Gary",4,800030
+HARPER,Township 5 East,President / Vice President,,Reform,"Baldwin, Chuck",0,800030
+HARPER,Township 5 East,President / Vice President,,Republican,"Romney, Mitt",121,800030
+HARPER,Township 5 West,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Ayers, Avery L",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Barnett, Andre",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Barr, Roseanne C",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Bush, Kent W",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Christensen, Will",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Duncan, Richard A",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Goode, Virgil",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Hoefling, Tom",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Knill, Dennis J",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Reed, Jill A.",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Rogers, Rick L",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Stein, Jill E",1,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Thorne, Kevin M",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Warner, Gerald L.",0,800040
+HARPER,Township 5 West,President / Vice President,,Democratic,"Obama, Barack",9,800040
+HARPER,Township 5 West,President / Vice President,,Libertarian,"Johnson, Gary",0,800040
+HARPER,Township 5 West,President / Vice President,,Reform,"Baldwin, Chuck",1,800040
+HARPER,Township 5 West,President / Vice President,,Republican,"Romney, Mitt",31,800040
+HARPER,Township 6 East,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Ayers, Avery L",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Barnett, Andre",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Barr, Roseanne C",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Bush, Kent W",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Christensen, Will",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Duncan, Richard A",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Goode, Virgil",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Hoefling, Tom",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Knill, Dennis J",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Reed, Jill A.",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Rogers, Rick L",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Stein, Jill E",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Thorne, Kevin M",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Warner, Gerald L.",0,800050
+HARPER,Township 6 East,President / Vice President,,Democratic,"Obama, Barack",19,800050
+HARPER,Township 6 East,President / Vice President,,Libertarian,"Johnson, Gary",1,800050
+HARPER,Township 6 East,President / Vice President,,Reform,"Baldwin, Chuck",0,800050
+HARPER,Township 6 East,President / Vice President,,Republican,"Romney, Mitt",79,800050
+HARPER,Township 6 West,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Ayers, Avery L",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Barnett, Andre",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Barr, Roseanne C",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Bush, Kent W",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Christensen, Will",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Duncan, Richard A",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Goode, Virgil",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Hoefling, Tom",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Knill, Dennis J",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Reed, Jill A.",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Rogers, Rick L",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Stein, Jill E",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Thorne, Kevin M",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Warner, Gerald L.",0,800060
+HARPER,Township 6 West,President / Vice President,,Democratic,"Obama, Barack",3,800060
+HARPER,Township 6 West,President / Vice President,,Libertarian,"Johnson, Gary",2,800060
+HARPER,Township 6 West,President / Vice President,,Reform,"Baldwin, Chuck",0,800060
+HARPER,Township 6 West,President / Vice President,,Republican,"Romney, Mitt",28,800060
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Christensen, Will",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+HARPER,Anthony Ward 2 Exclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900010
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Christensen, Will",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+HARPER,Anthony Ward 2 Exclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900020
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Christensen, Will",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+HARPER,Anthony Ward 3 Exclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900030
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Christensen, Will",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+HARPER,Anthony Ward 3 Exclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900040
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Christensen, Will",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900050
+HARPER,Anthony Ward 4 Exclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900050
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Christensen, Will",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900060
+HARPER,Harper Ward 1 Exclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900060
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Barnett, Andre",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Bush, Kent W",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Christensen, Will",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Goode, Virgil",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Stein, Jill E",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,Democratic,"Obama, Barack",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900070
+HARPER,Township 5 West Enclave,President / Vice President,,Republican,"Romney, Mitt",0,900070
+HARPER,Anthony Ward 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",73,000010
+HARPER,Anthony Ward 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",21,000010
+HARPER,Anthony Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",320,000010
+HARPER,Anthony Ward 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",42,000020
+HARPER,Anthony Ward 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000020
+HARPER,Anthony Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",161,000020
+HARPER,Anthony Ward 3,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",10,000030
+HARPER,Anthony Ward 3,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000030
+HARPER,Anthony Ward 3,United States House of Representatives,4,Republican,"Pompeo, Mike",62,000030
+HARPER,Anthony Ward 4,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",18,000040
+HARPER,Anthony Ward 4,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",9,000040
+HARPER,Anthony Ward 4,United States House of Representatives,4,Republican,"Pompeo, Mike",113,000040
+HARPER,Harper Ward 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",56,000050
+HARPER,Harper Ward 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",15,000050
+HARPER,Harper Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",161,000050
+HARPER,Harper Ward 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",57,000060
+HARPER,Harper Ward 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",18,000060
+HARPER,Harper Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",205,000060
+HARPER,Township 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",69,000070
+HARPER,Township 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",25,000070
+HARPER,Township 1,United States House of Representatives,4,Republican,"Pompeo, Mike",302,000070
+HARPER,Township 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000080
+HARPER,Township 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000080
+HARPER,Township 2,United States House of Representatives,4,Republican,"Pompeo, Mike",48,000080
+HARPER,Township 4,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",26,000100
+HARPER,Township 4,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,000100
+HARPER,Township 4,United States House of Representatives,4,Republican,"Pompeo, Mike",45,000100
+HARPER,Township 3 East,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",17,800010
+HARPER,Township 3 East,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,800010
+HARPER,Township 3 East,United States House of Representatives,4,Republican,"Pompeo, Mike",36,800010
+HARPER,Township 3 West,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",11,800020
+HARPER,Township 3 West,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,800020
+HARPER,Township 3 West,United States House of Representatives,4,Republican,"Pompeo, Mike",64,800020
+HARPER,Township 5 East,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",22,800030
+HARPER,Township 5 East,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,800030
+HARPER,Township 5 East,United States House of Representatives,4,Republican,"Pompeo, Mike",118,800030
+HARPER,Township 5 West,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",7,800040
+HARPER,Township 5 West,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,800040
+HARPER,Township 5 West,United States House of Representatives,4,Republican,"Pompeo, Mike",33,800040
+HARPER,Township 6 East,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",12,800050
+HARPER,Township 6 East,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,800050
+HARPER,Township 6 East,United States House of Representatives,4,Republican,"Pompeo, Mike",77,800050
+HARPER,Township 6 West,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",4,800060
+HARPER,Township 6 West,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,800060
+HARPER,Township 6 West,United States House of Representatives,4,Republican,"Pompeo, Mike",27,800060
+HARPER,Anthony Ward 2 Exclave 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900010
+HARPER,Anthony Ward 2 Exclave 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900010
+HARPER,Anthony Ward 2 Exclave 1,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900010
+HARPER,Anthony Ward 2 Exclave 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900020
+HARPER,Anthony Ward 2 Exclave 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900020
+HARPER,Anthony Ward 2 Exclave 2,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900020
+HARPER,Anthony Ward 3 Exclave 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900030
+HARPER,Anthony Ward 3 Exclave 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900030
+HARPER,Anthony Ward 3 Exclave 1,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900030
+HARPER,Anthony Ward 3 Exclave 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900040
+HARPER,Anthony Ward 3 Exclave 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900040
+HARPER,Anthony Ward 3 Exclave 2,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900040
+HARPER,Anthony Ward 4 Exclave 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900050
+HARPER,Anthony Ward 4 Exclave 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900050
+HARPER,Anthony Ward 4 Exclave 1,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900050
+HARPER,Harper Ward 1 Exclave 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900060
+HARPER,Harper Ward 1 Exclave 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900060
+HARPER,Harper Ward 1 Exclave 1,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900060
+HARPER,Township 5 West Enclave,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900070
+HARPER,Township 5 West Enclave,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900070
+HARPER,Township 5 West Enclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900070

--- a/2012/20121106__ks__general__harvey__precinct.csv
+++ b/2012/20121106__ks__general__harvey__precinct.csv
@@ -1,0 +1,1151 @@
+county,precinct,office,district,party,candidate,votes,vtd
+HARVEY,Alta Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",107,000010
+HARVEY,Burrton Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",89,000020
+HARVEY,Emma Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",226,000040
+HARVEY,Garden Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",117,000050
+HARVEY,Halstead City Ward 1 Precinct 1,Kansas House of Representatives,74,Republican,"Schroeder, Don",303,000060
+HARVEY,Halstead City Ward 1 Precinct 2,Kansas House of Representatives,74,Republican,"Schroeder, Don",393,000070
+HARVEY,Halstead Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",107,000080
+HARVEY,Hesston Precinct 1,Kansas House of Representatives,74,Republican,"Schroeder, Don",647,000090
+HARVEY,Hesston Precinct 2,Kansas House of Representatives,74,Republican,"Schroeder, Don",719,00010A
+HARVEY,Highland Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",158,000110
+HARVEY,Lake Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",71,000120
+HARVEY,Lakin Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",92,000130
+HARVEY,Macon Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",211,000140
+HARVEY,Newton City Ward 1 Precinct 1,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",183,000150
+HARVEY,Newton City Ward 1 Precinct 1,Kansas House of Representatives,72,Republican,"Rhoades, Marc",205,000150
+HARVEY,Newton City Ward 1 Precinct 2,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",136,000160
+HARVEY,Newton City Ward 1 Precinct 2,Kansas House of Representatives,72,Republican,"Rhoades, Marc",200,000160
+HARVEY,Newton City Ward 1 Precinct 3,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",93,000170
+HARVEY,Newton City Ward 1 Precinct 3,Kansas House of Representatives,72,Republican,"Rhoades, Marc",147,000170
+HARVEY,Newton City Ward 2 Precinct 1,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",135,000180
+HARVEY,Newton City Ward 2 Precinct 1,Kansas House of Representatives,72,Republican,"Rhoades, Marc",187,000180
+HARVEY,Newton City Ward 2 Precinct 2,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",395,00019A
+HARVEY,Newton City Ward 2 Precinct 2,Kansas House of Representatives,72,Republican,"Rhoades, Marc",521,00019A
+HARVEY,Newton City Ward 3 Precinct 1,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",154,000200
+HARVEY,Newton City Ward 3 Precinct 1,Kansas House of Representatives,72,Republican,"Rhoades, Marc",236,000200
+HARVEY,Newton City Ward 3 Precinct 2,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",218,000210
+HARVEY,Newton City Ward 3 Precinct 2,Kansas House of Representatives,72,Republican,"Rhoades, Marc",374,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",188,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Kansas House of Representatives,72,Republican,"Rhoades, Marc",342,00022A
+HARVEY,Newton City Ward 4 Precinct 1,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",209,000230
+HARVEY,Newton City Ward 4 Precinct 1,Kansas House of Representatives,72,Republican,"Rhoades, Marc",262,000230
+HARVEY,Newton City Ward 4 Precinct 2,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",365,000240
+HARVEY,Newton City Ward 4 Precinct 2,Kansas House of Representatives,72,Republican,"Rhoades, Marc",502,000240
+HARVEY,Newton City Ward 4 Precinct 3,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",265,000250
+HARVEY,Newton City Ward 4 Precinct 3,Kansas House of Representatives,72,Republican,"Rhoades, Marc",430,000250
+HARVEY,Newton City Ward 4 Precinct 4,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",118,000260
+HARVEY,Newton City Ward 4 Precinct 4,Kansas House of Representatives,72,Republican,"Rhoades, Marc",165,000260
+HARVEY,Newton Township Part A,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",0,00027A
+HARVEY,Newton Township Part A,Kansas House of Representatives,72,Republican,"Rhoades, Marc",0,00027A
+HARVEY,Newton Township Part B,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",38,00027B
+HARVEY,Newton Township Part B,Kansas House of Representatives,72,Republican,"Rhoades, Marc",130,00027B
+HARVEY,Newton Township Part B Exclave,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",0,00027C
+HARVEY,Newton Township Part B Exclave,Kansas House of Representatives,72,Republican,"Rhoades, Marc",0,00027C
+HARVEY,Newton Township Part C,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",0,00027D
+HARVEY,Newton Township Part C,Kansas House of Representatives,72,Republican,"Rhoades, Marc",0,00027D
+HARVEY,North Newton City,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",562,000280
+HARVEY,North Newton City,Kansas House of Representatives,72,Republican,"Rhoades, Marc",363,000280
+HARVEY,Pleasant Township,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",92,000290
+HARVEY,Pleasant Township,Kansas House of Representatives,72,Republican,"Rhoades, Marc",177,000290
+HARVEY,Richland Township,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",43,000300
+HARVEY,Richland Township,Kansas House of Representatives,72,Republican,"Rhoades, Marc",155,000300
+HARVEY,Sedgwick Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",122,000310
+HARVEY,Walton Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",112,000320
+HARVEY,Darlington Township H72,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",16,120020
+HARVEY,Darlington Township H72,Kansas House of Representatives,72,Republican,"Rhoades, Marc",49,120020
+HARVEY,Darlington Township H74,Kansas House of Representatives,74,Republican,"Schroeder, Don",175,120030
+HARVEY,Newton City Ward 3 Precinct 4,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",344,800010
+HARVEY,Newton City Ward 3 Precinct 4,Kansas House of Representatives,72,Republican,"Rhoades, Marc",731,800010
+HARVEY,Burrton City,Kansas House of Representatives,74,Republican,"Schroeder, Don",285,900010
+HARVEY,Sedgwick City,Kansas House of Representatives,74,Republican,"Schroeder, Don",516,900020
+HARVEY,Walton City,Kansas House of Representatives,74,Republican,"Schroeder, Don",88,900030
+HARVEY,Burrton City Exclave,Kansas House of Representatives,74,Republican,"Schroeder, Don",0,900040
+HARVEY,Newton Township Part D,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",7,900050
+HARVEY,Newton Township Part D,Kansas House of Representatives,72,Republican,"Rhoades, Marc",45,900050
+HARVEY,Newton Township Part E,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",0,900060
+HARVEY,Newton Township Part E,Kansas House of Representatives,72,Republican,"Rhoades, Marc",0,900060
+HARVEY,Newton Township Part F,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",0,900070
+HARVEY,Newton Township Part F,Kansas House of Representatives,72,Republican,"Rhoades, Marc",0,900070
+HARVEY,Newton Township Part G,Kansas House of Representatives,72,Democratic,"Reynolds, Glenda",0,900080
+HARVEY,Newton Township Part G,Kansas House of Representatives,72,Republican,"Rhoades, Marc",0,900080
+HARVEY,Alta Township,Kansas Senate,31,Republican,"McGinn, Carolyn",101,000010
+HARVEY,Burrton Township,Kansas Senate,31,Republican,"McGinn, Carolyn",87,000020
+HARVEY,Emma Township,Kansas Senate,31,Republican,"McGinn, Carolyn",218,000040
+HARVEY,Garden Township,Kansas Senate,31,Republican,"McGinn, Carolyn",121,000050
+HARVEY,Halstead City Ward 1 Precinct 1,Kansas Senate,31,Republican,"McGinn, Carolyn",312,000060
+HARVEY,Halstead City Ward 1 Precinct 2,Kansas Senate,31,Republican,"McGinn, Carolyn",407,000070
+HARVEY,Halstead Township,Kansas Senate,31,Republican,"McGinn, Carolyn",113,000080
+HARVEY,Hesston Precinct 1,Kansas Senate,31,Republican,"McGinn, Carolyn",672,000090
+HARVEY,Hesston Precinct 2,Kansas Senate,31,Republican,"McGinn, Carolyn",730,00010A
+HARVEY,Highland Township,Kansas Senate,31,Republican,"McGinn, Carolyn",168,000110
+HARVEY,Lake Township,Kansas Senate,31,Republican,"McGinn, Carolyn",75,000120
+HARVEY,Lakin Township,Kansas Senate,31,Republican,"McGinn, Carolyn",88,000130
+HARVEY,Macon Township,Kansas Senate,31,Republican,"McGinn, Carolyn",219,000140
+HARVEY,Newton City Ward 1 Precinct 1,Kansas Senate,31,Republican,"McGinn, Carolyn",316,000150
+HARVEY,Newton City Ward 1 Precinct 2,Kansas Senate,31,Republican,"McGinn, Carolyn",292,000160
+HARVEY,Newton City Ward 1 Precinct 3,Kansas Senate,31,Republican,"McGinn, Carolyn",190,000170
+HARVEY,Newton City Ward 2 Precinct 1,Kansas Senate,31,Republican,"McGinn, Carolyn",276,000180
+HARVEY,Newton City Ward 2 Precinct 2,Kansas Senate,31,Republican,"McGinn, Carolyn",776,00019A
+HARVEY,Newton City Ward 3 Precinct 1,Kansas Senate,31,Republican,"McGinn, Carolyn",299,000200
+HARVEY,Newton City Ward 3 Precinct 2,Kansas Senate,31,Republican,"McGinn, Carolyn",487,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Kansas Senate,31,Republican,"McGinn, Carolyn",458,00022A
+HARVEY,Newton City Ward 4 Precinct 1,Kansas Senate,31,Republican,"McGinn, Carolyn",391,000230
+HARVEY,Newton City Ward 4 Precinct 2,Kansas Senate,31,Republican,"McGinn, Carolyn",758,000240
+HARVEY,Newton City Ward 4 Precinct 3,Kansas Senate,31,Republican,"McGinn, Carolyn",586,000250
+HARVEY,Newton City Ward 4 Precinct 4,Kansas Senate,31,Republican,"McGinn, Carolyn",219,000260
+HARVEY,Newton Township Part A,Kansas Senate,31,Republican,"McGinn, Carolyn",0,00027A
+HARVEY,Newton Township Part B,Kansas Senate,31,Republican,"McGinn, Carolyn",141,00027B
+HARVEY,Newton Township Part B Exclave,Kansas Senate,31,Republican,"McGinn, Carolyn",0,00027C
+HARVEY,Newton Township Part C,Kansas Senate,31,Republican,"McGinn, Carolyn",0,00027D
+HARVEY,North Newton City,Kansas Senate,31,Republican,"McGinn, Carolyn",800,000280
+HARVEY,Pleasant Township,Kansas Senate,31,Republican,"McGinn, Carolyn",223,000290
+HARVEY,Richland Township,Kansas Senate,31,Republican,"McGinn, Carolyn",162,000300
+HARVEY,Sedgwick Township,Kansas Senate,31,Republican,"McGinn, Carolyn",115,000310
+HARVEY,Walton Township,Kansas Senate,31,Republican,"McGinn, Carolyn",117,000320
+HARVEY,Darlington Township H72,Kansas Senate,31,Republican,"McGinn, Carolyn",55,120020
+HARVEY,Darlington Township H74,Kansas Senate,31,Republican,"McGinn, Carolyn",176,120030
+HARVEY,Newton City Ward 3 Precinct 4,Kansas Senate,31,Republican,"McGinn, Carolyn",950,800010
+HARVEY,Burrton City,Kansas Senate,31,Republican,"McGinn, Carolyn",287,900010
+HARVEY,Sedgwick City,Kansas Senate,31,Republican,"McGinn, Carolyn",536,900020
+HARVEY,Walton City,Kansas Senate,31,Republican,"McGinn, Carolyn",86,900030
+HARVEY,Burrton City Exclave,Kansas Senate,31,Republican,"McGinn, Carolyn",0,900040
+HARVEY,Newton Township Part D,Kansas Senate,31,Republican,"McGinn, Carolyn",45,900050
+HARVEY,Newton Township Part E,Kansas Senate,31,Republican,"McGinn, Carolyn",0,900060
+HARVEY,Newton Township Part F,Kansas Senate,31,Republican,"McGinn, Carolyn",0,900070
+HARVEY,Newton Township Part G,Kansas Senate,31,Republican,"McGinn, Carolyn",0,900080
+HARVEY,Alta Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Stein, Jill E",1,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+HARVEY,Alta Township,President / Vice President,,Democratic,"Obama, Barack",26,000010
+HARVEY,Alta Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000010
+HARVEY,Alta Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+HARVEY,Alta Township,President / Vice President,,Republican,"Romney, Mitt",92,000010
+HARVEY,Burrton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+HARVEY,Burrton Township,President / Vice President,,Democratic,"Obama, Barack",26,000020
+HARVEY,Burrton Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+HARVEY,Burrton Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000020
+HARVEY,Burrton Township,President / Vice President,,Republican,"Romney, Mitt",65,000020
+HARVEY,Emma Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Stein, Jill E",1,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+HARVEY,Emma Township,President / Vice President,,Democratic,"Obama, Barack",51,000040
+HARVEY,Emma Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000040
+HARVEY,Emma Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+HARVEY,Emma Township,President / Vice President,,Republican,"Romney, Mitt",197,000040
+HARVEY,Garden Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+HARVEY,Garden Township,President / Vice President,,Democratic,"Obama, Barack",41,000050
+HARVEY,Garden Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000050
+HARVEY,Garden Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+HARVEY,Garden Township,President / Vice President,,Republican,"Romney, Mitt",94,000050
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",102,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",228,000060
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",1,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",153,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",14,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",287,000070
+HARVEY,Halstead Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Goode, Virgil",1,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+HARVEY,Halstead Township,President / Vice President,,Democratic,"Obama, Barack",54,000080
+HARVEY,Halstead Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+HARVEY,Halstead Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+HARVEY,Halstead Township,President / Vice President,,Republican,"Romney, Mitt",73,000080
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Goode, Virgil",1,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Stein, Jill E",3,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,Democratic,"Obama, Barack",314,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",14,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,Republican,"Romney, Mitt",446,000090
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Goode, Virgil",1,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Stein, Jill E",1,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,Democratic,"Obama, Barack",256,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",6,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,Republican,"Romney, Mitt",566,00010A
+HARVEY,Highland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Stein, Jill E",1,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+HARVEY,Highland Township,President / Vice President,,Democratic,"Obama, Barack",74,000110
+HARVEY,Highland Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000110
+HARVEY,Highland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+HARVEY,Highland Township,President / Vice President,,Republican,"Romney, Mitt",112,000110
+HARVEY,Lake Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+HARVEY,Lake Township,President / Vice President,,Democratic,"Obama, Barack",18,000120
+HARVEY,Lake Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+HARVEY,Lake Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+HARVEY,Lake Township,President / Vice President,,Republican,"Romney, Mitt",68,000120
+HARVEY,Lakin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+HARVEY,Lakin Township,President / Vice President,,Democratic,"Obama, Barack",30,000130
+HARVEY,Lakin Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+HARVEY,Lakin Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000130
+HARVEY,Lakin Township,President / Vice President,,Republican,"Romney, Mitt",85,000130
+HARVEY,Macon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+HARVEY,Macon Township,President / Vice President,,Democratic,"Obama, Barack",85,000140
+HARVEY,Macon Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000140
+HARVEY,Macon Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000140
+HARVEY,Macon Township,President / Vice President,,Republican,"Romney, Mitt",156,000140
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",187,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",8,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",202,000150
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",2,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",146,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",8,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",187,000160
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",113,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",5,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",132,000170
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",2,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",163,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",165,000180
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",1,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",2,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",409,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",13,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",5,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",500,00019A
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",182,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",10,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",208,000200
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",1,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",2,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",224,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",10,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",4,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",366,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Barnett, Andre",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Bush, Kent W",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Christensen, Will",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Goode, Virgil",1,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Stein, Jill E",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,Democratic,"Obama, Barack",206,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,Libertarian,"Johnson, Gary",7,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,Reform,"Baldwin, Chuck",2,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,Republican,"Romney, Mitt",333,00022A
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",220,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",3,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",244,000230
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",363,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",15,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",6,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",498,000240
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",1,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",287,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",8,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",3,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",401,000250
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Goode, Virgil",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Stein, Jill E",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,Democratic,"Obama, Barack",115,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",2,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",1,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,Republican,"Romney, Mitt",168,000260
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Barnett, Andre",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Bush, Kent W",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Christensen, Will",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Goode, Virgil",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Stein, Jill E",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,Democratic,"Obama, Barack",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,Reform,"Baldwin, Chuck",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,Republican,"Romney, Mitt",0,00027A
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Ayers, Avery L",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Barnett, Andre",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Bush, Kent W",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Christensen, Will",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Duncan, Richard A",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Goode, Virgil",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Knill, Dennis J",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Reed, Jill A.",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Rogers, Rick L",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Stein, Jill E",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,Democratic,"Obama, Barack",48,00027B
+HARVEY,Newton Township Part B,President / Vice President,,Libertarian,"Johnson, Gary",1,00027B
+HARVEY,Newton Township Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,Republican,"Romney, Mitt",119,00027B
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Christensen, Will",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00027C
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Ayers, Avery L",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Barnett, Andre",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Barr, Roseanne C",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Bush, Kent W",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Christensen, Will",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Duncan, Richard A",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Goode, Virgil",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Hoefling, Tom",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Knill, Dennis J",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Reed, Jill A.",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Rogers, Rick L",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Stein, Jill E",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Thorne, Kevin M",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Warner, Gerald L.",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,Democratic,"Obama, Barack",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,Libertarian,"Johnson, Gary",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,Reform,"Baldwin, Chuck",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,Republican,"Romney, Mitt",0,00027D
+HARVEY,North Newton City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Barnett, Andre",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Bush, Kent W",1,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Christensen, Will",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Goode, Virgil",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Stein, Jill E",1,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+HARVEY,North Newton City,President / Vice President,,Democratic,"Obama, Barack",558,000280
+HARVEY,North Newton City,President / Vice President,,Libertarian,"Johnson, Gary",5,000280
+HARVEY,North Newton City,President / Vice President,,Reform,"Baldwin, Chuck",3,000280
+HARVEY,North Newton City,President / Vice President,,Republican,"Romney, Mitt",368,000280
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Barnett, Andre",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Bush, Kent W",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Christensen, Will",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Goode, Virgil",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Stein, Jill E",1,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+HARVEY,Pleasant Township,President / Vice President,,Democratic,"Obama, Barack",83,000290
+HARVEY,Pleasant Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000290
+HARVEY,Pleasant Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000290
+HARVEY,Pleasant Township,President / Vice President,,Republican,"Romney, Mitt",185,000290
+HARVEY,Richland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Barnett, Andre",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Bush, Kent W",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Christensen, Will",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Goode, Virgil",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Stein, Jill E",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+HARVEY,Richland Township,President / Vice President,,Democratic,"Obama, Barack",35,000300
+HARVEY,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000300
+HARVEY,Richland Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000300
+HARVEY,Richland Township,President / Vice President,,Republican,"Romney, Mitt",166,000300
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Barnett, Andre",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Bush, Kent W",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Christensen, Will",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Goode, Virgil",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Stein, Jill E",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,Democratic,"Obama, Barack",28,000310
+HARVEY,Sedgwick Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000310
+HARVEY,Sedgwick Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,Republican,"Romney, Mitt",110,000310
+HARVEY,Walton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Barnett, Andre",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Bush, Kent W",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Christensen, Will",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Goode, Virgil",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Stein, Jill E",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+HARVEY,Walton Township,President / Vice President,,Democratic,"Obama, Barack",47,000320
+HARVEY,Walton Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000320
+HARVEY,Walton Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000320
+HARVEY,Walton Township,President / Vice President,,Republican,"Romney, Mitt",90,000320
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Barnett, Andre",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Bush, Kent W",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Christensen, Will",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Goode, Virgil",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Stein, Jill E",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,Democratic,"Obama, Barack",10,120020
+HARVEY,Darlington Township H72,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,Republican,"Romney, Mitt",53,120020
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Barnett, Andre",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Bush, Kent W",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Christensen, Will",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Goode, Virgil",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Stein, Jill E",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,Democratic,"Obama, Barack",66,120030
+HARVEY,Darlington Township H74,President / Vice President,,Libertarian,"Johnson, Gary",3,120030
+HARVEY,Darlington Township H74,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,Republican,"Romney, Mitt",155,120030
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Goode, Virgil",1,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Stein, Jill E",1,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,Democratic,"Obama, Barack",355,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",17,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",1,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,Republican,"Romney, Mitt",729,800010
+HARVEY,Burrton City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Barnett, Andre",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Bush, Kent W",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Christensen, Will",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Goode, Virgil",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Stein, Jill E",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+HARVEY,Burrton City,President / Vice President,,Democratic,"Obama, Barack",95,900010
+HARVEY,Burrton City,President / Vice President,,Libertarian,"Johnson, Gary",11,900010
+HARVEY,Burrton City,President / Vice President,,Reform,"Baldwin, Chuck",2,900010
+HARVEY,Burrton City,President / Vice President,,Republican,"Romney, Mitt",226,900010
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Barnett, Andre",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Bush, Kent W",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Christensen, Will",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Goode, Virgil",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Stein, Jill E",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+HARVEY,Sedgwick City,President / Vice President,,Democratic,"Obama, Barack",155,900020
+HARVEY,Sedgwick City,President / Vice President,,Libertarian,"Johnson, Gary",18,900020
+HARVEY,Sedgwick City,President / Vice President,,Reform,"Baldwin, Chuck",4,900020
+HARVEY,Sedgwick City,President / Vice President,,Republican,"Romney, Mitt",405,900020
+HARVEY,Walton City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Barnett, Andre",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Bush, Kent W",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Christensen, Will",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Goode, Virgil",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Stein, Jill E",2,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+HARVEY,Walton City,President / Vice President,,Democratic,"Obama, Barack",39,900030
+HARVEY,Walton City,President / Vice President,,Libertarian,"Johnson, Gary",1,900030
+HARVEY,Walton City,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+HARVEY,Walton City,President / Vice President,,Republican,"Romney, Mitt",64,900030
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Christensen, Will",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900040
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Ayers, Avery L",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Barnett, Andre",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Barr, Roseanne C",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Bush, Kent W",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Christensen, Will",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Duncan, Richard A",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Goode, Virgil",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Knill, Dennis J",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Reed, Jill A.",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Rogers, Rick L",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Stein, Jill E",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Thorne, Kevin M",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Warner, Gerald L.",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,Democratic,"Obama, Barack",9,900050
+HARVEY,Newton Township Part D,President / Vice President,,Libertarian,"Johnson, Gary",1,900050
+HARVEY,Newton Township Part D,President / Vice President,,Reform,"Baldwin, Chuck",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,Republican,"Romney, Mitt",45,900050
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Ayers, Avery L",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Barnett, Andre",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Barr, Roseanne C",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Bush, Kent W",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Christensen, Will",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Duncan, Richard A",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Goode, Virgil",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Knill, Dennis J",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Reed, Jill A.",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Rogers, Rick L",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Stein, Jill E",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Thorne, Kevin M",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Warner, Gerald L.",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,Democratic,"Obama, Barack",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,Reform,"Baldwin, Chuck",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,Republican,"Romney, Mitt",0,900060
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Ayers, Avery L",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Barnett, Andre",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Barr, Roseanne C",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Bush, Kent W",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Christensen, Will",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Duncan, Richard A",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Goode, Virgil",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Hoefling, Tom",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Knill, Dennis J",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Reed, Jill A.",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Rogers, Rick L",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Stein, Jill E",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Thorne, Kevin M",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Warner, Gerald L.",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,Democratic,"Obama, Barack",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,Libertarian,"Johnson, Gary",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,Reform,"Baldwin, Chuck",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,Republican,"Romney, Mitt",0,900070
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Ayers, Avery L",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Barnett, Andre",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Barr, Roseanne C",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Bush, Kent W",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Christensen, Will",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Duncan, Richard A",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Goode, Virgil",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Hoefling, Tom",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Knill, Dennis J",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Reed, Jill A.",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Rogers, Rick L",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Stein, Jill E",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Thorne, Kevin M",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Warner, Gerald L.",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,Democratic,"Obama, Barack",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,Libertarian,"Johnson, Gary",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,Reform,"Baldwin, Chuck",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,Republican,"Romney, Mitt",0,900080
+HARVEY,Alta Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",26,000010
+HARVEY,Alta Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000010
+HARVEY,Alta Township,United States House of Representatives,4,Republican,"Pompeo, Mike",93,000010
+HARVEY,Burrton Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",19,000020
+HARVEY,Burrton Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",14,000020
+HARVEY,Burrton Township,United States House of Representatives,4,Republican,"Pompeo, Mike",62,000020
+HARVEY,Emma Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",47,000040
+HARVEY,Emma Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",13,000040
+HARVEY,Emma Township,United States House of Representatives,4,Republican,"Pompeo, Mike",190,000040
+HARVEY,Garden Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",34,000050
+HARVEY,Garden Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",11,000050
+HARVEY,Garden Township,United States House of Representatives,4,Republican,"Pompeo, Mike",93,000050
+HARVEY,Halstead City Ward 1 Precinct 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",86,000060
+HARVEY,Halstead City Ward 1 Precinct 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",28,000060
+HARVEY,Halstead City Ward 1 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",220,000060
+HARVEY,Halstead City Ward 1 Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",125,000070
+HARVEY,Halstead City Ward 1 Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",30,000070
+HARVEY,Halstead City Ward 1 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",294,000070
+HARVEY,Halstead Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",44,000080
+HARVEY,Halstead Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",13,000080
+HARVEY,Halstead Township,United States House of Representatives,4,Republican,"Pompeo, Mike",71,000080
+HARVEY,Hesston Precinct 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",269,000090
+HARVEY,Hesston Precinct 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",34,000090
+HARVEY,Hesston Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",440,000090
+HARVEY,Hesston Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",202,00010A
+HARVEY,Hesston Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",35,00010A
+HARVEY,Hesston Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",566,00010A
+HARVEY,Highland Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",76,000110
+HARVEY,Highland Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",7,000110
+HARVEY,Highland Township,United States House of Representatives,4,Republican,"Pompeo, Mike",107,000110
+HARVEY,Lake Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",16,000120
+HARVEY,Lake Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,000120
+HARVEY,Lake Township,United States House of Representatives,4,Republican,"Pompeo, Mike",61,000120
+HARVEY,Lakin Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",22,000130
+HARVEY,Lakin Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",9,000130
+HARVEY,Lakin Township,United States House of Representatives,4,Republican,"Pompeo, Mike",81,000130
+HARVEY,Macon Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",81,000140
+HARVEY,Macon Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",9,000140
+HARVEY,Macon Township,United States House of Representatives,4,Republican,"Pompeo, Mike",153,000140
+HARVEY,Newton City Ward 1 Precinct 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",159,000150
+HARVEY,Newton City Ward 1 Precinct 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",38,000150
+HARVEY,Newton City Ward 1 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",199,000150
+HARVEY,Newton City Ward 1 Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",131,000160
+HARVEY,Newton City Ward 1 Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",26,000160
+HARVEY,Newton City Ward 1 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",180,000160
+HARVEY,Newton City Ward 1 Precinct 3,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",88,000170
+HARVEY,Newton City Ward 1 Precinct 3,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",12,000170
+HARVEY,Newton City Ward 1 Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Mike",139,000170
+HARVEY,Newton City Ward 2 Precinct 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",134,000180
+HARVEY,Newton City Ward 2 Precinct 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",23,000180
+HARVEY,Newton City Ward 2 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",165,000180
+HARVEY,Newton City Ward 2 Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",368,00019A
+HARVEY,Newton City Ward 2 Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",53,00019A
+HARVEY,Newton City Ward 2 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",499,00019A
+HARVEY,Newton City Ward 3 Precinct 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",148,000200
+HARVEY,Newton City Ward 3 Precinct 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",26,000200
+HARVEY,Newton City Ward 3 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",212,000200
+HARVEY,Newton City Ward 3 Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",192,000210
+HARVEY,Newton City Ward 3 Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",36,000210
+HARVEY,Newton City Ward 3 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",366,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",175,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",36,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States House of Representatives,4,Republican,"Pompeo, Mike",321,00022A
+HARVEY,Newton City Ward 4 Precinct 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",194,000230
+HARVEY,Newton City Ward 4 Precinct 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",24,000230
+HARVEY,Newton City Ward 4 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",249,000230
+HARVEY,Newton City Ward 4 Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",331,000240
+HARVEY,Newton City Ward 4 Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",46,000240
+HARVEY,Newton City Ward 4 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",484,000240
+HARVEY,Newton City Ward 4 Precinct 3,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",242,000250
+HARVEY,Newton City Ward 4 Precinct 3,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",38,000250
+HARVEY,Newton City Ward 4 Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Mike",407,000250
+HARVEY,Newton City Ward 4 Precinct 4,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",100,000260
+HARVEY,Newton City Ward 4 Precinct 4,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",20,000260
+HARVEY,Newton City Ward 4 Precinct 4,United States House of Representatives,4,Republican,"Pompeo, Mike",156,000260
+HARVEY,Newton Township Part A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,00027A
+HARVEY,Newton Township Part A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,00027A
+HARVEY,Newton Township Part A,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00027A
+HARVEY,Newton Township Part B,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",40,00027B
+HARVEY,Newton Township Part B,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,00027B
+HARVEY,Newton Township Part B,United States House of Representatives,4,Republican,"Pompeo, Mike",122,00027B
+HARVEY,Newton Township Part B Exclave,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,00027C
+HARVEY,Newton Township Part B Exclave,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,00027C
+HARVEY,Newton Township Part B Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00027C
+HARVEY,Newton Township Part C,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,00027D
+HARVEY,Newton Township Part C,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,00027D
+HARVEY,Newton Township Part C,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00027D
+HARVEY,North Newton City,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",512,000280
+HARVEY,North Newton City,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",23,000280
+HARVEY,North Newton City,United States House of Representatives,4,Republican,"Pompeo, Mike",378,000280
+HARVEY,Pleasant Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",78,000290
+HARVEY,Pleasant Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",9,000290
+HARVEY,Pleasant Township,United States House of Representatives,4,Republican,"Pompeo, Mike",185,000290
+HARVEY,Richland Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",31,000300
+HARVEY,Richland Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",11,000300
+HARVEY,Richland Township,United States House of Representatives,4,Republican,"Pompeo, Mike",160,000300
+HARVEY,Sedgwick Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",23,000310
+HARVEY,Sedgwick Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",12,000310
+HARVEY,Sedgwick Township,United States House of Representatives,4,Republican,"Pompeo, Mike",102,000310
+HARVEY,Walton Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",34,000320
+HARVEY,Walton Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",13,000320
+HARVEY,Walton Township,United States House of Representatives,4,Republican,"Pompeo, Mike",86,000320
+HARVEY,Darlington Township H72,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",8,120020
+HARVEY,Darlington Township H72,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",7,120020
+HARVEY,Darlington Township H72,United States House of Representatives,4,Republican,"Pompeo, Mike",49,120020
+HARVEY,Darlington Township H74,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",62,120030
+HARVEY,Darlington Township H74,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",10,120030
+HARVEY,Darlington Township H74,United States House of Representatives,4,Republican,"Pompeo, Mike",150,120030
+HARVEY,Newton City Ward 3 Precinct 4,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",292,800010
+HARVEY,Newton City Ward 3 Precinct 4,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",49,800010
+HARVEY,Newton City Ward 3 Precinct 4,United States House of Representatives,4,Republican,"Pompeo, Mike",738,800010
+HARVEY,Burrton City,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",68,900010
+HARVEY,Burrton City,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",22,900010
+HARVEY,Burrton City,United States House of Representatives,4,Republican,"Pompeo, Mike",232,900010
+HARVEY,Sedgwick City,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",120,900020
+HARVEY,Sedgwick City,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",37,900020
+HARVEY,Sedgwick City,United States House of Representatives,4,Republican,"Pompeo, Mike",418,900020
+HARVEY,Walton City,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",34,900030
+HARVEY,Walton City,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,900030
+HARVEY,Walton City,United States House of Representatives,4,Republican,"Pompeo, Mike",66,900030
+HARVEY,Burrton City Exclave,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900040
+HARVEY,Burrton City Exclave,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900040
+HARVEY,Burrton City Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900040
+HARVEY,Newton Township Part D,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",5,900050
+HARVEY,Newton Township Part D,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900050
+HARVEY,Newton Township Part D,United States House of Representatives,4,Republican,"Pompeo, Mike",48,900050
+HARVEY,Newton Township Part E,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900060
+HARVEY,Newton Township Part E,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900060
+HARVEY,Newton Township Part E,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900060
+HARVEY,Newton Township Part F,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900070
+HARVEY,Newton Township Part F,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900070
+HARVEY,Newton Township Part F,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900070
+HARVEY,Newton Township Part G,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900080
+HARVEY,Newton Township Part G,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900080
+HARVEY,Newton Township Part G,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900080

--- a/2012/20121106__ks__general__haskell__precinct.csv
+++ b/2012/20121106__ks__general__haskell__precinct.csv
@@ -1,0 +1,256 @@
+county,precinct,office,district,party,candidate,votes,vtd
+HASKELL,Ivanhoe Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",47,000010
+HASKELL,North Dudley,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",51,000020
+HASKELL,North Lockport,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",5,000030
+HASKELL,North Lockport,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",48,000030
+HASKELL,Satanta 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",77,000040
+HASKELL,South Lockport,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",8,000060
+HASKELL,South Lockport,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",47,000060
+HASKELL,Satanta 2 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",20,120020
+HASKELL,Satanta 2 H124,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",308,120030
+HASKELL,Sublette 1 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",21,120040
+HASKELL,Sublette 1 H124,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",316,120050
+HASKELL,Sublette 3 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",4,120060
+HASKELL,Sublette 3 H124,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",215,120070
+HASKELL,Ivanhoe Township,Kansas Senate,39,Republican,"Powell, Larry R.",47,000010
+HASKELL,North Dudley,Kansas Senate,39,Republican,"Powell, Larry R.",45,000020
+HASKELL,North Lockport,Kansas Senate,39,Republican,"Powell, Larry R.",50,000030
+HASKELL,Satanta 1,Kansas Senate,39,Republican,"Powell, Larry R.",77,000040
+HASKELL,South Lockport,Kansas Senate,39,Republican,"Powell, Larry R.",51,000060
+HASKELL,Satanta 2 H122,Kansas Senate,39,Republican,"Powell, Larry R.",24,120020
+HASKELL,Satanta 2 H124,Kansas Senate,39,Republican,"Powell, Larry R.",298,120030
+HASKELL,Sublette 1 H122,Kansas Senate,39,Republican,"Powell, Larry R.",23,120040
+HASKELL,Sublette 1 H124,Kansas Senate,39,Republican,"Powell, Larry R.",328,120050
+HASKELL,Sublette 3 H122,Kansas Senate,39,Republican,"Powell, Larry R.",3,120060
+HASKELL,Sublette 3 H124,Kansas Senate,39,Republican,"Powell, Larry R.",235,120070
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,Democratic,"Obama, Barack",16,000010
+HASKELL,Ivanhoe Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+HASKELL,Ivanhoe Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,Republican,"Romney, Mitt",44,000010
+HASKELL,North Dudley,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Barnett, Andre",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Bush, Kent W",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Christensen, Will",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Goode, Virgil",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Stein, Jill E",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+HASKELL,North Dudley,President / Vice President,,Democratic,"Obama, Barack",3,000020
+HASKELL,North Dudley,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+HASKELL,North Dudley,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+HASKELL,North Dudley,President / Vice President,,Republican,"Romney, Mitt",54,000020
+HASKELL,North Lockport,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Barnett, Andre",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Bush, Kent W",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Christensen, Will",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Goode, Virgil",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Stein, Jill E",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+HASKELL,North Lockport,President / Vice President,,Democratic,"Obama, Barack",3,000030
+HASKELL,North Lockport,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+HASKELL,North Lockport,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+HASKELL,North Lockport,President / Vice President,,Republican,"Romney, Mitt",50,000030
+HASKELL,Satanta 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Barnett, Andre",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Bush, Kent W",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Christensen, Will",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Goode, Virgil",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Stein, Jill E",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+HASKELL,Satanta 1,President / Vice President,,Democratic,"Obama, Barack",12,000040
+HASKELL,Satanta 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+HASKELL,Satanta 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+HASKELL,Satanta 1,President / Vice President,,Republican,"Romney, Mitt",71,000040
+HASKELL,South Lockport,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Barnett, Andre",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Bush, Kent W",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Christensen, Will",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Goode, Virgil",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Stein, Jill E",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+HASKELL,South Lockport,President / Vice President,,Democratic,"Obama, Barack",9,000060
+HASKELL,South Lockport,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+HASKELL,South Lockport,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+HASKELL,South Lockport,President / Vice President,,Republican,"Romney, Mitt",49,000060
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Barnett, Andre",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Bush, Kent W",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Christensen, Will",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Goode, Virgil",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Stein, Jill E",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,Democratic,"Obama, Barack",2,120020
+HASKELL,Satanta 2 H122,President / Vice President,,Libertarian,"Johnson, Gary",1,120020
+HASKELL,Satanta 2 H122,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,Republican,"Romney, Mitt",24,120020
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Barnett, Andre",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Bush, Kent W",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Christensen, Will",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Goode, Virgil",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Stein, Jill E",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,Democratic,"Obama, Barack",82,120030
+HASKELL,Satanta 2 H124,President / Vice President,,Libertarian,"Johnson, Gary",7,120030
+HASKELL,Satanta 2 H124,President / Vice President,,Reform,"Baldwin, Chuck",1,120030
+HASKELL,Satanta 2 H124,President / Vice President,,Republican,"Romney, Mitt",277,120030
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Barnett, Andre",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Bush, Kent W",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Christensen, Will",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Goode, Virgil",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Stein, Jill E",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,Democratic,"Obama, Barack",3,120040
+HASKELL,Sublette 1 H122,President / Vice President,,Libertarian,"Johnson, Gary",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,Reform,"Baldwin, Chuck",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,Republican,"Romney, Mitt",26,120040
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Barnett, Andre",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Bush, Kent W",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Christensen, Will",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Goode, Virgil",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Stein, Jill E",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,Democratic,"Obama, Barack",46,120050
+HASKELL,Sublette 1 H124,President / Vice President,,Libertarian,"Johnson, Gary",3,120050
+HASKELL,Sublette 1 H124,President / Vice President,,Reform,"Baldwin, Chuck",3,120050
+HASKELL,Sublette 1 H124,President / Vice President,,Republican,"Romney, Mitt",342,120050
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Ayers, Avery L",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Barnett, Andre",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Barr, Roseanne C",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Bush, Kent W",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Christensen, Will",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Duncan, Richard A",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Goode, Virgil",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Knill, Dennis J",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Reed, Jill A.",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Rogers, Rick L",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Stein, Jill E",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Thorne, Kevin M",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Warner, Gerald L.",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,Democratic,"Obama, Barack",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,Libertarian,"Johnson, Gary",1,120060
+HASKELL,Sublette 3 H122,President / Vice President,,Reform,"Baldwin, Chuck",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,Republican,"Romney, Mitt",2,120060
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Ayers, Avery L",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Barnett, Andre",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Barr, Roseanne C",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Bush, Kent W",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Christensen, Will",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Duncan, Richard A",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Goode, Virgil",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Knill, Dennis J",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Reed, Jill A.",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Rogers, Rick L",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Stein, Jill E",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Thorne, Kevin M",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Warner, Gerald L.",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,Democratic,"Obama, Barack",39,120070
+HASKELL,Sublette 3 H124,President / Vice President,,Libertarian,"Johnson, Gary",3,120070
+HASKELL,Sublette 3 H124,President / Vice President,,Reform,"Baldwin, Chuck",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,Republican,"Romney, Mitt",220,120070
+HASKELL,Ivanhoe Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000010
+HASKELL,North Dudley,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000020
+HASKELL,North Lockport,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000030
+HASKELL,Satanta 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",78,000040
+HASKELL,South Lockport,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000060
+HASKELL,Satanta 2 H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,120020
+HASKELL,Satanta 2 H124,United States House of Representatives,1,Republican,"Huelskamp, Tim",302,120030
+HASKELL,Sublette 1 H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,120040
+HASKELL,Sublette 1 H124,United States House of Representatives,1,Republican,"Huelskamp, Tim",345,120050
+HASKELL,Sublette 3 H122,United States House of Representatives,1,Republican,"Huelskamp, Tim",1,120060
+HASKELL,Sublette 3 H124,United States House of Representatives,1,Republican,"Huelskamp, Tim",238,120070

--- a/2012/20121106__ks__general__hodgeman__precinct.csv
+++ b/2012/20121106__ks__general__hodgeman__precinct.csv
@@ -1,0 +1,270 @@
+county,precinct,office,district,party,candidate,votes,vtd
+HODGEMAN,Benton Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",6,000010
+HODGEMAN,Benton Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",20,000010
+HODGEMAN,Marena Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",57,000020
+HODGEMAN,Marena Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",183,000020
+HODGEMAN,North Center,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",45,000030
+HODGEMAN,North Center,Kansas House of Representatives,117,Republican,"Ewy, John L.",251,000030
+HODGEMAN,North Hallet,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",1,000040
+HODGEMAN,North Hallet,Kansas House of Representatives,117,Republican,"Ewy, John L.",8,000040
+HODGEMAN,North Roscoe,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",1,000050
+HODGEMAN,North Roscoe,Kansas House of Representatives,117,Republican,"Ewy, John L.",28,000050
+HODGEMAN,Sawlog Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",9,000060
+HODGEMAN,Sawlog Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",37,000060
+HODGEMAN,South Center,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",35,000070
+HODGEMAN,South Center,Kansas House of Representatives,117,Republican,"Ewy, John L.",237,000070
+HODGEMAN,South Hallet,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",1,000080
+HODGEMAN,South Hallet,Kansas House of Representatives,117,Republican,"Ewy, John L.",17,000080
+HODGEMAN,South Roscoe,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",1,000090
+HODGEMAN,South Roscoe,Kansas House of Representatives,117,Republican,"Ewy, John L.",32,000090
+HODGEMAN,Sterling Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",17,000100
+HODGEMAN,Sterling Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",51,000100
+HODGEMAN,Valley Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",3,000110
+HODGEMAN,Valley Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",19,000110
+HODGEMAN,Benton Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",0,000010
+HODGEMAN,Benton Township,Kansas Senate,38,Republican,"Love, Garrett",25,000010
+HODGEMAN,Marena Township,Kansas Senate,33,Republican,"Holmes, Mitch",221,000020
+HODGEMAN,North Center,Kansas Senate,33,Republican,"Holmes, Mitch",222,000030
+HODGEMAN,North Hallet,Kansas Senate,33,Republican,"Holmes, Mitch",8,000040
+HODGEMAN,North Roscoe,Kansas Senate,33,Republican,"Holmes, Mitch",24,000050
+HODGEMAN,Sawlog Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",8,000060
+HODGEMAN,Sawlog Township,Kansas Senate,38,Republican,"Love, Garrett",35,000060
+HODGEMAN,South Center,Kansas Senate,33,Republican,"Holmes, Mitch",209,000070
+HODGEMAN,South Hallet,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",1,000080
+HODGEMAN,South Hallet,Kansas Senate,38,Republican,"Love, Garrett",17,000080
+HODGEMAN,South Roscoe,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",3,000090
+HODGEMAN,South Roscoe,Kansas Senate,38,Republican,"Love, Garrett",29,000090
+HODGEMAN,Sterling Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",18,000100
+HODGEMAN,Sterling Township,Kansas Senate,38,Republican,"Love, Garrett",49,000100
+HODGEMAN,Valley Township,Kansas Senate,33,Republican,"Holmes, Mitch",18,000110
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+HODGEMAN,Benton Township,President / Vice President,,Democratic,"Obama, Barack",1,000010
+HODGEMAN,Benton Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+HODGEMAN,Benton Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+HODGEMAN,Benton Township,President / Vice President,,Republican,"Romney, Mitt",24,000010
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+HODGEMAN,Marena Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+HODGEMAN,Marena Township,President / Vice President,,Democratic,"Obama, Barack",35,000020
+HODGEMAN,Marena Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+HODGEMAN,Marena Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000020
+HODGEMAN,Marena Township,President / Vice President,,Republican,"Romney, Mitt",203,000020
+HODGEMAN,North Center,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Barnett, Andre",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Bush, Kent W",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Christensen, Will",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Goode, Virgil",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Stein, Jill E",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+HODGEMAN,North Center,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+HODGEMAN,North Center,President / Vice President,,Democratic,"Obama, Barack",68,000030
+HODGEMAN,North Center,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+HODGEMAN,North Center,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+HODGEMAN,North Center,President / Vice President,,Republican,"Romney, Mitt",228,000030
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Barnett, Andre",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Bush, Kent W",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Christensen, Will",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Goode, Virgil",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Stein, Jill E",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+HODGEMAN,North Hallet,President / Vice President,,Democratic,"Obama, Barack",1,000040
+HODGEMAN,North Hallet,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+HODGEMAN,North Hallet,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+HODGEMAN,North Hallet,President / Vice President,,Republican,"Romney, Mitt",8,000040
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Barnett, Andre",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Bush, Kent W",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Christensen, Will",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Goode, Virgil",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Stein, Jill E",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,Democratic,"Obama, Barack",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,Republican,"Romney, Mitt",29,000050
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,Democratic,"Obama, Barack",4,000060
+HODGEMAN,Sawlog Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+HODGEMAN,Sawlog Township,President / Vice President,,Republican,"Romney, Mitt",42,000060
+HODGEMAN,South Center,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Barnett, Andre",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Bush, Kent W",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Christensen, Will",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Goode, Virgil",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Stein, Jill E",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+HODGEMAN,South Center,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+HODGEMAN,South Center,President / Vice President,,Democratic,"Obama, Barack",51,000070
+HODGEMAN,South Center,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+HODGEMAN,South Center,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+HODGEMAN,South Center,President / Vice President,,Republican,"Romney, Mitt",217,000070
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Barnett, Andre",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Bush, Kent W",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Christensen, Will",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Goode, Virgil",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Stein, Jill E",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+HODGEMAN,South Hallet,President / Vice President,,Democratic,"Obama, Barack",0,000080
+HODGEMAN,South Hallet,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+HODGEMAN,South Hallet,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+HODGEMAN,South Hallet,President / Vice President,,Republican,"Romney, Mitt",18,000080
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Barnett, Andre",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Bush, Kent W",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Christensen, Will",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Goode, Virgil",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Stein, Jill E",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,Democratic,"Obama, Barack",5,000090
+HODGEMAN,South Roscoe,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,Republican,"Romney, Mitt",29,000090
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,Democratic,"Obama, Barack",9,000100
+HODGEMAN,Sterling Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+HODGEMAN,Sterling Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+HODGEMAN,Sterling Township,President / Vice President,,Republican,"Romney, Mitt",54,000100
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+HODGEMAN,Valley Township,President / Vice President,,Democratic,"Obama, Barack",5,000110
+HODGEMAN,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+HODGEMAN,Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+HODGEMAN,Valley Township,President / Vice President,,Republican,"Romney, Mitt",16,000110
+HODGEMAN,Benton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000010
+HODGEMAN,Marena Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",220,000020
+HODGEMAN,North Center,United States House of Representatives,1,Republican,"Huelskamp, Tim",249,000030
+HODGEMAN,North Hallet,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,000040
+HODGEMAN,North Roscoe,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000050
+HODGEMAN,Sawlog Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000060
+HODGEMAN,South Center,United States House of Representatives,1,Republican,"Huelskamp, Tim",230,000070
+HODGEMAN,South Hallet,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000080
+HODGEMAN,South Roscoe,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000090
+HODGEMAN,Sterling Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",59,000100
+HODGEMAN,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000110

--- a/2012/20121106__ks__general__jackson__precinct.csv
+++ b/2012/20121106__ks__general__jackson__precinct.csv
@@ -1,0 +1,523 @@
+county,precinct,office,district,party,candidate,votes,vtd
+JACKSON,Adrian Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",58,000010
+JACKSON,Banner Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",119,000020
+JACKSON,Cedar Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",407,000030
+JACKSON,Douglas Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",751,000040
+JACKSON,Franklin Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",372,000050
+JACKSON,Garfield Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",205,000060
+JACKSON,Grant Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",70,000070
+JACKSON,Holton Ward 1,Kansas House of Representatives,61,Republican,"Carlson, Richard",327,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,Kansas House of Representatives,61,Republican,"Carlson, Richard",0,00008B
+JACKSON,Holton Ward 2,Kansas House of Representatives,61,Republican,"Carlson, Richard",390,000090
+JACKSON,Holton Ward 3,Kansas House of Representatives,61,Republican,"Carlson, Richard",292,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,Kansas House of Representatives,61,Republican,"Carlson, Richard",0,00010B
+JACKSON,Jefferson Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",202,000110
+JACKSON,Liberty Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",221,000120
+JACKSON,Lincoln Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",247,000130
+JACKSON,Netawaka Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",57,000140
+JACKSON,Netawaka Township,Kansas House of Representatives,62,Republican,"Garber, Randy",92,000140
+JACKSON,Soldier Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",153,000150
+JACKSON,Straight Creek Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",63,000160
+JACKSON,Washington Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",217,000170
+JACKSON,Whiting Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",62,000180
+JACKSON,Whiting Township,Kansas House of Representatives,62,Republican,"Garber, Randy",93,000180
+JACKSON,Adrian Township,Kansas Senate,1,Democratic,"Lukert, Steve",18,000010
+JACKSON,Adrian Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",48,000010
+JACKSON,Banner Township,Kansas Senate,1,Democratic,"Lukert, Steve",88,000020
+JACKSON,Banner Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",61,000020
+JACKSON,Cedar Township,Kansas Senate,1,Democratic,"Lukert, Steve",232,000030
+JACKSON,Cedar Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",280,000030
+JACKSON,Douglas Township,Kansas Senate,1,Democratic,"Lukert, Steve",436,000040
+JACKSON,Douglas Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",552,000040
+JACKSON,Franklin Township,Kansas Senate,1,Democratic,"Lukert, Steve",294,000050
+JACKSON,Franklin Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",179,000050
+JACKSON,Garfield Township,Kansas Senate,1,Democratic,"Lukert, Steve",105,000060
+JACKSON,Garfield Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",153,000060
+JACKSON,Grant Township,Kansas Senate,1,Democratic,"Lukert, Steve",43,000070
+JACKSON,Grant Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",35,000070
+JACKSON,Holton Ward 1,Kansas Senate,1,Democratic,"Lukert, Steve",234,00008A
+JACKSON,Holton Ward 1,Kansas Senate,1,Republican,"Pyle, Dennis D.",181,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,Kansas Senate,1,Democratic,"Lukert, Steve",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00008B
+JACKSON,Holton Ward 2,Kansas Senate,1,Democratic,"Lukert, Steve",272,000090
+JACKSON,Holton Ward 2,Kansas Senate,1,Republican,"Pyle, Dennis D.",207,000090
+JACKSON,Holton Ward 3,Kansas Senate,1,Democratic,"Lukert, Steve",227,00010A
+JACKSON,Holton Ward 3,Kansas Senate,1,Republican,"Pyle, Dennis D.",157,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,Kansas Senate,1,Democratic,"Lukert, Steve",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00010B
+JACKSON,Jefferson Township,Kansas Senate,1,Democratic,"Lukert, Steve",127,000110
+JACKSON,Jefferson Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",120,000110
+JACKSON,Liberty Township,Kansas Senate,1,Democratic,"Lukert, Steve",184,000120
+JACKSON,Liberty Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",109,000120
+JACKSON,Lincoln Township,Kansas Senate,1,Democratic,"Lukert, Steve",212,000130
+JACKSON,Lincoln Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",145,000130
+JACKSON,Netawaka Township,Kansas Senate,1,Democratic,"Lukert, Steve",76,000140
+JACKSON,Netawaka Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",77,000140
+JACKSON,Soldier Township,Kansas Senate,1,Democratic,"Lukert, Steve",95,000150
+JACKSON,Soldier Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",83,000150
+JACKSON,Straight Creek Township,Kansas Senate,1,Democratic,"Lukert, Steve",51,000160
+JACKSON,Straight Creek Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",38,000160
+JACKSON,Washington Township,Kansas Senate,1,Democratic,"Lukert, Steve",69,000170
+JACKSON,Washington Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",170,000170
+JACKSON,Whiting Township,Kansas Senate,1,Democratic,"Lukert, Steve",95,000180
+JACKSON,Whiting Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",69,000180
+JACKSON,Adrian Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+JACKSON,Adrian Township,President / Vice President,,Democratic,"Obama, Barack",11,000010
+JACKSON,Adrian Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+JACKSON,Adrian Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+JACKSON,Adrian Township,President / Vice President,,Republican,"Romney, Mitt",52,000010
+JACKSON,Banner Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+JACKSON,Banner Township,President / Vice President,,Democratic,"Obama, Barack",38,000020
+JACKSON,Banner Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+JACKSON,Banner Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+JACKSON,Banner Township,President / Vice President,,Republican,"Romney, Mitt",112,000020
+JACKSON,Cedar Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+JACKSON,Cedar Township,President / Vice President,,Democratic,"Obama, Barack",171,000030
+JACKSON,Cedar Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000030
+JACKSON,Cedar Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000030
+JACKSON,Cedar Township,President / Vice President,,Republican,"Romney, Mitt",327,000030
+JACKSON,Douglas Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+JACKSON,Douglas Township,President / Vice President,,Democratic,"Obama, Barack",368,000040
+JACKSON,Douglas Township,President / Vice President,,Libertarian,"Johnson, Gary",17,000040
+JACKSON,Douglas Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000040
+JACKSON,Douglas Township,President / Vice President,,Republican,"Romney, Mitt",612,000040
+JACKSON,Franklin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+JACKSON,Franklin Township,President / Vice President,,Democratic,"Obama, Barack",144,000050
+JACKSON,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000050
+JACKSON,Franklin Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000050
+JACKSON,Franklin Township,President / Vice President,,Republican,"Romney, Mitt",325,000050
+JACKSON,Garfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+JACKSON,Garfield Township,President / Vice President,,Democratic,"Obama, Barack",65,000060
+JACKSON,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000060
+JACKSON,Garfield Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+JACKSON,Garfield Township,President / Vice President,,Republican,"Romney, Mitt",184,000060
+JACKSON,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+JACKSON,Grant Township,President / Vice President,,Democratic,"Obama, Barack",35,000070
+JACKSON,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000070
+JACKSON,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+JACKSON,Grant Township,President / Vice President,,Republican,"Romney, Mitt",41,000070
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Christensen, Will",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,Democratic,"Obama, Barack",158,00008A
+JACKSON,Holton Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",5,00008A
+JACKSON,Holton Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",3,00008A
+JACKSON,Holton Ward 1,President / Vice President,,Republican,"Romney, Mitt",256,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Ayers, Avery L",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Barnett, Andre",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Barr, Roseanne C",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Bush, Kent W",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Christensen, Will",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Duncan, Richard A",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Goode, Virgil",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Hoefling, Tom",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Knill, Dennis J",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Reed, Jill A.",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Rogers, Rick L",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Stein, Jill E",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Thorne, Kevin M",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,write - in,"Warner, Gerald L.",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,Democratic,"Obama, Barack",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,Libertarian,"Johnson, Gary",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,Reform,"Baldwin, Chuck",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,President / Vice President,,Republican,"Romney, Mitt",0,00008B
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,Democratic,"Obama, Barack",183,000090
+JACKSON,Holton Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",8,000090
+JACKSON,Holton Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,Republican,"Romney, Mitt",287,000090
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,Democratic,"Obama, Barack",157,00010A
+JACKSON,Holton Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",4,00010A
+JACKSON,Holton Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,Republican,"Romney, Mitt",224,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Ayers, Avery L",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Barnett, Andre",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Barr, Roseanne C",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Bush, Kent W",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Christensen, Will",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Duncan, Richard A",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Goode, Virgil",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Hoefling, Tom",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Knill, Dennis J",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Reed, Jill A.",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Rogers, Rick L",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Stein, Jill E",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Thorne, Kevin M",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Warner, Gerald L.",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,Democratic,"Obama, Barack",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,Libertarian,"Johnson, Gary",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,Reform,"Baldwin, Chuck",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,Republican,"Romney, Mitt",0,00010B
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+JACKSON,Jefferson Township,President / Vice President,,Democratic,"Obama, Barack",62,000110
+JACKSON,Jefferson Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+JACKSON,Jefferson Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+JACKSON,Jefferson Township,President / Vice President,,Republican,"Romney, Mitt",186,000110
+JACKSON,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+JACKSON,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",90,000120
+JACKSON,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000120
+JACKSON,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+JACKSON,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",198,000120
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+JACKSON,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",201,000130
+JACKSON,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000130
+JACKSON,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000130
+JACKSON,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",148,000130
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+JACKSON,Netawaka Township,President / Vice President,,Democratic,"Obama, Barack",41,000140
+JACKSON,Netawaka Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000140
+JACKSON,Netawaka Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+JACKSON,Netawaka Township,President / Vice President,,Republican,"Romney, Mitt",107,000140
+JACKSON,Soldier Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+JACKSON,Soldier Township,President / Vice President,,Democratic,"Obama, Barack",50,000150
+JACKSON,Soldier Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000150
+JACKSON,Soldier Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+JACKSON,Soldier Township,President / Vice President,,Republican,"Romney, Mitt",122,000150
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,Democratic,"Obama, Barack",23,000160
+JACKSON,Straight Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+JACKSON,Straight Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,Republican,"Romney, Mitt",65,000160
+JACKSON,Washington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+JACKSON,Washington Township,President / Vice President,,Democratic,"Obama, Barack",61,000170
+JACKSON,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000170
+JACKSON,Washington Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000170
+JACKSON,Washington Township,President / Vice President,,Republican,"Romney, Mitt",165,000170
+JACKSON,Whiting Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+JACKSON,Whiting Township,President / Vice President,,Democratic,"Obama, Barack",43,000180
+JACKSON,Whiting Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000180
+JACKSON,Whiting Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000180
+JACKSON,Whiting Township,President / Vice President,,Republican,"Romney, Mitt",116,000180
+JACKSON,Adrian Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",15,000010
+JACKSON,Adrian Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000010
+JACKSON,Adrian Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",41,000010
+JACKSON,Banner Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",47,000020
+JACKSON,Banner Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000020
+JACKSON,Banner Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",97,000020
+JACKSON,Cedar Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",190,000030
+JACKSON,Cedar Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",29,000030
+JACKSON,Cedar Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",294,000030
+JACKSON,Douglas Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",395,000040
+JACKSON,Douglas Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",64,000040
+JACKSON,Douglas Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",547,000040
+JACKSON,Franklin Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",158,000050
+JACKSON,Franklin Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,000050
+JACKSON,Franklin Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",303,000050
+JACKSON,Garfield Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",71,000060
+JACKSON,Garfield Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,000060
+JACKSON,Garfield Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",179,000060
+JACKSON,Grant Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",31,000070
+JACKSON,Grant Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000070
+JACKSON,Grant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",48,000070
+JACKSON,Holton Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",145,00008A
+JACKSON,Holton Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",25,00008A
+JACKSON,Holton Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",246,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00008B
+JACKSON,Holton Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",159,000090
+JACKSON,Holton Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",24,000090
+JACKSON,Holton Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",291,000090
+JACKSON,Holton Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",163,00010A
+JACKSON,Holton Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,00010A
+JACKSON,Holton Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",198,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00010B
+JACKSON,Jefferson Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",70,000110
+JACKSON,Jefferson Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000110
+JACKSON,Jefferson Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",165,000110
+JACKSON,Liberty Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",101,000120
+JACKSON,Liberty Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,000120
+JACKSON,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",179,000120
+JACKSON,Lincoln Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",172,000130
+JACKSON,Lincoln Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",24,000130
+JACKSON,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",159,000130
+JACKSON,Netawaka Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",57,000140
+JACKSON,Netawaka Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,000140
+JACKSON,Netawaka Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",84,000140
+JACKSON,Soldier Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",54,000150
+JACKSON,Soldier Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000150
+JACKSON,Soldier Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",115,000150
+JACKSON,Straight Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",24,000160
+JACKSON,Straight Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000160
+JACKSON,Straight Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",61,000160
+JACKSON,Washington Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",53,000170
+JACKSON,Washington Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",19,000170
+JACKSON,Washington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",169,000170
+JACKSON,Whiting Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",46,000180
+JACKSON,Whiting Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000180
+JACKSON,Whiting Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",104,000180

--- a/2012/20121106__ks__general__jefferson__precinct.csv
+++ b/2012/20121106__ks__general__jefferson__precinct.csv
@@ -1,0 +1,352 @@
+county,precinct,office,district,party,candidate,votes,vtd
+JEFFERSON,Delaware Township,Kansas House of Representatives,47,Democratic,"Hanson, Bruce",365,000010
+JEFFERSON,Delaware Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",426,000010
+JEFFERSON,East Fairview,Kansas House of Representatives,47,Democratic,"Hanson, Bruce",160,000020
+JEFFERSON,East Fairview,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",222,000020
+JEFFERSON,Jefferson Township,Kansas House of Representatives,47,Democratic,"Hanson, Bruce",176,000030
+JEFFERSON,Jefferson Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",257,000030
+JEFFERSON,Kaw Township,Kansas House of Representatives,47,Democratic,"Hanson, Bruce",233,000040
+JEFFERSON,Kaw Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",421,000040
+JEFFERSON,Kentucky Township,Kansas House of Representatives,47,Democratic,"Hanson, Bruce",149,000050
+JEFFERSON,Kentucky Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",547,000050
+JEFFERSON,Norton Township,Kansas House of Representatives,47,Democratic,"Hanson, Bruce",141,000060
+JEFFERSON,Norton Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",205,000060
+JEFFERSON,Oskaloosa Township,Kansas House of Representatives,47,Democratic,"Hanson, Bruce",349,000070
+JEFFERSON,Oskaloosa Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",539,000070
+JEFFERSON,Ozawkie Township,Kansas House of Representatives,47,Democratic,"Hanson, Bruce",274,000080
+JEFFERSON,Ozawkie Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",410,000080
+JEFFERSON,Rock Creek Township,Kansas House of Representatives,47,Democratic,"Hanson, Bruce",484,000090
+JEFFERSON,Rock Creek Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",648,000090
+JEFFERSON,Rural Township,Kansas House of Representatives,47,Democratic,"Hanson, Bruce",126,000100
+JEFFERSON,Rural Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",217,000100
+JEFFERSON,Sarcoxie Township,Kansas House of Representatives,47,Democratic,"Hanson, Bruce",282,000110
+JEFFERSON,Sarcoxie Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",232,000110
+JEFFERSON,Union Township,Kansas House of Representatives,47,Democratic,"Hanson, Bruce",277,000120
+JEFFERSON,Union Township,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",397,000120
+JEFFERSON,West Fairview,Kansas House of Representatives,47,Democratic,"Hanson, Bruce",120,000130
+JEFFERSON,West Fairview,Kansas House of Representatives,47,Republican,"Gonzalez, Ramon C. Jr.",221,000130
+JEFFERSON,Delaware Township,Kansas Senate,2,Democratic,"Francisco, Marci",232,000010
+JEFFERSON,Delaware Township,Kansas Senate,2,Republican,"Ellis, Ronald B.",565,000010
+JEFFERSON,East Fairview,Kansas Senate,2,Democratic,"Francisco, Marci",136,000020
+JEFFERSON,East Fairview,Kansas Senate,2,Republican,"Ellis, Ronald B.",244,000020
+JEFFERSON,Jefferson Township,Kansas Senate,2,Democratic,"Francisco, Marci",123,000030
+JEFFERSON,Jefferson Township,Kansas Senate,2,Republican,"Ellis, Ronald B.",316,000030
+JEFFERSON,Kaw Township,Kansas Senate,19,Democratic,"Hensley, Anthony",312,000040
+JEFFERSON,Kaw Township,Kansas Senate,19,Republican,"Moore, Casey W.",350,000040
+JEFFERSON,Kentucky Township,Kansas Senate,2,Democratic,"Francisco, Marci",235,000050
+JEFFERSON,Kentucky Township,Kansas Senate,2,Republican,"Ellis, Ronald B.",448,000050
+JEFFERSON,Norton Township,Kansas Senate,2,Democratic,"Francisco, Marci",90,000060
+JEFFERSON,Norton Township,Kansas Senate,2,Republican,"Ellis, Ronald B.",263,000060
+JEFFERSON,Oskaloosa Township,Kansas Senate,2,Democratic,"Francisco, Marci",205,000070
+JEFFERSON,Oskaloosa Township,Kansas Senate,2,Republican,"Ellis, Ronald B.",688,000070
+JEFFERSON,Ozawkie Township,Kansas Senate,2,Democratic,"Francisco, Marci",195,000080
+JEFFERSON,Ozawkie Township,Kansas Senate,2,Republican,"Ellis, Ronald B.",495,000080
+JEFFERSON,Rock Creek Township,Kansas Senate,2,Democratic,"Francisco, Marci",299,000090
+JEFFERSON,Rock Creek Township,Kansas Senate,2,Republican,"Ellis, Ronald B.",847,000090
+JEFFERSON,Rural Township,Kansas Senate,2,Democratic,"Francisco, Marci",141,000100
+JEFFERSON,Rural Township,Kansas Senate,2,Republican,"Ellis, Ronald B.",202,000100
+JEFFERSON,Sarcoxie Township,Kansas Senate,2,Democratic,"Francisco, Marci",284,000110
+JEFFERSON,Sarcoxie Township,Kansas Senate,2,Republican,"Ellis, Ronald B.",234,000110
+JEFFERSON,Union Township,Kansas Senate,2,Democratic,"Francisco, Marci",211,000120
+JEFFERSON,Union Township,Kansas Senate,2,Republican,"Ellis, Ronald B.",466,000120
+JEFFERSON,West Fairview,Kansas Senate,2,Democratic,"Francisco, Marci",91,000130
+JEFFERSON,West Fairview,Kansas Senate,2,Republican,"Ellis, Ronald B.",250,000130
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,Democratic,"Obama, Barack",280,000010
+JEFFERSON,Delaware Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000010
+JEFFERSON,Delaware Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000010
+JEFFERSON,Delaware Township,President / Vice President,,Republican,"Romney, Mitt",511,000010
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Barnett, Andre",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Bush, Kent W",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Christensen, Will",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Goode, Virgil",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Stein, Jill E",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+JEFFERSON,East Fairview,President / Vice President,,Democratic,"Obama, Barack",166,000020
+JEFFERSON,East Fairview,President / Vice President,,Libertarian,"Johnson, Gary",10,000020
+JEFFERSON,East Fairview,President / Vice President,,Reform,"Baldwin, Chuck",5,000020
+JEFFERSON,East Fairview,President / Vice President,,Republican,"Romney, Mitt",204,000020
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,Democratic,"Obama, Barack",149,000030
+JEFFERSON,Jefferson Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000030
+JEFFERSON,Jefferson Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000030
+JEFFERSON,Jefferson Township,President / Vice President,,Republican,"Romney, Mitt",288,000030
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Stein, Jill E",1,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,Democratic,"Obama, Barack",258,000040
+JEFFERSON,Kaw Township,President / Vice President,,Libertarian,"Johnson, Gary",17,000040
+JEFFERSON,Kaw Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000040
+JEFFERSON,Kaw Township,President / Vice President,,Republican,"Romney, Mitt",390,000040
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Stein, Jill E",1,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,Democratic,"Obama, Barack",304,000050
+JEFFERSON,Kentucky Township,President / Vice President,,Libertarian,"Johnson, Gary",18,000050
+JEFFERSON,Kentucky Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000050
+JEFFERSON,Kentucky Township,President / Vice President,,Republican,"Romney, Mitt",369,000050
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+JEFFERSON,Norton Township,President / Vice President,,Democratic,"Obama, Barack",110,000060
+JEFFERSON,Norton Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000060
+JEFFERSON,Norton Township,President / Vice President,,Reform,"Baldwin, Chuck",7,000060
+JEFFERSON,Norton Township,President / Vice President,,Republican,"Romney, Mitt",238,000060
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Christensen, Will",1,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,Democratic,"Obama, Barack",302,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,Libertarian,"Johnson, Gary",22,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,Republican,"Romney, Mitt",561,000070
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,Democratic,"Obama, Barack",242,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,Republican,"Romney, Mitt",438,000080
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,Democratic,"Obama, Barack",414,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",27,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",6,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,Republican,"Romney, Mitt",717,000090
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+JEFFERSON,Rural Township,President / Vice President,,Democratic,"Obama, Barack",144,000100
+JEFFERSON,Rural Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000100
+JEFFERSON,Rural Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+JEFFERSON,Rural Township,President / Vice President,,Republican,"Romney, Mitt",196,000100
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Goode, Virgil",1,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,Democratic,"Obama, Barack",260,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,Republican,"Romney, Mitt",247,000110
+JEFFERSON,Union Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+JEFFERSON,Union Township,President / Vice President,,Democratic,"Obama, Barack",241,000120
+JEFFERSON,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",14,000120
+JEFFERSON,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000120
+JEFFERSON,Union Township,President / Vice President,,Republican,"Romney, Mitt",437,000120
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Barnett, Andre",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Bush, Kent W",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Christensen, Will",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Goode, Virgil",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Stein, Jill E",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+JEFFERSON,West Fairview,President / Vice President,,Democratic,"Obama, Barack",107,000130
+JEFFERSON,West Fairview,President / Vice President,,Libertarian,"Johnson, Gary",9,000130
+JEFFERSON,West Fairview,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+JEFFERSON,West Fairview,President / Vice President,,Republican,"Romney, Mitt",231,000130
+JEFFERSON,Delaware Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",284,000010
+JEFFERSON,Delaware Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",59,000010
+JEFFERSON,Delaware Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",457,000010
+JEFFERSON,East Fairview,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",140,000020
+JEFFERSON,East Fairview,United States House of Representatives,2,Libertarian,"Hawver, Dennis",43,000020
+JEFFERSON,East Fairview,United States House of Representatives,2,Republican,"Jenkins, Lynn",203,000020
+JEFFERSON,Jefferson Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",130,000030
+JEFFERSON,Jefferson Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",24,000030
+JEFFERSON,Jefferson Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",296,000030
+JEFFERSON,Kaw Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",270,000040
+JEFFERSON,Kaw Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",44,000040
+JEFFERSON,Kaw Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",352,000040
+JEFFERSON,Kentucky Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",277,000050
+JEFFERSON,Kentucky Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",57,000050
+JEFFERSON,Kentucky Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",359,000050
+JEFFERSON,Norton Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",115,000060
+JEFFERSON,Norton Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",17,000060
+JEFFERSON,Norton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",226,000060
+JEFFERSON,Oskaloosa Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",297,000070
+JEFFERSON,Oskaloosa Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",61,000070
+JEFFERSON,Oskaloosa Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",525,000070
+JEFFERSON,Ozawkie Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",225,000080
+JEFFERSON,Ozawkie Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",69,000080
+JEFFERSON,Ozawkie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",398,000080
+JEFFERSON,Rock Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",403,000090
+JEFFERSON,Rock Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",106,000090
+JEFFERSON,Rock Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",652,000090
+JEFFERSON,Rural Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",147,000100
+JEFFERSON,Rural Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",21,000100
+JEFFERSON,Rural Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",181,000100
+JEFFERSON,Sarcoxie Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",227,000110
+JEFFERSON,Sarcoxie Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",38,000110
+JEFFERSON,Sarcoxie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",253,000110
+JEFFERSON,Union Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",199,000120
+JEFFERSON,Union Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",46,000120
+JEFFERSON,Union Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",440,000120
+JEFFERSON,West Fairview,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",109,000130
+JEFFERSON,West Fairview,United States House of Representatives,2,Libertarian,"Hawver, Dennis",26,000130
+JEFFERSON,West Fairview,United States House of Representatives,2,Republican,"Jenkins, Lynn",209,000130

--- a/2012/20121106__ks__general__jewell__precinct.csv
+++ b/2012/20121106__ks__general__jewell__precinct.csv
@@ -1,0 +1,611 @@
+county,precinct,office,district,party,candidate,votes,vtd
+JEWELL,Allen Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",3,000010
+JEWELL,Allen Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",7,000010
+JEWELL,Athens Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",19,000020
+JEWELL,Browns Creek Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",29,000030
+JEWELL,Buffalo Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",51,000040
+JEWELL,Buffalo Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",161,000040
+JEWELL,Burr Oak Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",81,000050
+JEWELL,Calvin Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",35,000060
+JEWELL,Center Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",376,000070
+JEWELL,Erving Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",11,000080
+JEWELL,Esbon Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",63,000090
+JEWELL,Grant Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",40,000100
+JEWELL,Grant Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",40,000100
+JEWELL,Harrison Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",14,000110
+JEWELL,Highland Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",13,000120
+JEWELL,Holmwood Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",13,000130
+JEWELL,Ionia Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",39,000140
+JEWELL,Jackson Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",23,000150
+JEWELL,Jackson Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",34,000150
+JEWELL,Limestone Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",22,000160
+JEWELL,Montana Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",15,000170
+JEWELL,Montana Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",19,000170
+JEWELL,Odessa Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",7,000180
+JEWELL,Prairie Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",15,000190
+JEWELL,Prairie Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",50,000190
+JEWELL,Richland Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",7,000200
+JEWELL,Richland Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",11,000200
+JEWELL,Sinclair Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",9,000210
+JEWELL,Sinclair Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",7,000210
+JEWELL,Vicksburg Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",2,000220
+JEWELL,Vicksburg Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",11,000220
+JEWELL,Walnut Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",35,000230
+JEWELL,Washington Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",10,000240
+JEWELL,Washington Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",10,000240
+JEWELL,White Mound Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",17,000250
+JEWELL,Allen Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000010
+JEWELL,Allen Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",9,000010
+JEWELL,Athens Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000020
+JEWELL,Athens Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",21,000020
+JEWELL,Browns Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000030
+JEWELL,Browns Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",28,000030
+JEWELL,Buffalo Township,Kansas Senate,36,Democratic,"Clark, Marquis",27,000040
+JEWELL,Buffalo Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",183,000040
+JEWELL,Burr Oak Township,Kansas Senate,36,Democratic,"Clark, Marquis",16,000050
+JEWELL,Burr Oak Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",80,000050
+JEWELL,Calvin Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000060
+JEWELL,Calvin Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",36,000060
+JEWELL,Center Township,Kansas Senate,36,Democratic,"Clark, Marquis",77,000070
+JEWELL,Center Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",369,000070
+JEWELL,Erving Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000080
+JEWELL,Erving Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",10,000080
+JEWELL,Esbon Township,Kansas Senate,36,Democratic,"Clark, Marquis",13,000090
+JEWELL,Esbon Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",62,000090
+JEWELL,Grant Township,Kansas Senate,36,Democratic,"Clark, Marquis",9,000100
+JEWELL,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",70,000100
+JEWELL,Harrison Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000110
+JEWELL,Harrison Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",12,000110
+JEWELL,Highland Township,Kansas Senate,36,Democratic,"Clark, Marquis",7,000120
+JEWELL,Highland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",10,000120
+JEWELL,Holmwood Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000130
+JEWELL,Holmwood Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",10,000130
+JEWELL,Ionia Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000140
+JEWELL,Ionia Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",39,000140
+JEWELL,Jackson Township,Kansas Senate,36,Democratic,"Clark, Marquis",7,000150
+JEWELL,Jackson Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",46,000150
+JEWELL,Limestone Township,Kansas Senate,36,Democratic,"Clark, Marquis",7,000160
+JEWELL,Limestone Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",20,000160
+JEWELL,Montana Township,Kansas Senate,36,Democratic,"Clark, Marquis",5,000170
+JEWELL,Montana Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",29,000170
+JEWELL,Odessa Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000180
+JEWELL,Odessa Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",7,000180
+JEWELL,Prairie Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000190
+JEWELL,Prairie Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",69,000190
+JEWELL,Richland Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000200
+JEWELL,Richland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000200
+JEWELL,Sinclair Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000210
+JEWELL,Sinclair Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",12,000210
+JEWELL,Vicksburg Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000220
+JEWELL,Vicksburg Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000220
+JEWELL,Walnut Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000230
+JEWELL,Walnut Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",35,000230
+JEWELL,Washington Township,Kansas Senate,36,Democratic,"Clark, Marquis",5,000240
+JEWELL,Washington Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000240
+JEWELL,White Mound Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000250
+JEWELL,White Mound Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",19,000250
+JEWELL,Allen Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+JEWELL,Allen Township,President / Vice President,,Democratic,"Obama, Barack",1,000010
+JEWELL,Allen Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+JEWELL,Allen Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+JEWELL,Allen Township,President / Vice President,,Republican,"Romney, Mitt",10,000010
+JEWELL,Athens Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+JEWELL,Athens Township,President / Vice President,,Democratic,"Obama, Barack",2,000020
+JEWELL,Athens Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+JEWELL,Athens Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+JEWELL,Athens Township,President / Vice President,,Republican,"Romney, Mitt",22,000020
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,Democratic,"Obama, Barack",4,000030
+JEWELL,Browns Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,Republican,"Romney, Mitt",29,000030
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+JEWELL,Buffalo Township,President / Vice President,,Democratic,"Obama, Barack",28,000040
+JEWELL,Buffalo Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000040
+JEWELL,Buffalo Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+JEWELL,Buffalo Township,President / Vice President,,Republican,"Romney, Mitt",183,000040
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,Democratic,"Obama, Barack",19,000050
+JEWELL,Burr Oak Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000050
+JEWELL,Burr Oak Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000050
+JEWELL,Burr Oak Township,President / Vice President,,Republican,"Romney, Mitt",78,000050
+JEWELL,Calvin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+JEWELL,Calvin Township,President / Vice President,,Democratic,"Obama, Barack",3,000060
+JEWELL,Calvin Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+JEWELL,Calvin Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+JEWELL,Calvin Township,President / Vice President,,Republican,"Romney, Mitt",33,000060
+JEWELL,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+JEWELL,Center Township,President / Vice President,,Democratic,"Obama, Barack",95,000070
+JEWELL,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000070
+JEWELL,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000070
+JEWELL,Center Township,President / Vice President,,Republican,"Romney, Mitt",368,000070
+JEWELL,Erving Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+JEWELL,Erving Township,President / Vice President,,Democratic,"Obama, Barack",2,000080
+JEWELL,Erving Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+JEWELL,Erving Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+JEWELL,Erving Township,President / Vice President,,Republican,"Romney, Mitt",9,000080
+JEWELL,Esbon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+JEWELL,Esbon Township,President / Vice President,,Democratic,"Obama, Barack",13,000090
+JEWELL,Esbon Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000090
+JEWELL,Esbon Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000090
+JEWELL,Esbon Township,President / Vice President,,Republican,"Romney, Mitt",59,000090
+JEWELL,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+JEWELL,Grant Township,President / Vice President,,Democratic,"Obama, Barack",8,000100
+JEWELL,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+JEWELL,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+JEWELL,Grant Township,President / Vice President,,Republican,"Romney, Mitt",75,000100
+JEWELL,Harrison Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+JEWELL,Harrison Township,President / Vice President,,Democratic,"Obama, Barack",1,000110
+JEWELL,Harrison Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+JEWELL,Harrison Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+JEWELL,Harrison Township,President / Vice President,,Republican,"Romney, Mitt",14,000110
+JEWELL,Highland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+JEWELL,Highland Township,President / Vice President,,Democratic,"Obama, Barack",7,000120
+JEWELL,Highland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+JEWELL,Highland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+JEWELL,Highland Township,President / Vice President,,Republican,"Romney, Mitt",13,000120
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+JEWELL,Holmwood Township,President / Vice President,,Democratic,"Obama, Barack",2,000130
+JEWELL,Holmwood Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+JEWELL,Holmwood Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+JEWELL,Holmwood Township,President / Vice President,,Republican,"Romney, Mitt",10,000130
+JEWELL,Ionia Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+JEWELL,Ionia Township,President / Vice President,,Democratic,"Obama, Barack",2,000140
+JEWELL,Ionia Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+JEWELL,Ionia Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+JEWELL,Ionia Township,President / Vice President,,Republican,"Romney, Mitt",38,000140
+JEWELL,Jackson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+JEWELL,Jackson Township,President / Vice President,,Democratic,"Obama, Barack",9,000150
+JEWELL,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+JEWELL,Jackson Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000150
+JEWELL,Jackson Township,President / Vice President,,Republican,"Romney, Mitt",50,000150
+JEWELL,Limestone Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+JEWELL,Limestone Township,President / Vice President,,Democratic,"Obama, Barack",6,000160
+JEWELL,Limestone Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+JEWELL,Limestone Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000160
+JEWELL,Limestone Township,President / Vice President,,Republican,"Romney, Mitt",25,000160
+JEWELL,Montana Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+JEWELL,Montana Township,President / Vice President,,Democratic,"Obama, Barack",8,000170
+JEWELL,Montana Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+JEWELL,Montana Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+JEWELL,Montana Township,President / Vice President,,Republican,"Romney, Mitt",29,000170
+JEWELL,Odessa Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+JEWELL,Odessa Township,President / Vice President,,Democratic,"Obama, Barack",0,000180
+JEWELL,Odessa Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+JEWELL,Odessa Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+JEWELL,Odessa Township,President / Vice President,,Republican,"Romney, Mitt",7,000180
+JEWELL,Prairie Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+JEWELL,Prairie Township,President / Vice President,,Democratic,"Obama, Barack",3,000190
+JEWELL,Prairie Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+JEWELL,Prairie Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+JEWELL,Prairie Township,President / Vice President,,Republican,"Romney, Mitt",66,000190
+JEWELL,Richland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+JEWELL,Richland Township,President / Vice President,,Democratic,"Obama, Barack",4,000200
+JEWELL,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+JEWELL,Richland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+JEWELL,Richland Township,President / Vice President,,Republican,"Romney, Mitt",17,000200
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+JEWELL,Sinclair Township,President / Vice President,,Democratic,"Obama, Barack",0,000210
+JEWELL,Sinclair Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000210
+JEWELL,Sinclair Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+JEWELL,Sinclair Township,President / Vice President,,Republican,"Romney, Mitt",15,000210
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,Democratic,"Obama, Barack",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,Republican,"Romney, Mitt",14,000220
+JEWELL,Walnut Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+JEWELL,Walnut Township,President / Vice President,,Democratic,"Obama, Barack",4,000230
+JEWELL,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+JEWELL,Walnut Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+JEWELL,Walnut Township,President / Vice President,,Republican,"Romney, Mitt",36,000230
+JEWELL,Washington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+JEWELL,Washington Township,President / Vice President,,Democratic,"Obama, Barack",5,000240
+JEWELL,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+JEWELL,Washington Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000240
+JEWELL,Washington Township,President / Vice President,,Republican,"Romney, Mitt",16,000240
+JEWELL,White Mound Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+JEWELL,White Mound Township,President / Vice President,,Democratic,"Obama, Barack",3,000250
+JEWELL,White Mound Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000250
+JEWELL,White Mound Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+JEWELL,White Mound Township,President / Vice President,,Republican,"Romney, Mitt",19,000250
+JEWELL,Allen Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",10,000010
+JEWELL,Athens Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000020
+JEWELL,Browns Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000030
+JEWELL,Buffalo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",195,000040
+JEWELL,Burr Oak Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",83,000050
+JEWELL,Calvin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000060
+JEWELL,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",385,000070
+JEWELL,Erving Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000080
+JEWELL,Esbon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,000090
+JEWELL,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",76,000100
+JEWELL,Harrison Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000110
+JEWELL,Highland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000120
+JEWELL,Holmwood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000130
+JEWELL,Ionia Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000140
+JEWELL,Jackson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000150
+JEWELL,Limestone Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000160
+JEWELL,Montana Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000170
+JEWELL,Odessa Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",6,000180
+JEWELL,Prairie Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",63,000190
+JEWELL,Richland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000200
+JEWELL,Sinclair Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000210
+JEWELL,Vicksburg Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000220
+JEWELL,Walnut Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000230
+JEWELL,Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000240
+JEWELL,White Mound Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000250

--- a/2012/20121106__ks__general__johnson__precinct.csv
+++ b/2012/20121106__ks__general__johnson__precinct.csv
@@ -1,0 +1,6744 @@
+county,precinct,office,district,candidate,candidate_first,candidate_middle,candidate_last,candidate_suffix,party,votes
+Johnson,Aubry Twp 0-01,,,Registered Voters,,,,,,160
+Johnson,Aubry Twp 0-02,,,Registered Voters,,,,,,998
+Johnson,Aubry Twp 0-03,,,Registered Voters,,,,,,623
+Johnson,Aubry Twp 0-04,,,Registered Voters,,,,,,1362
+Johnson,Aubry Twp 0-05,,,Registered Voters,,,,,,26
+Johnson,Aubry Twp 0-06,,,Registered Voters,,,,,,141
+Johnson,Bonner Springs 4-01,,,Registered Voters,,,,,,0
+Johnson,De Soto 0-01,,,Registered Voters,,,,,,1362
+Johnson,De Soto 0-02,,,Registered Voters,,,,,,784
+Johnson,De Soto 0-03,,,Registered Voters,,,,,,1088
+Johnson,De Soto 0-04,,,Registered Voters,,,,,,0
+Johnson,De Soto 0-05,,,Registered Voters,,,,,,0
+Johnson,De Soto 0-06,,,Registered Voters,,,,,,155
+Johnson,De Soto 0-07,,,Registered Voters,,,,,,2
+Johnson,De Soto 0-08,,,Registered Voters,,,,,,0
+Johnson,Edgerton 0-01,,,Registered Voters,,,,,,1034
+Johnson,Edgerton 0-02,,,Registered Voters,,,,,,2
+Johnson,Edgerton 0-03,,,Registered Voters,,,,,,0
+Johnson,Edgerton 0-04,,,Registered Voters,,,,,,0
+Johnson,Edgerton 0-05,,,Registered Voters,,,,,,7
+Johnson,Edgerton 0-06,,,Registered Voters,,,,,,0
+Johnson,Edgerton 0-07,,,Registered Voters,,,,,,0
+Johnson,Edgerton 0-08,,,Registered Voters,,,,,,0
+Johnson,Fairway 1-00,,,Registered Voters,,,,,,830
+Johnson,Fairway 2-00,,,Registered Voters,,,,,,696
+Johnson,Fairway 3-00,,,Registered Voters,,,,,,868
+Johnson,Fairway 4-00,,,Registered Voters,,,,,,869
+Johnson,Gardner 0-01,,,Registered Voters,,,,,,1727
+Johnson,Gardner 0-02,,,Registered Voters,,,,,,407
+Johnson,Gardner 0-03,,,Registered Voters,,,,,,1603
+Johnson,Gardner 0-04,,,Registered Voters,,,,,,1046
+Johnson,Gardner 0-05,,,Registered Voters,,,,,,0
+Johnson,Gardner 0-06,,,Registered Voters,,,,,,1340
+Johnson,Gardner 0-07,,,Registered Voters,,,,,,31
+Johnson,Gardner 0-08,,,Registered Voters,,,,,,85
+Johnson,Gardner 0-09,,,Registered Voters,,,,,,1708
+Johnson,Gardner 0-10,,,Registered Voters,,,,,,1024
+Johnson,Gardner 0-11,,,Registered Voters,,,,,,0
+Johnson,Gardner 0-12,,,Registered Voters,,,,,,26
+Johnson,Gardner 0-13,,,Registered Voters,,,,,,1223
+Johnson,Gardner 0-14,,,Registered Voters,,,,,,975
+Johnson,Gardner 0-15,,,Registered Voters,,,,,,0
+Johnson,Gardner Twp 0-01,,,Registered Voters,,,,,,542
+Johnson,Gardner Twp 0-02,,,Registered Voters,,,,,,681
+Johnson,Gardner Twp 0-03,,,Registered Voters,,,,,,0
+Johnson,Gardner Twp 0-04,,,Registered Voters,,,,,,1
+Johnson,Gardner Twp 0-05,,,Registered Voters,,,,,,8
+Johnson,Gardner Twp 0-06,,,Registered Voters,,,,,,0
+Johnson,Gardner Twp 0-07,,,Registered Voters,,,,,,4
+Johnson,Gardner Twp 0-08,,,Registered Voters,,,,,,8
+Johnson,Gardner Twp 0-09,,,Registered Voters,,,,,,5
+Johnson,Gardner Twp 0-10,,,Registered Voters,,,,,,3
+Johnson,Gardner Twp 0-11,,,Registered Voters,,,,,,161
+Johnson,Gardner Twp 0-12,,,Registered Voters,,,,,,0
+Johnson,Lake Quivira 0-01,,,Registered Voters,,,,,,796
+Johnson,Leawood 1-01,,,Registered Voters,,,,,,784
+Johnson,Leawood 1-02,,,Registered Voters,,,,,,1231
+Johnson,Leawood 1-03,,,Registered Voters,,,,,,1067
+Johnson,Leawood 1-04,,,Registered Voters,,,,,,876
+Johnson,Leawood 1-05,,,Registered Voters,,,,,,843
+Johnson,Leawood 1-06,,,Registered Voters,,,,,,228
+Johnson,Leawood 2-01,,,Registered Voters,,,,,,1001
+Johnson,Leawood 2-02,,,Registered Voters,,,,,,1247
+Johnson,Leawood 2-03,,,Registered Voters,,,,,,1258
+Johnson,Leawood 2-04,,,Registered Voters,,,,,,1352
+Johnson,Leawood 2-05,,,Registered Voters,,,,,,716
+Johnson,Leawood 2-06,,,Registered Voters,,,,,,513
+Johnson,Leawood 3-01,,,Registered Voters,,,,,,663
+Johnson,Leawood 3-02,,,Registered Voters,,,,,,1248
+Johnson,Leawood 3-03,,,Registered Voters,,,,,,740
+Johnson,Leawood 3-04,,,Registered Voters,,,,,,382
+Johnson,Leawood 3-05,,,Registered Voters,,,,,,1604
+Johnson,Leawood 3-06,,,Registered Voters,,,,,,1431
+Johnson,Leawood 3-07,,,Registered Voters,,,,,,1111
+Johnson,Leawood 4-01,,,Registered Voters,,,,,,350
+Johnson,Leawood 4-02,,,Registered Voters,,,,,,939
+Johnson,Leawood 4-03,,,Registered Voters,,,,,,1010
+Johnson,Leawood 4-04,,,Registered Voters,,,,,,1225
+Johnson,Leawood 4-05,,,Registered Voters,,,,,,1174
+Johnson,Leawood 4-06,,,Registered Voters,,,,,,875
+Johnson,Leawood 4-07,,,Registered Voters,,,,,,1591
+Johnson,Leawood 4-08,,,Registered Voters,,,,,,633
+Johnson,Lenexa 1-01,,,Registered Voters,,,,,,682
+Johnson,Lenexa 1-02,,,Registered Voters,,,,,,1428
+Johnson,Lenexa 1-03,,,Registered Voters,,,,,,1564
+Johnson,Lenexa 1-04,,,Registered Voters,,,,,,1216
+Johnson,Lenexa 1-05,,,Registered Voters,,,,,,1085
+Johnson,Lenexa 1-06,,,Registered Voters,,,,,,1322
+Johnson,Lenexa 1-07,,,Registered Voters,,,,,,829
+Johnson,Lenexa 1-08,,,Registered Voters,,,,,,411
+Johnson,Lenexa 1-09,,,Registered Voters,,,,,,19
+Johnson,Lenexa 2-01,,,Registered Voters,,,,,,1378
+Johnson,Lenexa 2-02,,,Registered Voters,,,,,,374
+Johnson,Lenexa 2-03,,,Registered Voters,,,,,,1349
+Johnson,Lenexa 2-04,,,Registered Voters,,,,,,1465
+Johnson,Lenexa 2-05,,,Registered Voters,,,,,,1517
+Johnson,Lenexa 2-06,,,Registered Voters,,,,,,879
+Johnson,Lenexa 2-07,,,Registered Voters,,,,,,1495
+Johnson,Lenexa 2-08,,,Registered Voters,,,,,,0
+Johnson,Lenexa 3-01,,,Registered Voters,,,,,,1216
+Johnson,Lenexa 3-02,,,Registered Voters,,,,,,1271
+Johnson,Lenexa 3-03,,,Registered Voters,,,,,,1389
+Johnson,Lenexa 3-04,,,Registered Voters,,,,,,939
+Johnson,Lenexa 3-05,,,Registered Voters,,,,,,1155
+Johnson,Lenexa 3-06,,,Registered Voters,,,,,,885
+Johnson,Lenexa 3-07,,,Registered Voters,,,,,,1095
+Johnson,Lenexa 3-08,,,Registered Voters,,,,,,1157
+Johnson,Lenexa 4-01,,,Registered Voters,,,,,,598
+Johnson,Lenexa 4-02,,,Registered Voters,,,,,,1080
+Johnson,Lenexa 4-03,,,Registered Voters,,,,,,1013
+Johnson,Lenexa 4-04,,,Registered Voters,,,,,,712
+Johnson,Lenexa 4-05,,,Registered Voters,,,,,,550
+Johnson,Lenexa 4-06,,,Registered Voters,,,,,,1091
+Johnson,Lenexa 4-07,,,Registered Voters,,,,,,926
+Johnson,Lenexa 4-08,,,Registered Voters,,,,,,794
+Johnson,Lenexa 4-09,,,Registered Voters,,,,,,912
+Johnson,Lenexa 4-10,,,Registered Voters,,,,,,608
+Johnson,Lenexa 4-11,,,Registered Voters,,,,,,161
+Johnson,Lexington Twp 0-01,,,Registered Voters,,,,,,1050
+Johnson,Lexington Twp 0-02,,,Registered Voters,,,,,,3
+Johnson,Lexington Twp 0-03,,,Registered Voters,,,,,,5
+Johnson,Lexington Twp 0-04,,,Registered Voters,,,,,,0
+Johnson,Lexington Twp 0-05,,,Registered Voters,,,,,,0
+Johnson,McCamish Twp 0-01,,,Registered Voters,,,,,,247
+Johnson,McCamish Twp 0-02,,,Registered Voters,,,,,,499
+Johnson,McCamish Twp 0-03,,,Registered Voters,,,,,,0
+Johnson,Merriam 1-01,,,Registered Voters,,,,,,727
+Johnson,Merriam 1-02,,,Registered Voters,,,,,,1001
+Johnson,Merriam 2-01,,,Registered Voters,,,,,,1130
+Johnson,Merriam 2-02,,,Registered Voters,,,,,,4
+Johnson,Merriam 2-03,,,Registered Voters,,,,,,636
+Johnson,Merriam 3-01,,,Registered Voters,,,,,,1095
+Johnson,Merriam 3-02,,,Registered Voters,,,,,,795
+Johnson,Merriam 4-01,,,Registered Voters,,,,,,1076
+Johnson,Merriam 4-02,,,Registered Voters,,,,,,461
+Johnson,Merriam 4-03,,,Registered Voters,,,,,,610
+Johnson,Mission 1-01,,,Registered Voters,,,,,,1005
+Johnson,Mission 1-02,,,Registered Voters,,,,,,838
+Johnson,Mission 2-01,,,Registered Voters,,,,,,631
+Johnson,Mission 2-02,,,Registered Voters,,,,,,822
+Johnson,Mission 3-01,,,Registered Voters,,,,,,1288
+Johnson,Mission 3-02,,,Registered Voters,,,,,,528
+Johnson,Mission 4-01,,,Registered Voters,,,,,,586
+Johnson,Mission 4-02,,,Registered Voters,,,,,,725
+Johnson,Mission 4-03,,,Registered Voters,,,,,,501
+Johnson,Mission Hills 0-01,,,Registered Voters,,,,,,703
+Johnson,Mission Hills 0-02,,,Registered Voters,,,,,,857
+Johnson,Mission Hills 0-03,,,Registered Voters,,,,,,598
+Johnson,Mission Hills 0-04,,,Registered Voters,,,,,,905
+Johnson,Mission Woods 0-01,,,Registered Voters,,,,,,150
+Johnson,Olathe 1-01,,,Registered Voters,,,,,,1314
+Johnson,Olathe 1-02,,,Registered Voters,,,,,,902
+Johnson,Olathe 1-03,,,Registered Voters,,,,,,745
+Johnson,Olathe 1-04,,,Registered Voters,,,,,,1234
+Johnson,Olathe 1-05,,,Registered Voters,,,,,,1114
+Johnson,Olathe 1-06,,,Registered Voters,,,,,,769
+Johnson,Olathe 1-07,,,Registered Voters,,,,,,0
+Johnson,Olathe 1-08,,,Registered Voters,,,,,,1545
+Johnson,Olathe 1-09,,,Registered Voters,,,,,,1240
+Johnson,Olathe 1-10,,,Registered Voters,,,,,,0
+Johnson,Olathe 1-11,,,Registered Voters,,,,,,242
+Johnson,Olathe 1-12,,,Registered Voters,,,,,,47
+Johnson,Olathe 1-13,,,Registered Voters,,,,,,0
+Johnson,Olathe 1-14,,,Registered Voters,,,,,,1021
+Johnson,Olathe 1-15,,,Registered Voters,,,,,,1072
+Johnson,Olathe 1-16,,,Registered Voters,,,,,,1414
+Johnson,Olathe 1-17,,,Registered Voters,,,,,,282
+Johnson,Olathe 1-18,,,Registered Voters,,,,,,298
+Johnson,Olathe 1-19,,,Registered Voters,,,,,,610
+Johnson,Olathe 1-20,,,Registered Voters,,,,,,932
+Johnson,Olathe 1-21,,,Registered Voters,,,,,,1437
+Johnson,Olathe 1-22,,,Registered Voters,,,,,,1515
+Johnson,Olathe 1-23,,,Registered Voters,,,,,,0
+Johnson,Olathe 1-24,,,Registered Voters,,,,,,0
+Johnson,Olathe 1-25,,,Registered Voters,,,,,,0
+Johnson,Olathe 1-26,,,Registered Voters,,,,,,8
+Johnson,Olathe 1-27,,,Registered Voters,,,,,,914
+Johnson,Olathe 1-28,,,Registered Voters,,,,,,316
+Johnson,Olathe 1-29,,,Registered Voters,,,,,,196
+Johnson,Olathe 2-01,,,Registered Voters,,,,,,643
+Johnson,Olathe 2-02,,,Registered Voters,,,,,,585
+Johnson,Olathe 2-03,,,Registered Voters,,,,,,960
+Johnson,Olathe 2-04,,,Registered Voters,,,,,,1214
+Johnson,Olathe 2-05,,,Registered Voters,,,,,,1854
+Johnson,Olathe 2-06,,,Registered Voters,,,,,,1005
+Johnson,Olathe 2-07,,,Registered Voters,,,,,,1444
+Johnson,Olathe 2-08,,,Registered Voters,,,,,,1542
+Johnson,Olathe 2-09,,,Registered Voters,,,,,,476
+Johnson,Olathe 2-10,,,Registered Voters,,,,,,2069
+Johnson,Olathe 2-11,,,Registered Voters,,,,,,1472
+Johnson,Olathe 2-12,,,Registered Voters,,,,,,908
+Johnson,Olathe 2-13,,,Registered Voters,,,,,,984
+Johnson,Olathe 2-14,,,Registered Voters,,,,,,988
+Johnson,Olathe 2-15,,,Registered Voters,,,,,,592
+Johnson,Olathe 2-16,,,Registered Voters,,,,,,0
+Johnson,Olathe 2-17,,,Registered Voters,,,,,,0
+Johnson,Olathe 2-18,,,Registered Voters,,,,,,0
+Johnson,Olathe 2-19,,,Registered Voters,,,,,,12
+Johnson,Olathe 2-20,,,Registered Voters,,,,,,0
+Johnson,Olathe 2-21,,,Registered Voters,,,,,,0
+Johnson,Olathe 2-22,,,Registered Voters,,,,,,1453
+Johnson,Olathe 2-23,,,Registered Voters,,,,,,1094
+Johnson,Olathe 2-24,,,Registered Voters,,,,,,18
+Johnson,Olathe 2-25,,,Registered Voters,,,,,,13
+Johnson,Olathe 2-26,,,Registered Voters,,,,,,0
+Johnson,Olathe 2-27,,,Registered Voters,,,,,,18
+Johnson,Olathe 2-28,,,Registered Voters,,,,,,380
+Johnson,Olathe 3-01,,,Registered Voters,,,,,,776
+Johnson,Olathe 3-02,,,Registered Voters,,,,,,1561
+Johnson,Olathe 3-03,,,Registered Voters,,,,,,736
+Johnson,Olathe 3-04,,,Registered Voters,,,,,,1275
+Johnson,Olathe 3-05,,,Registered Voters,,,,,,993
+Johnson,Olathe 3-06,,,Registered Voters,,,,,,866
+Johnson,Olathe 3-07,,,Registered Voters,,,,,,884
+Johnson,Olathe 3-08,,,Registered Voters,,,,,,1274
+Johnson,Olathe 3-09,,,Registered Voters,,,,,,827
+Johnson,Olathe 3-10,,,Registered Voters,,,,,,1400
+Johnson,Olathe 3-11,,,Registered Voters,,,,,,941
+Johnson,Olathe 3-12,,,Registered Voters,,,,,,1306
+Johnson,Olathe 3-13,,,Registered Voters,,,,,,1215
+Johnson,Olathe 3-14,,,Registered Voters,,,,,,0
+Johnson,Olathe 3-15,,,Registered Voters,,,,,,1011
+Johnson,Olathe 3-16,,,Registered Voters,,,,,,1049
+Johnson,Olathe 3-17,,,Registered Voters,,,,,,1310
+Johnson,Olathe 3-18,,,Registered Voters,,,,,,1317
+Johnson,Olathe 3-19,,,Registered Voters,,,,,,721
+Johnson,Olathe 3-20,,,Registered Voters,,,,,,877
+Johnson,Olathe 3-21,,,Registered Voters,,,,,,535
+Johnson,Olathe 3-22,,,Registered Voters,,,,,,1188
+Johnson,Olathe 3-23,,,Registered Voters,,,,,,1163
+Johnson,Olathe 3-24,,,Registered Voters,,,,,,0
+Johnson,Olathe 3-25,,,Registered Voters,,,,,,0
+Johnson,Olathe 3-26,,,Registered Voters,,,,,,156
+Johnson,Olathe 3-27,,,Registered Voters,,,,,,558
+Johnson,Olathe 4-01,,,Registered Voters,,,,,,1302
+Johnson,Olathe 4-02,,,Registered Voters,,,,,,1484
+Johnson,Olathe 4-03,,,Registered Voters,,,,,,1012
+Johnson,Olathe 4-04,,,Registered Voters,,,,,,754
+Johnson,Olathe 4-05,,,Registered Voters,,,,,,1077
+Johnson,Olathe 4-06,,,Registered Voters,,,,,,1739
+Johnson,Olathe 4-07,,,Registered Voters,,,,,,1555
+Johnson,Olathe 4-08,,,Registered Voters,,,,,,986
+Johnson,Olathe 4-09,,,Registered Voters,,,,,,1524
+Johnson,Olathe 4-10,,,Registered Voters,,,,,,812
+Johnson,Olathe 4-11,,,Registered Voters,,,,,,724
+Johnson,Olathe 4-12,,,Registered Voters,,,,,,1426
+Johnson,Olathe 4-13,,,Registered Voters,,,,,,841
+Johnson,Olathe 4-14,,,Registered Voters,,,,,,1663
+Johnson,Olathe 4-15,,,Registered Voters,,,,,,169
+Johnson,Olathe 4-16,,,Registered Voters,,,,,,4
+Johnson,Olathe 4-17,,,Registered Voters,,,,,,12
+Johnson,Olathe 4-18,,,Registered Voters,,,,,,588
+Johnson,Olathe Twp 0-01,,,Registered Voters,,,,,,466
+Johnson,Olathe Twp 0-02,,,Registered Voters,,,,,,93
+Johnson,Olathe Twp 0-03,,,Registered Voters,,,,,,81
+Johnson,Olathe Twp 0-04,,,Registered Voters,,,,,,2
+Johnson,Olathe Twp 0-05,,,Registered Voters,,,,,,3
+Johnson,Olathe Twp 0-06,,,Registered Voters,,,,,,2
+Johnson,Olathe Twp 0-07,,,Registered Voters,,,,,,2
+Johnson,Olathe Twp 0-08,,,Registered Voters,,,,,,19
+Johnson,Olathe Twp 0-09,,,Registered Voters,,,,,,0
+Johnson,Olathe Twp 0-10,,,Registered Voters,,,,,,19
+Johnson,Olathe Twp 0-11,,,Registered Voters,,,,,,8
+Johnson,Olathe Twp 0-12,,,Registered Voters,,,,,,0
+Johnson,Olathe Twp 0-13,,,Registered Voters,,,,,,0
+Johnson,Olathe Twp 0-14,,,Registered Voters,,,,,,1
+Johnson,Olathe Twp 0-17,,,Registered Voters,,,,,,0
+Johnson,Olathe Twp 0-24,,,Registered Voters,,,,,,4
+Johnson,Olathe Twp 0-25,,,Registered Voters,,,,,,11
+Johnson,Olathe Twp 0-26,,,Registered Voters,,,,,,5
+Johnson,Olathe Twp 0-27,,,Registered Voters,,,,,,0
+Johnson,Olathe Twp 0-32,,,Registered Voters,,,,,,41
+Johnson,Overland Park 1-01,,,Registered Voters,,,,,,1085
+Johnson,Overland Park 1-02,,,Registered Voters,,,,,,1186
+Johnson,Overland Park 1-03,,,Registered Voters,,,,,,1066
+Johnson,Overland Park 1-04,,,Registered Voters,,,,,,394
+Johnson,Overland Park 1-05,,,Registered Voters,,,,,,727
+Johnson,Overland Park 1-06,,,Registered Voters,,,,,,1164
+Johnson,Overland Park 1-07,,,Registered Voters,,,,,,1350
+Johnson,Overland Park 1-08,,,Registered Voters,,,,,,1253
+Johnson,Overland Park 1-09,,,Registered Voters,,,,,,607
+Johnson,Overland Park 1-10,,,Registered Voters,,,,,,1211
+Johnson,Overland Park 1-11,,,Registered Voters,,,,,,696
+Johnson,Overland Park 1-12,,,Registered Voters,,,,,,1429
+Johnson,Overland Park 1-13,,,Registered Voters,,,,,,912
+Johnson,Overland Park 1-14,,,Registered Voters,,,,,,1067
+Johnson,Overland Park 1-15,,,Registered Voters,,,,,,518
+Johnson,Overland Park 1-16,,,Registered Voters,,,,,,1259
+Johnson,Overland Park 1-17,,,Registered Voters,,,,,,617
+Johnson,Overland Park 1-18,,,Registered Voters,,,,,,801
+Johnson,Overland Park 1-19,,,Registered Voters,,,,,,1142
+Johnson,Overland Park 1-20,,,Registered Voters,,,,,,530
+Johnson,Overland Park 1-21,,,Registered Voters,,,,,,348
+Johnson,Overland Park 1-22,,,Registered Voters,,,,,,328
+Johnson,Overland Park 2-01,,,Registered Voters,,,,,,783
+Johnson,Overland Park 2-02,,,Registered Voters,,,,,,798
+Johnson,Overland Park 2-03,,,Registered Voters,,,,,,754
+Johnson,Overland Park 2-04,,,Registered Voters,,,,,,947
+Johnson,Overland Park 2-05,,,Registered Voters,,,,,,1033
+Johnson,Overland Park 2-06,,,Registered Voters,,,,,,874
+Johnson,Overland Park 2-07,,,Registered Voters,,,,,,709
+Johnson,Overland Park 2-08,,,Registered Voters,,,,,,830
+Johnson,Overland Park 2-09,,,Registered Voters,,,,,,871
+Johnson,Overland Park 2-10,,,Registered Voters,,,,,,673
+Johnson,Overland Park 2-11,,,Registered Voters,,,,,,843
+Johnson,Overland Park 2-12,,,Registered Voters,,,,,,708
+Johnson,Overland Park 2-13,,,Registered Voters,,,,,,729
+Johnson,Overland Park 2-14,,,Registered Voters,,,,,,623
+Johnson,Overland Park 2-15,,,Registered Voters,,,,,,1076
+Johnson,Overland Park 2-16,,,Registered Voters,,,,,,676
+Johnson,Overland Park 2-17,,,Registered Voters,,,,,,1010
+Johnson,Overland Park 2-18,,,Registered Voters,,,,,,1212
+Johnson,Overland Park 2-19,,,Registered Voters,,,,,,682
+Johnson,Overland Park 2-20,,,Registered Voters,,,,,,621
+Johnson,Overland Park 2-21,,,Registered Voters,,,,,,709
+Johnson,Overland Park 2-22,,,Registered Voters,,,,,,857
+Johnson,Overland Park 2-23,,,Registered Voters,,,,,,776
+Johnson,Overland Park 2-24,,,Registered Voters,,,,,,1494
+Johnson,Overland Park 2-25,,,Registered Voters,,,,,,896
+Johnson,Overland Park 2-26,,,Registered Voters,,,,,,469
+Johnson,Overland Park 3-01,,,Registered Voters,,,,,,1448
+Johnson,Overland Park 3-02,,,Registered Voters,,,,,,962
+Johnson,Overland Park 3-03,,,Registered Voters,,,,,,833
+Johnson,Overland Park 3-04,,,Registered Voters,,,,,,1137
+Johnson,Overland Park 3-05,,,Registered Voters,,,,,,1157
+Johnson,Overland Park 3-06,,,Registered Voters,,,,,,1203
+Johnson,Overland Park 3-07,,,Registered Voters,,,,,,1049
+Johnson,Overland Park 3-08,,,Registered Voters,,,,,,892
+Johnson,Overland Park 3-09,,,Registered Voters,,,,,,1380
+Johnson,Overland Park 3-10,,,Registered Voters,,,,,,704
+Johnson,Overland Park 3-11,,,Registered Voters,,,,,,1071
+Johnson,Overland Park 3-12,,,Registered Voters,,,,,,1064
+Johnson,Overland Park 3-13,,,Registered Voters,,,,,,1769
+Johnson,Overland Park 3-14,,,Registered Voters,,,,,,1327
+Johnson,Overland Park 3-15,,,Registered Voters,,,,,,818
+Johnson,Overland Park 3-16,,,Registered Voters,,,,,,885
+Johnson,Overland Park 3-17,,,Registered Voters,,,,,,689
+Johnson,Overland Park 3-18,,,Registered Voters,,,,,,1250
+Johnson,Overland Park 3-19,,,Registered Voters,,,,,,1196
+Johnson,Overland Park 3-20,,,Registered Voters,,,,,,1271
+Johnson,Overland Park 4-01,,,Registered Voters,,,,,,981
+Johnson,Overland Park 4-02,,,Registered Voters,,,,,,1520
+Johnson,Overland Park 4-03,,,Registered Voters,,,,,,1576
+Johnson,Overland Park 4-04,,,Registered Voters,,,,,,1560
+Johnson,Overland Park 4-05,,,Registered Voters,,,,,,1187
+Johnson,Overland Park 4-06,,,Registered Voters,,,,,,959
+Johnson,Overland Park 4-07,,,Registered Voters,,,,,,883
+Johnson,Overland Park 4-08,,,Registered Voters,,,,,,1030
+Johnson,Overland Park 4-09,,,Registered Voters,,,,,,953
+Johnson,Overland Park 4-10,,,Registered Voters,,,,,,765
+Johnson,Overland Park 4-11,,,Registered Voters,,,,,,1341
+Johnson,Overland Park 4-12,,,Registered Voters,,,,,,1735
+Johnson,Overland Park 4-13,,,Registered Voters,,,,,,815
+Johnson,Overland Park 4-14,,,Registered Voters,,,,,,638
+Johnson,Overland Park 4-15,,,Registered Voters,,,,,,1459
+Johnson,Overland Park 4-16,,,Registered Voters,,,,,,1122
+Johnson,Overland Park 4-17,,,Registered Voters,,,,,,1333
+Johnson,Overland Park 4-18,,,Registered Voters,,,,,,431
+Johnson,Overland Park 5-01,,,Registered Voters,,,,,,1159
+Johnson,Overland Park 5-02,,,Registered Voters,,,,,,687
+Johnson,Overland Park 5-03,,,Registered Voters,,,,,,887
+Johnson,Overland Park 5-04,,,Registered Voters,,,,,,1057
+Johnson,Overland Park 5-05,,,Registered Voters,,,,,,1032
+Johnson,Overland Park 5-06,,,Registered Voters,,,,,,1269
+Johnson,Overland Park 5-07,,,Registered Voters,,,,,,1344
+Johnson,Overland Park 5-08,,,Registered Voters,,,,,,1945
+Johnson,Overland Park 5-09,,,Registered Voters,,,,,,1568
+Johnson,Overland Park 5-10,,,Registered Voters,,,,,,1171
+Johnson,Overland Park 5-11,,,Registered Voters,,,,,,1602
+Johnson,Overland Park 5-12,,,Registered Voters,,,,,,362
+Johnson,Overland Park 5-13,,,Registered Voters,,,,,,1500
+Johnson,Overland Park 5-14,,,Registered Voters,,,,,,1201
+Johnson,Overland Park 5-15,,,Registered Voters,,,,,,1216
+Johnson,Overland Park 5-16,,,Registered Voters,,,,,,806
+Johnson,Overland Park 5-17,,,Registered Voters,,,,,,524
+Johnson,Overland Park 5-18,,,Registered Voters,,,,,,1240
+Johnson,Overland Park 5-19,,,Registered Voters,,,,,,116
+Johnson,Overland Park 6-01,,,Registered Voters,,,,,,1340
+Johnson,Overland Park 6-02,,,Registered Voters,,,,,,1079
+Johnson,Overland Park 6-03,,,Registered Voters,,,,,,1245
+Johnson,Overland Park 6-04,,,Registered Voters,,,,,,1278
+Johnson,Overland Park 6-05,,,Registered Voters,,,,,,1437
+Johnson,Overland Park 6-06,,,Registered Voters,,,,,,0
+Johnson,Overland Park 6-07,,,Registered Voters,,,,,,339
+Johnson,Overland Park 6-08,,,Registered Voters,,,,,,1425
+Johnson,Overland Park 6-09,,,Registered Voters,,,,,,1502
+Johnson,Overland Park 6-10,,,Registered Voters,,,,,,1307
+Johnson,Overland Park 6-11,,,Registered Voters,,,,,,1168
+Johnson,Overland Park 6-12,,,Registered Voters,,,,,,530
+Johnson,Overland Park 6-13,,,Registered Voters,,,,,,1432
+Johnson,Overland Park 6-14,,,Registered Voters,,,,,,3
+Johnson,Overland Park 6-15,,,Registered Voters,,,,,,1443
+Johnson,Overland Park 6-16,,,Registered Voters,,,,,,789
+Johnson,Overland Park 6-17,,,Registered Voters,,,,,,1157
+Johnson,Overland Park 6-18,,,Registered Voters,,,,,,0
+Johnson,Overland Park 6-19,,,Registered Voters,,,,,,1374
+Johnson,Overland Park 6-20,,,Registered Voters,,,,,,543
+Johnson,Overland Park 6-21,,,Registered Voters,,,,,,1495
+Johnson,Overland Park 6-22,,,Registered Voters,,,,,,431
+Johnson,Overland Park 6-23,,,Registered Voters,,,,,,237
+Johnson,Oxford Twp 0-01,,,Registered Voters,,,,,,2
+Johnson,Oxford Twp 0-02,,,Registered Voters,,,,,,734
+Johnson,Oxford Twp 0-03,,,Registered Voters,,,,,,0
+Johnson,Oxford Twp 0-04,,,Registered Voters,,,,,,674
+Johnson,Oxford Twp 0-05,,,Registered Voters,,,,,,20
+Johnson,Oxford Twp 0-08,,,Registered Voters,,,,,,0
+Johnson,Oxford Twp 0-09,,,Registered Voters,,,,,,51
+Johnson,Oxford Twp 0-10,,,Registered Voters,,,,,,2
+Johnson,Oxford Twp 0-11,,,Registered Voters,,,,,,152
+Johnson,Prairie Village 1-01,,,Registered Voters,,,,,,1100
+Johnson,Prairie Village 1-02,,,Registered Voters,,,,,,870
+Johnson,Prairie Village 1-03,,,Registered Voters,,,,,,1203
+Johnson,Prairie Village 2-01,,,Registered Voters,,,,,,1039
+Johnson,Prairie Village 2-02,,,Registered Voters,,,,,,650
+Johnson,Prairie Village 2-03,,,Registered Voters,,,,,,994
+Johnson,Prairie Village 3-01,,,Registered Voters,,,,,,713
+Johnson,Prairie Village 3-02,,,Registered Voters,,,,,,1109
+Johnson,Prairie Village 3-03,,,Registered Voters,,,,,,978
+Johnson,Prairie Village 4-01,,,Registered Voters,,,,,,993
+Johnson,Prairie Village 4-02,,,Registered Voters,,,,,,767
+Johnson,Prairie Village 4-03,,,Registered Voters,,,,,,1121
+Johnson,Prairie Village 5-01,,,Registered Voters,,,,,,1101
+Johnson,Prairie Village 5-02,,,Registered Voters,,,,,,1049
+Johnson,Prairie Village 5-03,,,Registered Voters,,,,,,814
+Johnson,Prairie Village 6-01,,,Registered Voters,,,,,,1114
+Johnson,Prairie Village 6-02,,,Registered Voters,,,,,,966
+Johnson,Prairie Village 6-03,,,Registered Voters,,,,,,812
+Johnson,Roeland Park 1-01,,,Registered Voters,,,,,,757
+Johnson,Roeland Park 1-02,,,Registered Voters,,,,,,414
+Johnson,Roeland Park 1-03,,,Registered Voters,,,,,,0
+Johnson,Roeland Park 2-01,,,Registered Voters,,,,,,582
+Johnson,Roeland Park 2-02,,,Registered Voters,,,,,,733
+Johnson,Roeland Park 3-01,,,Registered Voters,,,,,,481
+Johnson,Roeland Park 3-02,,,Registered Voters,,,,,,841
+Johnson,Roeland Park 4-01,,,Registered Voters,,,,,,393
+Johnson,Roeland Park 4-02,,,Registered Voters,,,,,,1063
+Johnson,Shawnee 1-01,,,Registered Voters,,,,,,1242
+Johnson,Shawnee 1-02,,,Registered Voters,,,,,,830
+Johnson,Shawnee 1-03,,,Registered Voters,,,,,,847
+Johnson,Shawnee 1-04,,,Registered Voters,,,,,,1360
+Johnson,Shawnee 1-05,,,Registered Voters,,,,,,1384
+Johnson,Shawnee 1-06,,,Registered Voters,,,,,,1058
+Johnson,Shawnee 1-07,,,Registered Voters,,,,,,1256
+Johnson,Shawnee 1-08,,,Registered Voters,,,,,,1360
+Johnson,Shawnee 1-09,,,Registered Voters,,,,,,314
+Johnson,Shawnee 1-10,,,Registered Voters,,,,,,391
+Johnson,Shawnee 1-11,,,Registered Voters,,,,,,974
+Johnson,Shawnee 1-12,,,Registered Voters,,,,,,14
+Johnson,Shawnee 2-01,,,Registered Voters,,,,,,642
+Johnson,Shawnee 2-02,,,Registered Voters,,,,,,1079
+Johnson,Shawnee 2-03,,,Registered Voters,,,,,,1136
+Johnson,Shawnee 2-04,,,Registered Voters,,,,,,1294
+Johnson,Shawnee 2-05,,,Registered Voters,,,,,,645
+Johnson,Shawnee 2-06,,,Registered Voters,,,,,,812
+Johnson,Shawnee 2-07,,,Registered Voters,,,,,,805
+Johnson,Shawnee 2-08,,,Registered Voters,,,,,,750
+Johnson,Shawnee 2-09,,,Registered Voters,,,,,,700
+Johnson,Shawnee 2-10,,,Registered Voters,,,,,,652
+Johnson,Shawnee 2-11,,,Registered Voters,,,,,,826
+Johnson,Shawnee 2-12,,,Registered Voters,,,,,,416
+Johnson,Shawnee 2-13,,,Registered Voters,,,,,,499
+Johnson,Shawnee 3-01,,,Registered Voters,,,,,,838
+Johnson,Shawnee 3-02,,,Registered Voters,,,,,,1445
+Johnson,Shawnee 3-03,,,Registered Voters,,,,,,1148
+Johnson,Shawnee 3-04,,,Registered Voters,,,,,,996
+Johnson,Shawnee 3-05,,,Registered Voters,,,,,,1260
+Johnson,Shawnee 3-06,,,Registered Voters,,,,,,1311
+Johnson,Shawnee 3-07,,,Registered Voters,,,,,,1572
+Johnson,Shawnee 3-08,,,Registered Voters,,,,,,1260
+Johnson,Shawnee 3-09,,,Registered Voters,,,,,,768
+Johnson,Shawnee 4-01,,,Registered Voters,,,,,,1361
+Johnson,Shawnee 4-02,,,Registered Voters,,,,,,836
+Johnson,Shawnee 4-03,,,Registered Voters,,,,,,420
+Johnson,Shawnee 4-04,,,Registered Voters,,,,,,780
+Johnson,Shawnee 4-05,,,Registered Voters,,,,,,1244
+Johnson,Shawnee 4-06,,,Registered Voters,,,,,,1067
+Johnson,Shawnee 4-07,,,Registered Voters,,,,,,1392
+Johnson,Shawnee 4-08,,,Registered Voters,,,,,,513
+Johnson,Shawnee 4-09,,,Registered Voters,,,,,,1683
+Johnson,Shawnee 4-10,,,Registered Voters,,,,,,0
+Johnson,Shawnee 4-11,,,Registered Voters,,,,,,1023
+Johnson,Shawnee 4-12,,,Registered Voters,,,,,,0
+Johnson,Shawnee 4-13,,,Registered Voters,,,,,,141
+Johnson,Spring Hill 0-01,,,Registered Voters,,,,,,1991
+Johnson,Spring Hill 0-02,,,Registered Voters,,,,,,0
+Johnson,Spring Hill 0-03,,,Registered Voters,,,,,,46
+Johnson,Spring Hill 0-04,,,Registered Voters,,,,,,0
+Johnson,Spring Hill Twp 0-01,,,Registered Voters,,,,,,1293
+Johnson,Spring Hill Twp 0-02,,,Registered Voters,,,,,,2
+Johnson,Spring Hill Twp 0-03,,,Registered Voters,,,,,,137
+Johnson,Spring Hill Twp 0-04,,,Registered Voters,,,,,,29
+Johnson,Spring Hill Twp 0-05,,,Registered Voters,,,,,,15
+Johnson,Westwood 0-01,,,Registered Voters,,,,,,637
+Johnson,Westwood 0-02,,,Registered Voters,,,,,,590
+Johnson,Westwood Hills 0-01,,,Registered Voters,,,,,,336
+Johnson,Total,,,Registered Voters,,,,,,383491
+Johnson,Aubry Twp 0-01,,,Ballots Cast,,,,,,130
+Johnson,Aubry Twp 0-02,,,Ballots Cast,,,,,,780
+Johnson,Aubry Twp 0-03,,,Ballots Cast,,,,,,453
+Johnson,Aubry Twp 0-04,,,Ballots Cast,,,,,,1014
+Johnson,Aubry Twp 0-05,,,Ballots Cast,,,,,,17
+Johnson,Aubry Twp 0-06,,,Ballots Cast,,,,,,105
+Johnson,Bonner Springs 4-01,,,Ballots Cast,,,,,,0
+Johnson,De Soto 0-01,,,Ballots Cast,,,,,,932
+Johnson,De Soto 0-02,,,Ballots Cast,,,,,,534
+Johnson,De Soto 0-03,,,Ballots Cast,,,,,,833
+Johnson,De Soto 0-04,,,Ballots Cast,,,,,,0
+Johnson,De Soto 0-05,,,Ballots Cast,,,,,,0
+Johnson,De Soto 0-06,,,Ballots Cast,,,,,,75
+Johnson,De Soto 0-07,,,Ballots Cast,,,,,,2
+Johnson,De Soto 0-08,,,Ballots Cast,,,,,,0
+Johnson,Edgerton 0-01,,,Ballots Cast,,,,,,677
+Johnson,Edgerton 0-02,,,Ballots Cast,,,,,,0
+Johnson,Edgerton 0-03,,,Ballots Cast,,,,,,0
+Johnson,Edgerton 0-04,,,Ballots Cast,,,,,,0
+Johnson,Edgerton 0-05,,,Ballots Cast,,,,,,0
+Johnson,Edgerton 0-06,,,Ballots Cast,,,,,,0
+Johnson,Edgerton 0-07,,,Ballots Cast,,,,,,0
+Johnson,Edgerton 0-08,,,Ballots Cast,,,,,,0
+Johnson,Fairway 1-00,,,Ballots Cast,,,,,,628
+Johnson,Fairway 2-00,,,Ballots Cast,,,,,,556
+Johnson,Fairway 3-00,,,Ballots Cast,,,,,,720
+Johnson,Fairway 4-00,,,Ballots Cast,,,,,,615
+Johnson,Gardner 0-01,,,Ballots Cast,,,,,,1242
+Johnson,Gardner 0-02,,,Ballots Cast,,,,,,193
+Johnson,Gardner 0-03,,,Ballots Cast,,,,,,931
+Johnson,Gardner 0-04,,,Ballots Cast,,,,,,694
+Johnson,Gardner 0-05,,,Ballots Cast,,,,,,0
+Johnson,Gardner 0-06,,,Ballots Cast,,,,,,960
+Johnson,Gardner 0-07,,,Ballots Cast,,,,,,26
+Johnson,Gardner 0-08,,,Ballots Cast,,,,,,68
+Johnson,Gardner 0-09,,,Ballots Cast,,,,,,1108
+Johnson,Gardner 0-10,,,Ballots Cast,,,,,,723
+Johnson,Gardner 0-11,,,Ballots Cast,,,,,,0
+Johnson,Gardner 0-12,,,Ballots Cast,,,,,,19
+Johnson,Gardner 0-13,,,Ballots Cast,,,,,,856
+Johnson,Gardner 0-14,,,Ballots Cast,,,,,,665
+Johnson,Gardner 0-15,,,Ballots Cast,,,,,,0
+Johnson,Gardner Twp 0-01,,,Ballots Cast,,,,,,399
+Johnson,Gardner Twp 0-02,,,Ballots Cast,,,,,,499
+Johnson,Gardner Twp 0-03,,,Ballots Cast,,,,,,0
+Johnson,Gardner Twp 0-04,,,Ballots Cast,,,,,,1
+Johnson,Gardner Twp 0-05,,,Ballots Cast,,,,,,8
+Johnson,Gardner Twp 0-06,,,Ballots Cast,,,,,,0
+Johnson,Gardner Twp 0-07,,,Ballots Cast,,,,,,4
+Johnson,Gardner Twp 0-08,,,Ballots Cast,,,,,,6
+Johnson,Gardner Twp 0-09,,,Ballots Cast,,,,,,2
+Johnson,Gardner Twp 0-10,,,Ballots Cast,,,,,,0
+Johnson,Gardner Twp 0-11,,,Ballots Cast,,,,,,115
+Johnson,Gardner Twp 0-12,,,Ballots Cast,,,,,,0
+Johnson,Lake Quivira 0-01,,,Ballots Cast,,,,,,673
+Johnson,Leawood 1-01,,,Ballots Cast,,,,,,632
+Johnson,Leawood 1-02,,,Ballots Cast,,,,,,970
+Johnson,Leawood 1-03,,,Ballots Cast,,,,,,866
+Johnson,Leawood 1-04,,,Ballots Cast,,,,,,684
+Johnson,Leawood 1-05,,,Ballots Cast,,,,,,631
+Johnson,Leawood 1-06,,,Ballots Cast,,,,,,171
+Johnson,Leawood 2-01,,,Ballots Cast,,,,,,790
+Johnson,Leawood 2-02,,,Ballots Cast,,,,,,961
+Johnson,Leawood 2-03,,,Ballots Cast,,,,,,953
+Johnson,Leawood 2-04,,,Ballots Cast,,,,,,986
+Johnson,Leawood 2-05,,,Ballots Cast,,,,,,575
+Johnson,Leawood 2-06,,,Ballots Cast,,,,,,405
+Johnson,Leawood 3-01,,,Ballots Cast,,,,,,533
+Johnson,Leawood 3-02,,,Ballots Cast,,,,,,912
+Johnson,Leawood 3-03,,,Ballots Cast,,,,,,575
+Johnson,Leawood 3-04,,,Ballots Cast,,,,,,287
+Johnson,Leawood 3-05,,,Ballots Cast,,,,,,1177
+Johnson,Leawood 3-06,,,Ballots Cast,,,,,,1097
+Johnson,Leawood 3-07,,,Ballots Cast,,,,,,854
+Johnson,Leawood 4-01,,,Ballots Cast,,,,,,267
+Johnson,Leawood 4-02,,,Ballots Cast,,,,,,751
+Johnson,Leawood 4-03,,,Ballots Cast,,,,,,739
+Johnson,Leawood 4-04,,,Ballots Cast,,,,,,953
+Johnson,Leawood 4-05,,,Ballots Cast,,,,,,922
+Johnson,Leawood 4-06,,,Ballots Cast,,,,,,696
+Johnson,Leawood 4-07,,,Ballots Cast,,,,,,1250
+Johnson,Leawood 4-08,,,Ballots Cast,,,,,,489
+Johnson,Lenexa 1-01,,,Ballots Cast,,,,,,509
+Johnson,Lenexa 1-02,,,Ballots Cast,,,,,,1044
+Johnson,Lenexa 1-03,,,Ballots Cast,,,,,,1220
+Johnson,Lenexa 1-04,,,Ballots Cast,,,,,,847
+Johnson,Lenexa 1-05,,,Ballots Cast,,,,,,841
+Johnson,Lenexa 1-06,,,Ballots Cast,,,,,,1003
+Johnson,Lenexa 1-07,,,Ballots Cast,,,,,,567
+Johnson,Lenexa 1-08,,,Ballots Cast,,,,,,257
+Johnson,Lenexa 1-09,,,Ballots Cast,,,,,,18
+Johnson,Lenexa 2-01,,,Ballots Cast,,,,,,1054
+Johnson,Lenexa 2-02,,,Ballots Cast,,,,,,297
+Johnson,Lenexa 2-03,,,Ballots Cast,,,,,,1090
+Johnson,Lenexa 2-04,,,Ballots Cast,,,,,,1113
+Johnson,Lenexa 2-05,,,Ballots Cast,,,,,,937
+Johnson,Lenexa 2-06,,,Ballots Cast,,,,,,698
+Johnson,Lenexa 2-07,,,Ballots Cast,,,,,,1135
+Johnson,Lenexa 2-08,,,Ballots Cast,,,,,,0
+Johnson,Lenexa 3-01,,,Ballots Cast,,,,,,745
+Johnson,Lenexa 3-02,,,Ballots Cast,,,,,,989
+Johnson,Lenexa 3-03,,,Ballots Cast,,,,,,1085
+Johnson,Lenexa 3-04,,,Ballots Cast,,,,,,732
+Johnson,Lenexa 3-05,,,Ballots Cast,,,,,,613
+Johnson,Lenexa 3-06,,,Ballots Cast,,,,,,690
+Johnson,Lenexa 3-07,,,Ballots Cast,,,,,,853
+Johnson,Lenexa 3-08,,,Ballots Cast,,,,,,913
+Johnson,Lenexa 4-01,,,Ballots Cast,,,,,,431
+Johnson,Lenexa 4-02,,,Ballots Cast,,,,,,829
+Johnson,Lenexa 4-03,,,Ballots Cast,,,,,,499
+Johnson,Lenexa 4-04,,,Ballots Cast,,,,,,459
+Johnson,Lenexa 4-05,,,Ballots Cast,,,,,,368
+Johnson,Lenexa 4-06,,,Ballots Cast,,,,,,696
+Johnson,Lenexa 4-07,,,Ballots Cast,,,,,,689
+Johnson,Lenexa 4-08,,,Ballots Cast,,,,,,660
+Johnson,Lenexa 4-09,,,Ballots Cast,,,,,,689
+Johnson,Lenexa 4-10,,,Ballots Cast,,,,,,415
+Johnson,Lenexa 4-11,,,Ballots Cast,,,,,,124
+Johnson,Lexington Twp 0-01,,,Ballots Cast,,,,,,789
+Johnson,Lexington Twp 0-02,,,Ballots Cast,,,,,,3
+Johnson,Lexington Twp 0-03,,,Ballots Cast,,,,,,4
+Johnson,Lexington Twp 0-04,,,Ballots Cast,,,,,,1
+Johnson,Lexington Twp 0-05,,,Ballots Cast,,,,,,0
+Johnson,McCamish Twp 0-01,,,Ballots Cast,,,,,,190
+Johnson,McCamish Twp 0-02,,,Ballots Cast,,,,,,379
+Johnson,McCamish Twp 0-03,,,Ballots Cast,,,,,,0
+Johnson,Merriam 1-01,,,Ballots Cast,,,,,,496
+Johnson,Merriam 1-02,,,Ballots Cast,,,,,,666
+Johnson,Merriam 2-01,,,Ballots Cast,,,,,,767
+Johnson,Merriam 2-02,,,Ballots Cast,,,,,,3
+Johnson,Merriam 2-03,,,Ballots Cast,,,,,,423
+Johnson,Merriam 3-01,,,Ballots Cast,,,,,,717
+Johnson,Merriam 3-02,,,Ballots Cast,,,,,,563
+Johnson,Merriam 4-01,,,Ballots Cast,,,,,,773
+Johnson,Merriam 4-02,,,Ballots Cast,,,,,,354
+Johnson,Merriam 4-03,,,Ballots Cast,,,,,,436
+Johnson,Mission 1-01,,,Ballots Cast,,,,,,712
+Johnson,Mission 1-02,,,Ballots Cast,,,,,,417
+Johnson,Mission 2-01,,,Ballots Cast,,,,,,435
+Johnson,Mission 2-02,,,Ballots Cast,,,,,,592
+Johnson,Mission 3-01,,,Ballots Cast,,,,,,746
+Johnson,Mission 3-02,,,Ballots Cast,,,,,,375
+Johnson,Mission 4-01,,,Ballots Cast,,,,,,439
+Johnson,Mission 4-02,,,Ballots Cast,,,,,,610
+Johnson,Mission 4-03,,,Ballots Cast,,,,,,370
+Johnson,Mission Hills 0-01,,,Ballots Cast,,,,,,548
+Johnson,Mission Hills 0-02,,,Ballots Cast,,,,,,690
+Johnson,Mission Hills 0-03,,,Ballots Cast,,,,,,442
+Johnson,Mission Hills 0-04,,,Ballots Cast,,,,,,699
+Johnson,Mission Woods 0-01,,,Ballots Cast,,,,,,112
+Johnson,Olathe 1-01,,,Ballots Cast,,,,,,830
+Johnson,Olathe 1-02,,,Ballots Cast,,,,,,544
+Johnson,Olathe 1-03,,,Ballots Cast,,,,,,472
+Johnson,Olathe 1-04,,,Ballots Cast,,,,,,840
+Johnson,Olathe 1-05,,,Ballots Cast,,,,,,841
+Johnson,Olathe 1-06,,,Ballots Cast,,,,,,553
+Johnson,Olathe 1-07,,,Ballots Cast,,,,,,0
+Johnson,Olathe 1-08,,,Ballots Cast,,,,,,1079
+Johnson,Olathe 1-09,,,Ballots Cast,,,,,,930
+Johnson,Olathe 1-10,,,Ballots Cast,,,,,,6
+Johnson,Olathe 1-11,,,Ballots Cast,,,,,,139
+Johnson,Olathe 1-12,,,Ballots Cast,,,,,,38
+Johnson,Olathe 1-13,,,Ballots Cast,,,,,,0
+Johnson,Olathe 1-14,,,Ballots Cast,,,,,,729
+Johnson,Olathe 1-15,,,Ballots Cast,,,,,,757
+Johnson,Olathe 1-16,,,Ballots Cast,,,,,,1039
+Johnson,Olathe 1-17,,,Ballots Cast,,,,,,202
+Johnson,Olathe 1-18,,,Ballots Cast,,,,,,220
+Johnson,Olathe 1-19,,,Ballots Cast,,,,,,384
+Johnson,Olathe 1-20,,,Ballots Cast,,,,,,619
+Johnson,Olathe 1-21,,,Ballots Cast,,,,,,1035
+Johnson,Olathe 1-22,,,Ballots Cast,,,,,,1147
+Johnson,Olathe 1-23,,,Ballots Cast,,,,,,0
+Johnson,Olathe 1-24,,,Ballots Cast,,,,,,0
+Johnson,Olathe 1-25,,,Ballots Cast,,,,,,0
+Johnson,Olathe 1-26,,,Ballots Cast,,,,,,4
+Johnson,Olathe 1-27,,,Ballots Cast,,,,,,574
+Johnson,Olathe 1-28,,,Ballots Cast,,,,,,214
+Johnson,Olathe 1-29,,,Ballots Cast,,,,,,131
+Johnson,Olathe 2-01,,,Ballots Cast,,,,,,384
+Johnson,Olathe 2-02,,,Ballots Cast,,,,,,456
+Johnson,Olathe 2-03,,,Ballots Cast,,,,,,642
+Johnson,Olathe 2-04,,,Ballots Cast,,,,,,776
+Johnson,Olathe 2-05,,,Ballots Cast,,,,,,1485
+Johnson,Olathe 2-06,,,Ballots Cast,,,,,,814
+Johnson,Olathe 2-07,,,Ballots Cast,,,,,,1052
+Johnson,Olathe 2-08,,,Ballots Cast,,,,,,954
+Johnson,Olathe 2-09,,,Ballots Cast,,,,,,359
+Johnson,Olathe 2-10,,,Ballots Cast,,,,,,1585
+Johnson,Olathe 2-11,,,Ballots Cast,,,,,,1145
+Johnson,Olathe 2-12,,,Ballots Cast,,,,,,605
+Johnson,Olathe 2-13,,,Ballots Cast,,,,,,700
+Johnson,Olathe 2-14,,,Ballots Cast,,,,,,657
+Johnson,Olathe 2-15,,,Ballots Cast,,,,,,472
+Johnson,Olathe 2-16,,,Ballots Cast,,,,,,0
+Johnson,Olathe 2-17,,,Ballots Cast,,,,,,0
+Johnson,Olathe 2-18,,,Ballots Cast,,,,,,0
+Johnson,Olathe 2-19,,,Ballots Cast,,,,,,8
+Johnson,Olathe 2-20,,,Ballots Cast,,,,,,0
+Johnson,Olathe 2-21,,,Ballots Cast,,,,,,0
+Johnson,Olathe 2-22,,,Ballots Cast,,,,,,1123
+Johnson,Olathe 2-23,,,Ballots Cast,,,,,,846
+Johnson,Olathe 2-24,,,Ballots Cast,,,,,,14
+Johnson,Olathe 2-25,,,Ballots Cast,,,,,,9
+Johnson,Olathe 2-26,,,Ballots Cast,,,,,,0
+Johnson,Olathe 2-27,,,Ballots Cast,,,,,,11
+Johnson,Olathe 2-28,,,Ballots Cast,,,,,,257
+Johnson,Olathe 3-01,,,Ballots Cast,,,,,,421
+Johnson,Olathe 3-02,,,Ballots Cast,,,,,,1088
+Johnson,Olathe 3-03,,,Ballots Cast,,,,,,547
+Johnson,Olathe 3-04,,,Ballots Cast,,,,,,926
+Johnson,Olathe 3-05,,,Ballots Cast,,,,,,812
+Johnson,Olathe 3-06,,,Ballots Cast,,,,,,636
+Johnson,Olathe 3-07,,,Ballots Cast,,,,,,638
+Johnson,Olathe 3-08,,,Ballots Cast,,,,,,943
+Johnson,Olathe 3-09,,,Ballots Cast,,,,,,521
+Johnson,Olathe 3-10,,,Ballots Cast,,,,,,1011
+Johnson,Olathe 3-11,,,Ballots Cast,,,,,,672
+Johnson,Olathe 3-12,,,Ballots Cast,,,,,,910
+Johnson,Olathe 3-13,,,Ballots Cast,,,,,,927
+Johnson,Olathe 3-14,,,Ballots Cast,,,,,,3
+Johnson,Olathe 3-15,,,Ballots Cast,,,,,,718
+Johnson,Olathe 3-16,,,Ballots Cast,,,,,,787
+Johnson,Olathe 3-17,,,Ballots Cast,,,,,,980
+Johnson,Olathe 3-18,,,Ballots Cast,,,,,,890
+Johnson,Olathe 3-19,,,Ballots Cast,,,,,,554
+Johnson,Olathe 3-20,,,Ballots Cast,,,,,,638
+Johnson,Olathe 3-21,,,Ballots Cast,,,,,,426
+Johnson,Olathe 3-22,,,Ballots Cast,,,,,,826
+Johnson,Olathe 3-23,,,Ballots Cast,,,,,,812
+Johnson,Olathe 3-24,,,Ballots Cast,,,,,,0
+Johnson,Olathe 3-25,,,Ballots Cast,,,,,,0
+Johnson,Olathe 3-26,,,Ballots Cast,,,,,,96
+Johnson,Olathe 3-27,,,Ballots Cast,,,,,,421
+Johnson,Olathe 4-01,,,Ballots Cast,,,,,,816
+Johnson,Olathe 4-02,,,Ballots Cast,,,,,,1116
+Johnson,Olathe 4-03,,,Ballots Cast,,,,,,532
+Johnson,Olathe 4-04,,,Ballots Cast,,,,,,540
+Johnson,Olathe 4-05,,,Ballots Cast,,,,,,823
+Johnson,Olathe 4-06,,,Ballots Cast,,,,,,1123
+Johnson,Olathe 4-07,,,Ballots Cast,,,,,,986
+Johnson,Olathe 4-08,,,Ballots Cast,,,,,,751
+Johnson,Olathe 4-09,,,Ballots Cast,,,,,,1085
+Johnson,Olathe 4-10,,,Ballots Cast,,,,,,615
+Johnson,Olathe 4-11,,,Ballots Cast,,,,,,450
+Johnson,Olathe 4-12,,,Ballots Cast,,,,,,1071
+Johnson,Olathe 4-13,,,Ballots Cast,,,,,,510
+Johnson,Olathe 4-14,,,Ballots Cast,,,,,,1016
+Johnson,Olathe 4-15,,,Ballots Cast,,,,,,93
+Johnson,Olathe 4-16,,,Ballots Cast,,,,,,3
+Johnson,Olathe 4-17,,,Ballots Cast,,,,,,5
+Johnson,Olathe 4-18,,,Ballots Cast,,,,,,351
+Johnson,Olathe Twp 0-01,,,Ballots Cast,,,,,,371
+Johnson,Olathe Twp 0-02,,,Ballots Cast,,,,,,69
+Johnson,Olathe Twp 0-03,,,Ballots Cast,,,,,,49
+Johnson,Olathe Twp 0-04,,,Ballots Cast,,,,,,2
+Johnson,Olathe Twp 0-05,,,Ballots Cast,,,,,,3
+Johnson,Olathe Twp 0-06,,,Ballots Cast,,,,,,1
+Johnson,Olathe Twp 0-07,,,Ballots Cast,,,,,,2
+Johnson,Olathe Twp 0-08,,,Ballots Cast,,,,,,16
+Johnson,Olathe Twp 0-09,,,Ballots Cast,,,,,,0
+Johnson,Olathe Twp 0-10,,,Ballots Cast,,,,,,19
+Johnson,Olathe Twp 0-11,,,Ballots Cast,,,,,,4
+Johnson,Olathe Twp 0-12,,,Ballots Cast,,,,,,0
+Johnson,Olathe Twp 0-13,,,Ballots Cast,,,,,,0
+Johnson,Olathe Twp 0-14,,,Ballots Cast,,,,,,1
+Johnson,Olathe Twp 0-17,,,Ballots Cast,,,,,,0
+Johnson,Olathe Twp 0-24,,,Ballots Cast,,,,,,3
+Johnson,Olathe Twp 0-25,,,Ballots Cast,,,,,,8
+Johnson,Olathe Twp 0-26,,,Ballots Cast,,,,,,4
+Johnson,Olathe Twp 0-27,,,Ballots Cast,,,,,,0
+Johnson,Olathe Twp 0-32,,,Ballots Cast,,,,,,30
+Johnson,Overland Park 1-01,,,Ballots Cast,,,,,,734
+Johnson,Overland Park 1-02,,,Ballots Cast,,,,,,762
+Johnson,Overland Park 1-03,,,Ballots Cast,,,,,,716
+Johnson,Overland Park 1-04,,,Ballots Cast,,,,,,275
+Johnson,Overland Park 1-05,,,Ballots Cast,,,,,,508
+Johnson,Overland Park 1-06,,,Ballots Cast,,,,,,856
+Johnson,Overland Park 1-07,,,Ballots Cast,,,,,,898
+Johnson,Overland Park 1-08,,,Ballots Cast,,,,,,712
+Johnson,Overland Park 1-09,,,Ballots Cast,,,,,,428
+Johnson,Overland Park 1-10,,,Ballots Cast,,,,,,830
+Johnson,Overland Park 1-11,,,Ballots Cast,,,,,,352
+Johnson,Overland Park 1-12,,,Ballots Cast,,,,,,829
+Johnson,Overland Park 1-13,,,Ballots Cast,,,,,,558
+Johnson,Overland Park 1-14,,,Ballots Cast,,,,,,736
+Johnson,Overland Park 1-15,,,Ballots Cast,,,,,,353
+Johnson,Overland Park 1-16,,,Ballots Cast,,,,,,857
+Johnson,Overland Park 1-17,,,Ballots Cast,,,,,,411
+Johnson,Overland Park 1-18,,,Ballots Cast,,,,,,651
+Johnson,Overland Park 1-19,,,Ballots Cast,,,,,,648
+Johnson,Overland Park 1-20,,,Ballots Cast,,,,,,414
+Johnson,Overland Park 1-21,,,Ballots Cast,,,,,,240
+Johnson,Overland Park 1-22,,,Ballots Cast,,,,,,182
+Johnson,Overland Park 2-01,,,Ballots Cast,,,,,,574
+Johnson,Overland Park 2-02,,,Ballots Cast,,,,,,643
+Johnson,Overland Park 2-03,,,Ballots Cast,,,,,,587
+Johnson,Overland Park 2-04,,,Ballots Cast,,,,,,715
+Johnson,Overland Park 2-05,,,Ballots Cast,,,,,,712
+Johnson,Overland Park 2-06,,,Ballots Cast,,,,,,665
+Johnson,Overland Park 2-07,,,Ballots Cast,,,,,,526
+Johnson,Overland Park 2-08,,,Ballots Cast,,,,,,462
+Johnson,Overland Park 2-09,,,Ballots Cast,,,,,,604
+Johnson,Overland Park 2-10,,,Ballots Cast,,,,,,480
+Johnson,Overland Park 2-11,,,Ballots Cast,,,,,,647
+Johnson,Overland Park 2-12,,,Ballots Cast,,,,,,504
+Johnson,Overland Park 2-13,,,Ballots Cast,,,,,,412
+Johnson,Overland Park 2-14,,,Ballots Cast,,,,,,461
+Johnson,Overland Park 2-15,,,Ballots Cast,,,,,,837
+Johnson,Overland Park 2-16,,,Ballots Cast,,,,,,523
+Johnson,Overland Park 2-17,,,Ballots Cast,,,,,,785
+Johnson,Overland Park 2-18,,,Ballots Cast,,,,,,866
+Johnson,Overland Park 2-19,,,Ballots Cast,,,,,,537
+Johnson,Overland Park 2-20,,,Ballots Cast,,,,,,485
+Johnson,Overland Park 2-21,,,Ballots Cast,,,,,,533
+Johnson,Overland Park 2-22,,,Ballots Cast,,,,,,653
+Johnson,Overland Park 2-23,,,Ballots Cast,,,,,,600
+Johnson,Overland Park 2-24,,,Ballots Cast,,,,,,1019
+Johnson,Overland Park 2-25,,,Ballots Cast,,,,,,700
+Johnson,Overland Park 2-26,,,Ballots Cast,,,,,,303
+Johnson,Overland Park 3-01,,,Ballots Cast,,,,,,1094
+Johnson,Overland Park 3-02,,,Ballots Cast,,,,,,685
+Johnson,Overland Park 3-03,,,Ballots Cast,,,,,,607
+Johnson,Overland Park 3-04,,,Ballots Cast,,,,,,844
+Johnson,Overland Park 3-05,,,Ballots Cast,,,,,,828
+Johnson,Overland Park 3-06,,,Ballots Cast,,,,,,917
+Johnson,Overland Park 3-07,,,Ballots Cast,,,,,,647
+Johnson,Overland Park 3-08,,,Ballots Cast,,,,,,687
+Johnson,Overland Park 3-09,,,Ballots Cast,,,,,,1024
+Johnson,Overland Park 3-10,,,Ballots Cast,,,,,,533
+Johnson,Overland Park 3-11,,,Ballots Cast,,,,,,739
+Johnson,Overland Park 3-12,,,Ballots Cast,,,,,,593
+Johnson,Overland Park 3-13,,,Ballots Cast,,,,,,1279
+Johnson,Overland Park 3-14,,,Ballots Cast,,,,,,886
+Johnson,Overland Park 3-15,,,Ballots Cast,,,,,,569
+Johnson,Overland Park 3-16,,,Ballots Cast,,,,,,683
+Johnson,Overland Park 3-17,,,Ballots Cast,,,,,,539
+Johnson,Overland Park 3-18,,,Ballots Cast,,,,,,707
+Johnson,Overland Park 3-19,,,Ballots Cast,,,,,,778
+Johnson,Overland Park 3-20,,,Ballots Cast,,,,,,924
+Johnson,Overland Park 4-01,,,Ballots Cast,,,,,,631
+Johnson,Overland Park 4-02,,,Ballots Cast,,,,,,1026
+Johnson,Overland Park 4-03,,,Ballots Cast,,,,,,1132
+Johnson,Overland Park 4-04,,,Ballots Cast,,,,,,1176
+Johnson,Overland Park 4-05,,,Ballots Cast,,,,,,888
+Johnson,Overland Park 4-06,,,Ballots Cast,,,,,,694
+Johnson,Overland Park 4-07,,,Ballots Cast,,,,,,590
+Johnson,Overland Park 4-08,,,Ballots Cast,,,,,,815
+Johnson,Overland Park 4-09,,,Ballots Cast,,,,,,769
+Johnson,Overland Park 4-10,,,Ballots Cast,,,,,,597
+Johnson,Overland Park 4-11,,,Ballots Cast,,,,,,952
+Johnson,Overland Park 4-12,,,Ballots Cast,,,,,,1284
+Johnson,Overland Park 4-13,,,Ballots Cast,,,,,,625
+Johnson,Overland Park 4-14,,,Ballots Cast,,,,,,499
+Johnson,Overland Park 4-15,,,Ballots Cast,,,,,,1137
+Johnson,Overland Park 4-16,,,Ballots Cast,,,,,,881
+Johnson,Overland Park 4-17,,,Ballots Cast,,,,,,952
+Johnson,Overland Park 4-18,,,Ballots Cast,,,,,,213
+Johnson,Overland Park 5-01,,,Ballots Cast,,,,,,856
+Johnson,Overland Park 5-02,,,Ballots Cast,,,,,,462
+Johnson,Overland Park 5-03,,,Ballots Cast,,,,,,656
+Johnson,Overland Park 5-04,,,Ballots Cast,,,,,,773
+Johnson,Overland Park 5-05,,,Ballots Cast,,,,,,668
+Johnson,Overland Park 5-06,,,Ballots Cast,,,,,,825
+Johnson,Overland Park 5-07,,,Ballots Cast,,,,,,1038
+Johnson,Overland Park 5-08,,,Ballots Cast,,,,,,1284
+Johnson,Overland Park 5-09,,,Ballots Cast,,,,,,1079
+Johnson,Overland Park 5-10,,,Ballots Cast,,,,,,870
+Johnson,Overland Park 5-11,,,Ballots Cast,,,,,,1058
+Johnson,Overland Park 5-12,,,Ballots Cast,,,,,,252
+Johnson,Overland Park 5-13,,,Ballots Cast,,,,,,1054
+Johnson,Overland Park 5-14,,,Ballots Cast,,,,,,856
+Johnson,Overland Park 5-15,,,Ballots Cast,,,,,,786
+Johnson,Overland Park 5-16,,,Ballots Cast,,,,,,544
+Johnson,Overland Park 5-17,,,Ballots Cast,,,,,,367
+Johnson,Overland Park 5-18,,,Ballots Cast,,,,,,693
+Johnson,Overland Park 5-19,,,Ballots Cast,,,,,,87
+Johnson,Overland Park 6-01,,,Ballots Cast,,,,,,1001
+Johnson,Overland Park 6-02,,,Ballots Cast,,,,,,799
+Johnson,Overland Park 6-03,,,Ballots Cast,,,,,,955
+Johnson,Overland Park 6-04,,,Ballots Cast,,,,,,953
+Johnson,Overland Park 6-05,,,Ballots Cast,,,,,,1050
+Johnson,Overland Park 6-06,,,Ballots Cast,,,,,,1
+Johnson,Overland Park 6-07,,,Ballots Cast,,,,,,267
+Johnson,Overland Park 6-08,,,Ballots Cast,,,,,,1131
+Johnson,Overland Park 6-09,,,Ballots Cast,,,,,,1154
+Johnson,Overland Park 6-10,,,Ballots Cast,,,,,,896
+Johnson,Overland Park 6-11,,,Ballots Cast,,,,,,850
+Johnson,Overland Park 6-12,,,Ballots Cast,,,,,,382
+Johnson,Overland Park 6-13,,,Ballots Cast,,,,,,1065
+Johnson,Overland Park 6-14,,,Ballots Cast,,,,,,3
+Johnson,Overland Park 6-15,,,Ballots Cast,,,,,,1099
+Johnson,Overland Park 6-16,,,Ballots Cast,,,,,,616
+Johnson,Overland Park 6-17,,,Ballots Cast,,,,,,881
+Johnson,Overland Park 6-18,,,Ballots Cast,,,,,,0
+Johnson,Overland Park 6-19,,,Ballots Cast,,,,,,1012
+Johnson,Overland Park 6-20,,,Ballots Cast,,,,,,436
+Johnson,Overland Park 6-21,,,Ballots Cast,,,,,,1193
+Johnson,Overland Park 6-22,,,Ballots Cast,,,,,,345
+Johnson,Overland Park 6-23,,,Ballots Cast,,,,,,178
+Johnson,Oxford Twp 0-01,,,Ballots Cast,,,,,,2
+Johnson,Oxford Twp 0-02,,,Ballots Cast,,,,,,591
+Johnson,Oxford Twp 0-03,,,Ballots Cast,,,,,,0
+Johnson,Oxford Twp 0-04,,,Ballots Cast,,,,,,508
+Johnson,Oxford Twp 0-05,,,Ballots Cast,,,,,,15
+Johnson,Oxford Twp 0-08,,,Ballots Cast,,,,,,0
+Johnson,Oxford Twp 0-09,,,Ballots Cast,,,,,,35
+Johnson,Oxford Twp 0-10,,,Ballots Cast,,,,,,2
+Johnson,Oxford Twp 0-11,,,Ballots Cast,,,,,,119
+Johnson,Prairie Village 1-01,,,Ballots Cast,,,,,,904
+Johnson,Prairie Village 1-02,,,Ballots Cast,,,,,,660
+Johnson,Prairie Village 1-03,,,Ballots Cast,,,,,,944
+Johnson,Prairie Village 2-01,,,Ballots Cast,,,,,,754
+Johnson,Prairie Village 2-02,,,Ballots Cast,,,,,,432
+Johnson,Prairie Village 2-03,,,Ballots Cast,,,,,,731
+Johnson,Prairie Village 3-01,,,Ballots Cast,,,,,,544
+Johnson,Prairie Village 3-02,,,Ballots Cast,,,,,,829
+Johnson,Prairie Village 3-03,,,Ballots Cast,,,,,,734
+Johnson,Prairie Village 4-01,,,Ballots Cast,,,,,,806
+Johnson,Prairie Village 4-02,,,Ballots Cast,,,,,,574
+Johnson,Prairie Village 4-03,,,Ballots Cast,,,,,,885
+Johnson,Prairie Village 5-01,,,Ballots Cast,,,,,,859
+Johnson,Prairie Village 5-02,,,Ballots Cast,,,,,,833
+Johnson,Prairie Village 5-03,,,Ballots Cast,,,,,,646
+Johnson,Prairie Village 6-01,,,Ballots Cast,,,,,,846
+Johnson,Prairie Village 6-02,,,Ballots Cast,,,,,,678
+Johnson,Prairie Village 6-03,,,Ballots Cast,,,,,,518
+Johnson,Roeland Park 1-01,,,Ballots Cast,,,,,,405
+Johnson,Roeland Park 1-02,,,Ballots Cast,,,,,,267
+Johnson,Roeland Park 1-03,,,Ballots Cast,,,,,,0
+Johnson,Roeland Park 2-01,,,Ballots Cast,,,,,,396
+Johnson,Roeland Park 2-02,,,Ballots Cast,,,,,,526
+Johnson,Roeland Park 3-01,,,Ballots Cast,,,,,,351
+Johnson,Roeland Park 3-02,,,Ballots Cast,,,,,,612
+Johnson,Roeland Park 4-01,,,Ballots Cast,,,,,,279
+Johnson,Roeland Park 4-02,,,Ballots Cast,,,,,,804
+Johnson,Shawnee 1-01,,,Ballots Cast,,,,,,904
+Johnson,Shawnee 1-02,,,Ballots Cast,,,,,,629
+Johnson,Shawnee 1-03,,,Ballots Cast,,,,,,641
+Johnson,Shawnee 1-04,,,Ballots Cast,,,,,,1060
+Johnson,Shawnee 1-05,,,Ballots Cast,,,,,,1085
+Johnson,Shawnee 1-06,,,Ballots Cast,,,,,,818
+Johnson,Shawnee 1-07,,,Ballots Cast,,,,,,920
+Johnson,Shawnee 1-08,,,Ballots Cast,,,,,,1030
+Johnson,Shawnee 1-09,,,Ballots Cast,,,,,,192
+Johnson,Shawnee 1-10,,,Ballots Cast,,,,,,305
+Johnson,Shawnee 1-11,,,Ballots Cast,,,,,,704
+Johnson,Shawnee 1-12,,,Ballots Cast,,,,,,9
+Johnson,Shawnee 2-01,,,Ballots Cast,,,,,,422
+Johnson,Shawnee 2-02,,,Ballots Cast,,,,,,745
+Johnson,Shawnee 2-03,,,Ballots Cast,,,,,,696
+Johnson,Shawnee 2-04,,,Ballots Cast,,,,,,920
+Johnson,Shawnee 2-05,,,Ballots Cast,,,,,,472
+Johnson,Shawnee 2-06,,,Ballots Cast,,,,,,607
+Johnson,Shawnee 2-07,,,Ballots Cast,,,,,,555
+Johnson,Shawnee 2-08,,,Ballots Cast,,,,,,503
+Johnson,Shawnee 2-09,,,Ballots Cast,,,,,,484
+Johnson,Shawnee 2-10,,,Ballots Cast,,,,,,433
+Johnson,Shawnee 2-11,,,Ballots Cast,,,,,,628
+Johnson,Shawnee 2-12,,,Ballots Cast,,,,,,223
+Johnson,Shawnee 2-13,,,Ballots Cast,,,,,,334
+Johnson,Shawnee 3-01,,,Ballots Cast,,,,,,620
+Johnson,Shawnee 3-02,,,Ballots Cast,,,,,,1113
+Johnson,Shawnee 3-03,,,Ballots Cast,,,,,,883
+Johnson,Shawnee 3-04,,,Ballots Cast,,,,,,788
+Johnson,Shawnee 3-05,,,Ballots Cast,,,,,,991
+Johnson,Shawnee 3-06,,,Ballots Cast,,,,,,925
+Johnson,Shawnee 3-07,,,Ballots Cast,,,,,,1065
+Johnson,Shawnee 3-08,,,Ballots Cast,,,,,,1015
+Johnson,Shawnee 3-09,,,Ballots Cast,,,,,,569
+Johnson,Shawnee 4-01,,,Ballots Cast,,,,,,1061
+Johnson,Shawnee 4-02,,,Ballots Cast,,,,,,614
+Johnson,Shawnee 4-03,,,Ballots Cast,,,,,,274
+Johnson,Shawnee 4-04,,,Ballots Cast,,,,,,394
+Johnson,Shawnee 4-05,,,Ballots Cast,,,,,,860
+Johnson,Shawnee 4-06,,,Ballots Cast,,,,,,723
+Johnson,Shawnee 4-07,,,Ballots Cast,,,,,,1069
+Johnson,Shawnee 4-08,,,Ballots Cast,,,,,,388
+Johnson,Shawnee 4-09,,,Ballots Cast,,,,,,1256
+Johnson,Shawnee 4-10,,,Ballots Cast,,,,,,0
+Johnson,Shawnee 4-11,,,Ballots Cast,,,,,,690
+Johnson,Shawnee 4-12,,,Ballots Cast,,,,,,0
+Johnson,Shawnee 4-13,,,Ballots Cast,,,,,,101
+Johnson,Spring Hill 0-01,,,Ballots Cast,,,,,,1320
+Johnson,Spring Hill 0-02,,,Ballots Cast,,,,,,0
+Johnson,Spring Hill 0-03,,,Ballots Cast,,,,,,42
+Johnson,Spring Hill 0-04,,,Ballots Cast,,,,,,0
+Johnson,Spring Hill Twp 0-01,,,Ballots Cast,,,,,,913
+Johnson,Spring Hill Twp 0-02,,,Ballots Cast,,,,,,2
+Johnson,Spring Hill Twp 0-03,,,Ballots Cast,,,,,,93
+Johnson,Spring Hill Twp 0-04,,,Ballots Cast,,,,,,18
+Johnson,Spring Hill Twp 0-05,,,Ballots Cast,,,,,,13
+Johnson,Westwood 0-01,,,Ballots Cast,,,,,,483
+Johnson,Westwood 0-02,,,Ballots Cast,,,,,,451
+Johnson,Westwood Hills 0-01,,,Ballots Cast,,,,,,249
+Johnson,Total,,,Ballots Cast,,,,,,275674
+Johnson,Aubry Twp 0-01,President,,Blank Votes,,,,,,0
+Johnson,Aubry Twp 0-02,President,,Blank Votes,,,,,,1
+Johnson,Aubry Twp 0-03,President,,Blank Votes,,,,,,0
+Johnson,Aubry Twp 0-04,President,,Blank Votes,,,,,,0
+Johnson,Aubry Twp 0-05,President,,Blank Votes,,,,,,0
+Johnson,Aubry Twp 0-06,President,,Blank Votes,,,,,,0
+Johnson,Bonner Springs 4-01,President,,Blank Votes,,,,,,0
+Johnson,De Soto 0-01,President,,Blank Votes,,,,,,5
+Johnson,De Soto 0-02,President,,Blank Votes,,,,,,0
+Johnson,De Soto 0-03,President,,Blank Votes,,,,,,5
+Johnson,De Soto 0-04,President,,Blank Votes,,,,,,0
+Johnson,De Soto 0-05,President,,Blank Votes,,,,,,0
+Johnson,De Soto 0-06,President,,Blank Votes,,,,,,0
+Johnson,De Soto 0-07,President,,Blank Votes,,,,,,0
+Johnson,De Soto 0-08,President,,Blank Votes,,,,,,0
+Johnson,Edgerton 0-01,President,,Blank Votes,,,,,,3
+Johnson,Edgerton 0-02,President,,Blank Votes,,,,,,0
+Johnson,Edgerton 0-03,President,,Blank Votes,,,,,,0
+Johnson,Edgerton 0-04,President,,Blank Votes,,,,,,0
+Johnson,Edgerton 0-05,President,,Blank Votes,,,,,,0
+Johnson,Edgerton 0-06,President,,Blank Votes,,,,,,0
+Johnson,Edgerton 0-07,President,,Blank Votes,,,,,,0
+Johnson,Edgerton 0-08,President,,Blank Votes,,,,,,0
+Johnson,Fairway 1-00,President,,Blank Votes,,,,,,0
+Johnson,Fairway 2-00,President,,Blank Votes,,,,,,2
+Johnson,Fairway 3-00,President,,Blank Votes,,,,,,0
+Johnson,Fairway 4-00,President,,Blank Votes,,,,,,2
+Johnson,Gardner 0-01,President,,Blank Votes,,,,,,0
+Johnson,Gardner 0-02,President,,Blank Votes,,,,,,0
+Johnson,Gardner 0-03,President,,Blank Votes,,,,,,0
+Johnson,Gardner 0-04,President,,Blank Votes,,,,,,1
+Johnson,Gardner 0-05,President,,Blank Votes,,,,,,0
+Johnson,Gardner 0-06,President,,Blank Votes,,,,,,1
+Johnson,Gardner 0-07,President,,Blank Votes,,,,,,0
+Johnson,Gardner 0-08,President,,Blank Votes,,,,,,0
+Johnson,Gardner 0-09,President,,Blank Votes,,,,,,0
+Johnson,Gardner 0-10,President,,Blank Votes,,,,,,1
+Johnson,Gardner 0-11,President,,Blank Votes,,,,,,0
+Johnson,Gardner 0-12,President,,Blank Votes,,,,,,0
+Johnson,Gardner 0-13,President,,Blank Votes,,,,,,1
+Johnson,Gardner 0-14,President,,Blank Votes,,,,,,4
+Johnson,Gardner 0-15,President,,Blank Votes,,,,,,0
+Johnson,Gardner Twp 0-01,President,,Blank Votes,,,,,,1
+Johnson,Gardner Twp 0-02,President,,Blank Votes,,,,,,1
+Johnson,Gardner Twp 0-03,President,,Blank Votes,,,,,,0
+Johnson,Gardner Twp 0-04,President,,Blank Votes,,,,,,0
+Johnson,Gardner Twp 0-05,President,,Blank Votes,,,,,,0
+Johnson,Gardner Twp 0-06,President,,Blank Votes,,,,,,0
+Johnson,Gardner Twp 0-07,President,,Blank Votes,,,,,,0
+Johnson,Gardner Twp 0-08,President,,Blank Votes,,,,,,0
+Johnson,Gardner Twp 0-09,President,,Blank Votes,,,,,,0
+Johnson,Gardner Twp 0-10,President,,Blank Votes,,,,,,0
+Johnson,Gardner Twp 0-11,President,,Blank Votes,,,,,,0
+Johnson,Gardner Twp 0-12,President,,Blank Votes,,,,,,0
+Johnson,Lake Quivira 0-01,President,,Blank Votes,,,,,,2
+Johnson,Leawood 1-01,President,,Blank Votes,,,,,,1
+Johnson,Leawood 1-02,President,,Blank Votes,,,,,,1
+Johnson,Leawood 1-03,President,,Blank Votes,,,,,,4
+Johnson,Leawood 1-04,President,,Blank Votes,,,,,,0
+Johnson,Leawood 1-05,President,,Blank Votes,,,,,,1
+Johnson,Leawood 1-06,President,,Blank Votes,,,,,,0
+Johnson,Leawood 2-01,President,,Blank Votes,,,,,,3
+Johnson,Leawood 2-02,President,,Blank Votes,,,,,,1
+Johnson,Leawood 2-03,President,,Blank Votes,,,,,,9
+Johnson,Leawood 2-04,President,,Blank Votes,,,,,,1
+Johnson,Leawood 2-05,President,,Blank Votes,,,,,,2
+Johnson,Leawood 2-06,President,,Blank Votes,,,,,,4
+Johnson,Leawood 3-01,President,,Blank Votes,,,,,,2
+Johnson,Leawood 3-02,President,,Blank Votes,,,,,,1
+Johnson,Leawood 3-03,President,,Blank Votes,,,,,,0
+Johnson,Leawood 3-04,President,,Blank Votes,,,,,,1
+Johnson,Leawood 3-05,President,,Blank Votes,,,,,,0
+Johnson,Leawood 3-06,President,,Blank Votes,,,,,,0
+Johnson,Leawood 3-07,President,,Blank Votes,,,,,,1
+Johnson,Leawood 4-01,President,,Blank Votes,,,,,,0
+Johnson,Leawood 4-02,President,,Blank Votes,,,,,,1
+Johnson,Leawood 4-03,President,,Blank Votes,,,,,,2
+Johnson,Leawood 4-04,President,,Blank Votes,,,,,,1
+Johnson,Leawood 4-05,President,,Blank Votes,,,,,,0
+Johnson,Leawood 4-06,President,,Blank Votes,,,,,,1
+Johnson,Leawood 4-07,President,,Blank Votes,,,,,,0
+Johnson,Leawood 4-08,President,,Blank Votes,,,,,,0
+Johnson,Lenexa 1-01,President,,Blank Votes,,,,,,0
+Johnson,Lenexa 1-02,President,,Blank Votes,,,,,,2
+Johnson,Lenexa 1-03,President,,Blank Votes,,,,,,4
+Johnson,Lenexa 1-04,President,,Blank Votes,,,,,,1
+Johnson,Lenexa 1-05,President,,Blank Votes,,,,,,2
+Johnson,Lenexa 1-06,President,,Blank Votes,,,,,,1
+Johnson,Lenexa 1-07,President,,Blank Votes,,,,,,1
+Johnson,Lenexa 1-08,President,,Blank Votes,,,,,,0
+Johnson,Lenexa 1-09,President,,Blank Votes,,,,,,0
+Johnson,Lenexa 2-01,President,,Blank Votes,,,,,,1
+Johnson,Lenexa 2-02,President,,Blank Votes,,,,,,0
+Johnson,Lenexa 2-03,President,,Blank Votes,,,,,,1
+Johnson,Lenexa 2-04,President,,Blank Votes,,,,,,0
+Johnson,Lenexa 2-05,President,,Blank Votes,,,,,,1
+Johnson,Lenexa 2-06,President,,Blank Votes,,,,,,0
+Johnson,Lenexa 2-07,President,,Blank Votes,,,,,,6
+Johnson,Lenexa 2-08,President,,Blank Votes,,,,,,0
+Johnson,Lenexa 3-01,President,,Blank Votes,,,,,,4
+Johnson,Lenexa 3-02,President,,Blank Votes,,,,,,1
+Johnson,Lenexa 3-03,President,,Blank Votes,,,,,,2
+Johnson,Lenexa 3-04,President,,Blank Votes,,,,,,2
+Johnson,Lenexa 3-05,President,,Blank Votes,,,,,,2
+Johnson,Lenexa 3-06,President,,Blank Votes,,,,,,1
+Johnson,Lenexa 3-07,President,,Blank Votes,,,,,,0
+Johnson,Lenexa 3-08,President,,Blank Votes,,,,,,1
+Johnson,Lenexa 4-01,President,,Blank Votes,,,,,,1
+Johnson,Lenexa 4-02,President,,Blank Votes,,,,,,2
+Johnson,Lenexa 4-03,President,,Blank Votes,,,,,,2
+Johnson,Lenexa 4-04,President,,Blank Votes,,,,,,3
+Johnson,Lenexa 4-05,President,,Blank Votes,,,,,,1
+Johnson,Lenexa 4-06,President,,Blank Votes,,,,,,0
+Johnson,Lenexa 4-07,President,,Blank Votes,,,,,,1
+Johnson,Lenexa 4-08,President,,Blank Votes,,,,,,6
+Johnson,Lenexa 4-09,President,,Blank Votes,,,,,,1
+Johnson,Lenexa 4-10,President,,Blank Votes,,,,,,0
+Johnson,Lenexa 4-11,President,,Blank Votes,,,,,,0
+Johnson,Lexington Twp 0-01,President,,Blank Votes,,,,,,0
+Johnson,Lexington Twp 0-02,President,,Blank Votes,,,,,,0
+Johnson,Lexington Twp 0-03,President,,Blank Votes,,,,,,0
+Johnson,Lexington Twp 0-04,President,,Blank Votes,,,,,,0
+Johnson,Lexington Twp 0-05,President,,Blank Votes,,,,,,0
+Johnson,McCamish Twp 0-01,President,,Blank Votes,,,,,,0
+Johnson,McCamish Twp 0-02,President,,Blank Votes,,,,,,4
+Johnson,McCamish Twp 0-03,President,,Blank Votes,,,,,,0
+Johnson,Merriam 1-01,President,,Blank Votes,,,,,,1
+Johnson,Merriam 1-02,President,,Blank Votes,,,,,,0
+Johnson,Merriam 2-01,President,,Blank Votes,,,,,,7
+Johnson,Merriam 2-02,President,,Blank Votes,,,,,,1
+Johnson,Merriam 2-03,President,,Blank Votes,,,,,,2
+Johnson,Merriam 3-01,President,,Blank Votes,,,,,,0
+Johnson,Merriam 3-02,President,,Blank Votes,,,,,,3
+Johnson,Merriam 4-01,President,,Blank Votes,,,,,,2
+Johnson,Merriam 4-02,President,,Blank Votes,,,,,,0
+Johnson,Merriam 4-03,President,,Blank Votes,,,,,,2
+Johnson,Mission 1-01,President,,Blank Votes,,,,,,2
+Johnson,Mission 1-02,President,,Blank Votes,,,,,,0
+Johnson,Mission 2-01,President,,Blank Votes,,,,,,1
+Johnson,Mission 2-02,President,,Blank Votes,,,,,,1
+Johnson,Mission 3-01,President,,Blank Votes,,,,,,1
+Johnson,Mission 3-02,President,,Blank Votes,,,,,,1
+Johnson,Mission 4-01,President,,Blank Votes,,,,,,2
+Johnson,Mission 4-02,President,,Blank Votes,,,,,,6
+Johnson,Mission 4-03,President,,Blank Votes,,,,,,2
+Johnson,Mission Hills 0-01,President,,Blank Votes,,,,,,0
+Johnson,Mission Hills 0-02,President,,Blank Votes,,,,,,1
+Johnson,Mission Hills 0-03,President,,Blank Votes,,,,,,0
+Johnson,Mission Hills 0-04,President,,Blank Votes,,,,,,4
+Johnson,Mission Woods 0-01,President,,Blank Votes,,,,,,0
+Johnson,Olathe 1-01,President,,Blank Votes,,,,,,3
+Johnson,Olathe 1-02,President,,Blank Votes,,,,,,1
+Johnson,Olathe 1-03,President,,Blank Votes,,,,,,1
+Johnson,Olathe 1-04,President,,Blank Votes,,,,,,1
+Johnson,Olathe 1-05,President,,Blank Votes,,,,,,1
+Johnson,Olathe 1-06,President,,Blank Votes,,,,,,2
+Johnson,Olathe 1-07,President,,Blank Votes,,,,,,0
+Johnson,Olathe 1-08,President,,Blank Votes,,,,,,1
+Johnson,Olathe 1-09,President,,Blank Votes,,,,,,1
+Johnson,Olathe 1-10,President,,Blank Votes,,,,,,0
+Johnson,Olathe 1-11,President,,Blank Votes,,,,,,0
+Johnson,Olathe 1-12,President,,Blank Votes,,,,,,0
+Johnson,Olathe 1-13,President,,Blank Votes,,,,,,0
+Johnson,Olathe 1-14,President,,Blank Votes,,,,,,1
+Johnson,Olathe 1-15,President,,Blank Votes,,,,,,0
+Johnson,Olathe 1-16,President,,Blank Votes,,,,,,2
+Johnson,Olathe 1-17,President,,Blank Votes,,,,,,0
+Johnson,Olathe 1-18,President,,Blank Votes,,,,,,0
+Johnson,Olathe 1-19,President,,Blank Votes,,,,,,2
+Johnson,Olathe 1-20,President,,Blank Votes,,,,,,2
+Johnson,Olathe 1-21,President,,Blank Votes,,,,,,2
+Johnson,Olathe 1-22,President,,Blank Votes,,,,,,5
+Johnson,Olathe 1-23,President,,Blank Votes,,,,,,0
+Johnson,Olathe 1-24,President,,Blank Votes,,,,,,0
+Johnson,Olathe 1-25,President,,Blank Votes,,,,,,0
+Johnson,Olathe 1-26,President,,Blank Votes,,,,,,0
+Johnson,Olathe 1-27,President,,Blank Votes,,,,,,2
+Johnson,Olathe 1-28,President,,Blank Votes,,,,,,0
+Johnson,Olathe 1-29,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-01,President,,Blank Votes,,,,,,1
+Johnson,Olathe 2-02,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-03,President,,Blank Votes,,,,,,4
+Johnson,Olathe 2-04,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-05,President,,Blank Votes,,,,,,1
+Johnson,Olathe 2-06,President,,Blank Votes,,,,,,2
+Johnson,Olathe 2-07,President,,Blank Votes,,,,,,1
+Johnson,Olathe 2-08,President,,Blank Votes,,,,,,1
+Johnson,Olathe 2-09,President,,Blank Votes,,,,,,1
+Johnson,Olathe 2-10,President,,Blank Votes,,,,,,4
+Johnson,Olathe 2-11,President,,Blank Votes,,,,,,4
+Johnson,Olathe 2-12,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-13,President,,Blank Votes,,,,,,1
+Johnson,Olathe 2-14,President,,Blank Votes,,,,,,2
+Johnson,Olathe 2-15,President,,Blank Votes,,,,,,3
+Johnson,Olathe 2-16,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-17,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-18,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-19,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-20,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-21,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-22,President,,Blank Votes,,,,,,1
+Johnson,Olathe 2-23,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-24,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-25,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-26,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-27,President,,Blank Votes,,,,,,0
+Johnson,Olathe 2-28,President,,Blank Votes,,,,,,0
+Johnson,Olathe 3-01,President,,Blank Votes,,,,,,0
+Johnson,Olathe 3-02,President,,Blank Votes,,,,,,2
+Johnson,Olathe 3-03,President,,Blank Votes,,,,,,0
+Johnson,Olathe 3-04,President,,Blank Votes,,,,,,2
+Johnson,Olathe 3-05,President,,Blank Votes,,,,,,2
+Johnson,Olathe 3-06,President,,Blank Votes,,,,,,3
+Johnson,Olathe 3-07,President,,Blank Votes,,,,,,3
+Johnson,Olathe 3-08,President,,Blank Votes,,,,,,2
+Johnson,Olathe 3-09,President,,Blank Votes,,,,,,2
+Johnson,Olathe 3-10,President,,Blank Votes,,,,,,3
+Johnson,Olathe 3-11,President,,Blank Votes,,,,,,1
+Johnson,Olathe 3-12,President,,Blank Votes,,,,,,2
+Johnson,Olathe 3-13,President,,Blank Votes,,,,,,0
+Johnson,Olathe 3-14,President,,Blank Votes,,,,,,0
+Johnson,Olathe 3-15,President,,Blank Votes,,,,,,1
+Johnson,Olathe 3-16,President,,Blank Votes,,,,,,1
+Johnson,Olathe 3-17,President,,Blank Votes,,,,,,1
+Johnson,Olathe 3-18,President,,Blank Votes,,,,,,3
+Johnson,Olathe 3-19,President,,Blank Votes,,,,,,1
+Johnson,Olathe 3-20,President,,Blank Votes,,,,,,2
+Johnson,Olathe 3-21,President,,Blank Votes,,,,,,0
+Johnson,Olathe 3-22,President,,Blank Votes,,,,,,3
+Johnson,Olathe 3-23,President,,Blank Votes,,,,,,0
+Johnson,Olathe 3-24,President,,Blank Votes,,,,,,0
+Johnson,Olathe 3-25,President,,Blank Votes,,,,,,0
+Johnson,Olathe 3-26,President,,Blank Votes,,,,,,0
+Johnson,Olathe 3-27,President,,Blank Votes,,,,,,1
+Johnson,Olathe 4-01,President,,Blank Votes,,,,,,2
+Johnson,Olathe 4-02,President,,Blank Votes,,,,,,2
+Johnson,Olathe 4-03,President,,Blank Votes,,,,,,1
+Johnson,Olathe 4-04,President,,Blank Votes,,,,,,1
+Johnson,Olathe 4-05,President,,Blank Votes,,,,,,1
+Johnson,Olathe 4-06,President,,Blank Votes,,,,,,5
+Johnson,Olathe 4-07,President,,Blank Votes,,,,,,1
+Johnson,Olathe 4-08,President,,Blank Votes,,,,,,0
+Johnson,Olathe 4-09,President,,Blank Votes,,,,,,1
+Johnson,Olathe 4-10,President,,Blank Votes,,,,,,0
+Johnson,Olathe 4-11,President,,Blank Votes,,,,,,0
+Johnson,Olathe 4-12,President,,Blank Votes,,,,,,1
+Johnson,Olathe 4-13,President,,Blank Votes,,,,,,1
+Johnson,Olathe 4-14,President,,Blank Votes,,,,,,5
+Johnson,Olathe 4-15,President,,Blank Votes,,,,,,0
+Johnson,Olathe 4-16,President,,Blank Votes,,,,,,0
+Johnson,Olathe 4-17,President,,Blank Votes,,,,,,0
+Johnson,Olathe 4-18,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-01,President,,Blank Votes,,,,,,3
+Johnson,Olathe Twp 0-02,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-03,President,,Blank Votes,,,,,,1
+Johnson,Olathe Twp 0-04,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-05,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-06,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-07,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-08,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-09,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-10,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-11,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-12,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-13,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-14,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-17,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-24,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-25,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-26,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-27,President,,Blank Votes,,,,,,0
+Johnson,Olathe Twp 0-32,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 1-01,President,,Blank Votes,,,,,,3
+Johnson,Overland Park 1-02,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 1-03,President,,Blank Votes,,,,,,3
+Johnson,Overland Park 1-04,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 1-05,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 1-06,President,,Blank Votes,,,,,,6
+Johnson,Overland Park 1-07,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 1-08,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 1-09,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 1-10,President,,Blank Votes,,,,,,4
+Johnson,Overland Park 1-11,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 1-12,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 1-13,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 1-14,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 1-15,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 1-16,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 1-17,President,,Blank Votes,,,,,,5
+Johnson,Overland Park 1-18,President,,Blank Votes,,,,,,3
+Johnson,Overland Park 1-19,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 1-20,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 1-21,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 1-22,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 2-01,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 2-02,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 2-03,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 2-04,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 2-05,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 2-06,President,,Blank Votes,,,,,,4
+Johnson,Overland Park 2-07,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 2-08,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 2-09,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 2-10,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 2-11,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 2-12,President,,Blank Votes,,,,,,3
+Johnson,Overland Park 2-13,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 2-14,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 2-15,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 2-16,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 2-17,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 2-18,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 2-19,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 2-20,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 2-21,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 2-22,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 2-23,President,,Blank Votes,,,,,,3
+Johnson,Overland Park 2-24,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 2-25,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 2-26,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 3-01,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 3-02,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 3-03,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 3-04,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 3-05,President,,Blank Votes,,,,,,4
+Johnson,Overland Park 3-06,President,,Blank Votes,,,,,,5
+Johnson,Overland Park 3-07,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 3-08,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 3-09,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 3-10,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 3-11,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 3-12,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 3-13,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 3-14,President,,Blank Votes,,,,,,4
+Johnson,Overland Park 3-15,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 3-16,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 3-17,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 3-18,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 3-19,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 3-20,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 4-01,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 4-02,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 4-03,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 4-04,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 4-05,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 4-06,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 4-07,President,,Blank Votes,,,,,,3
+Johnson,Overland Park 4-08,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 4-09,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 4-10,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 4-11,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 4-12,President,,Blank Votes,,,,,,4
+Johnson,Overland Park 4-13,President,,Blank Votes,,,,,,4
+Johnson,Overland Park 4-14,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 4-15,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 4-16,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 4-17,President,,Blank Votes,,,,,,4
+Johnson,Overland Park 4-18,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 5-01,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 5-02,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 5-03,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 5-04,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 5-05,President,,Blank Votes,,,,,,3
+Johnson,Overland Park 5-06,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 5-07,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 5-08,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 5-09,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 5-10,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 5-11,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 5-12,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 5-13,President,,Blank Votes,,,,,,3
+Johnson,Overland Park 5-14,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 5-15,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 5-16,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 5-17,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 5-18,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 5-19,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 6-01,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 6-02,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 6-03,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 6-04,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 6-05,President,,Blank Votes,,,,,,5
+Johnson,Overland Park 6-06,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 6-07,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 6-08,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 6-09,President,,Blank Votes,,,,,,4
+Johnson,Overland Park 6-10,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 6-11,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 6-12,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 6-13,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 6-14,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 6-15,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 6-16,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 6-17,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 6-18,President,,Blank Votes,,,,,,0
+Johnson,Overland Park 6-19,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 6-20,President,,Blank Votes,,,,,,1
+Johnson,Overland Park 6-21,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 6-22,President,,Blank Votes,,,,,,2
+Johnson,Overland Park 6-23,President,,Blank Votes,,,,,,0
+Johnson,Oxford Twp 0-01,President,,Blank Votes,,,,,,0
+Johnson,Oxford Twp 0-02,President,,Blank Votes,,,,,,0
+Johnson,Oxford Twp 0-03,President,,Blank Votes,,,,,,0
+Johnson,Oxford Twp 0-04,President,,Blank Votes,,,,,,1
+Johnson,Oxford Twp 0-05,President,,Blank Votes,,,,,,0
+Johnson,Oxford Twp 0-08,President,,Blank Votes,,,,,,0
+Johnson,Oxford Twp 0-09,President,,Blank Votes,,,,,,0
+Johnson,Oxford Twp 0-10,President,,Blank Votes,,,,,,0
+Johnson,Oxford Twp 0-11,President,,Blank Votes,,,,,,0
+Johnson,Prairie Village 1-01,President,,Blank Votes,,,,,,0
+Johnson,Prairie Village 1-02,President,,Blank Votes,,,,,,0
+Johnson,Prairie Village 1-03,President,,Blank Votes,,,,,,2
+Johnson,Prairie Village 2-01,President,,Blank Votes,,,,,,1
+Johnson,Prairie Village 2-02,President,,Blank Votes,,,,,,1
+Johnson,Prairie Village 2-03,President,,Blank Votes,,,,,,0
+Johnson,Prairie Village 3-01,President,,Blank Votes,,,,,,1
+Johnson,Prairie Village 3-02,President,,Blank Votes,,,,,,5
+Johnson,Prairie Village 3-03,President,,Blank Votes,,,,,,2
+Johnson,Prairie Village 4-01,President,,Blank Votes,,,,,,4
+Johnson,Prairie Village 4-02,President,,Blank Votes,,,,,,1
+Johnson,Prairie Village 4-03,President,,Blank Votes,,,,,,2
+Johnson,Prairie Village 5-01,President,,Blank Votes,,,,,,2
+Johnson,Prairie Village 5-02,President,,Blank Votes,,,,,,5
+Johnson,Prairie Village 5-03,President,,Blank Votes,,,,,,5
+Johnson,Prairie Village 6-01,President,,Blank Votes,,,,,,0
+Johnson,Prairie Village 6-02,President,,Blank Votes,,,,,,1
+Johnson,Prairie Village 6-03,President,,Blank Votes,,,,,,2
+Johnson,Roeland Park 1-01,President,,Blank Votes,,,,,,1
+Johnson,Roeland Park 1-02,President,,Blank Votes,,,,,,1
+Johnson,Roeland Park 1-03,President,,Blank Votes,,,,,,0
+Johnson,Roeland Park 2-01,President,,Blank Votes,,,,,,1
+Johnson,Roeland Park 2-02,President,,Blank Votes,,,,,,2
+Johnson,Roeland Park 3-01,President,,Blank Votes,,,,,,0
+Johnson,Roeland Park 3-02,President,,Blank Votes,,,,,,1
+Johnson,Roeland Park 4-01,President,,Blank Votes,,,,,,0
+Johnson,Roeland Park 4-02,President,,Blank Votes,,,,,,5
+Johnson,Shawnee 1-01,President,,Blank Votes,,,,,,4
+Johnson,Shawnee 1-02,President,,Blank Votes,,,,,,0
+Johnson,Shawnee 1-03,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 1-04,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 1-05,President,,Blank Votes,,,,,,0
+Johnson,Shawnee 1-06,President,,Blank Votes,,,,,,2
+Johnson,Shawnee 1-07,President,,Blank Votes,,,,,,2
+Johnson,Shawnee 1-08,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 1-09,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 1-10,President,,Blank Votes,,,,,,0
+Johnson,Shawnee 1-11,President,,Blank Votes,,,,,,0
+Johnson,Shawnee 1-12,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 2-01,President,,Blank Votes,,,,,,0
+Johnson,Shawnee 2-02,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 2-03,President,,Blank Votes,,,,,,4
+Johnson,Shawnee 2-04,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 2-05,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 2-06,President,,Blank Votes,,,,,,3
+Johnson,Shawnee 2-07,President,,Blank Votes,,,,,,3
+Johnson,Shawnee 2-08,President,,Blank Votes,,,,,,2
+Johnson,Shawnee 2-09,President,,Blank Votes,,,,,,2
+Johnson,Shawnee 2-10,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 2-11,President,,Blank Votes,,,,,,2
+Johnson,Shawnee 2-12,President,,Blank Votes,,,,,,3
+Johnson,Shawnee 2-13,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 3-01,President,,Blank Votes,,,,,,0
+Johnson,Shawnee 3-02,President,,Blank Votes,,,,,,0
+Johnson,Shawnee 3-03,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 3-04,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 3-05,President,,Blank Votes,,,,,,0
+Johnson,Shawnee 3-06,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 3-07,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 3-08,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 3-09,President,,Blank Votes,,,,,,3
+Johnson,Shawnee 4-01,President,,Blank Votes,,,,,,3
+Johnson,Shawnee 4-02,President,,Blank Votes,,,,,,0
+Johnson,Shawnee 4-03,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 4-04,President,,Blank Votes,,,,,,2
+Johnson,Shawnee 4-05,President,,Blank Votes,,,,,,3
+Johnson,Shawnee 4-06,President,,Blank Votes,,,,,,3
+Johnson,Shawnee 4-07,President,,Blank Votes,,,,,,2
+Johnson,Shawnee 4-08,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 4-09,President,,Blank Votes,,,,,,4
+Johnson,Shawnee 4-10,President,,Blank Votes,,,,,,0
+Johnson,Shawnee 4-11,President,,Blank Votes,,,,,,1
+Johnson,Shawnee 4-12,President,,Blank Votes,,,,,,0
+Johnson,Shawnee 4-13,President,,Blank Votes,,,,,,0
+Johnson,Spring Hill 0-01,President,,Blank Votes,,,,,,5
+Johnson,Spring Hill 0-02,President,,Blank Votes,,,,,,0
+Johnson,Spring Hill 0-03,President,,Blank Votes,,,,,,0
+Johnson,Spring Hill 0-04,President,,Blank Votes,,,,,,0
+Johnson,Spring Hill Twp 0-01,President,,Blank Votes,,,,,,4
+Johnson,Spring Hill Twp 0-02,President,,Blank Votes,,,,,,0
+Johnson,Spring Hill Twp 0-03,President,,Blank Votes,,,,,,0
+Johnson,Spring Hill Twp 0-04,President,,Blank Votes,,,,,,0
+Johnson,Spring Hill Twp 0-05,President,,Blank Votes,,,,,,0
+Johnson,Westwood 0-01,President,,Blank Votes,,,,,,2
+Johnson,Westwood 0-02,President,,Blank Votes,,,,,,2
+Johnson,Westwood Hills 0-01,President,,Blank Votes,,,,,,0
+Johnson,Total,President,,Blank Votes,,,,,,581
+Johnson,Aubry Twp 0-01,President,,Over Votes,,,,,,0
+Johnson,Aubry Twp 0-02,President,,Over Votes,,,,,,0
+Johnson,Aubry Twp 0-03,President,,Over Votes,,,,,,0
+Johnson,Aubry Twp 0-04,President,,Over Votes,,,,,,0
+Johnson,Aubry Twp 0-05,President,,Over Votes,,,,,,0
+Johnson,Aubry Twp 0-06,President,,Over Votes,,,,,,0
+Johnson,Bonner Springs 4-01,President,,Over Votes,,,,,,0
+Johnson,De Soto 0-01,President,,Over Votes,,,,,,0
+Johnson,De Soto 0-02,President,,Over Votes,,,,,,0
+Johnson,De Soto 0-03,President,,Over Votes,,,,,,0
+Johnson,De Soto 0-04,President,,Over Votes,,,,,,0
+Johnson,De Soto 0-05,President,,Over Votes,,,,,,0
+Johnson,De Soto 0-06,President,,Over Votes,,,,,,0
+Johnson,De Soto 0-07,President,,Over Votes,,,,,,0
+Johnson,De Soto 0-08,President,,Over Votes,,,,,,0
+Johnson,Edgerton 0-01,President,,Over Votes,,,,,,0
+Johnson,Edgerton 0-02,President,,Over Votes,,,,,,0
+Johnson,Edgerton 0-03,President,,Over Votes,,,,,,0
+Johnson,Edgerton 0-04,President,,Over Votes,,,,,,0
+Johnson,Edgerton 0-05,President,,Over Votes,,,,,,0
+Johnson,Edgerton 0-06,President,,Over Votes,,,,,,0
+Johnson,Edgerton 0-07,President,,Over Votes,,,,,,0
+Johnson,Edgerton 0-08,President,,Over Votes,,,,,,0
+Johnson,Fairway 1-00,President,,Over Votes,,,,,,0
+Johnson,Fairway 2-00,President,,Over Votes,,,,,,0
+Johnson,Fairway 3-00,President,,Over Votes,,,,,,0
+Johnson,Fairway 4-00,President,,Over Votes,,,,,,0
+Johnson,Gardner 0-01,President,,Over Votes,,,,,,0
+Johnson,Gardner 0-02,President,,Over Votes,,,,,,0
+Johnson,Gardner 0-03,President,,Over Votes,,,,,,1
+Johnson,Gardner 0-04,President,,Over Votes,,,,,,0
+Johnson,Gardner 0-05,President,,Over Votes,,,,,,0
+Johnson,Gardner 0-06,President,,Over Votes,,,,,,0
+Johnson,Gardner 0-07,President,,Over Votes,,,,,,0
+Johnson,Gardner 0-08,President,,Over Votes,,,,,,0
+Johnson,Gardner 0-09,President,,Over Votes,,,,,,0
+Johnson,Gardner 0-10,President,,Over Votes,,,,,,0
+Johnson,Gardner 0-11,President,,Over Votes,,,,,,0
+Johnson,Gardner 0-12,President,,Over Votes,,,,,,0
+Johnson,Gardner 0-13,President,,Over Votes,,,,,,0
+Johnson,Gardner 0-14,President,,Over Votes,,,,,,0
+Johnson,Gardner 0-15,President,,Over Votes,,,,,,0
+Johnson,Gardner Twp 0-01,President,,Over Votes,,,,,,0
+Johnson,Gardner Twp 0-02,President,,Over Votes,,,,,,0
+Johnson,Gardner Twp 0-03,President,,Over Votes,,,,,,0
+Johnson,Gardner Twp 0-04,President,,Over Votes,,,,,,0
+Johnson,Gardner Twp 0-05,President,,Over Votes,,,,,,0
+Johnson,Gardner Twp 0-06,President,,Over Votes,,,,,,0
+Johnson,Gardner Twp 0-07,President,,Over Votes,,,,,,0
+Johnson,Gardner Twp 0-08,President,,Over Votes,,,,,,0
+Johnson,Gardner Twp 0-09,President,,Over Votes,,,,,,0
+Johnson,Gardner Twp 0-10,President,,Over Votes,,,,,,0
+Johnson,Gardner Twp 0-11,President,,Over Votes,,,,,,0
+Johnson,Gardner Twp 0-12,President,,Over Votes,,,,,,0
+Johnson,Lake Quivira 0-01,President,,Over Votes,,,,,,0
+Johnson,Leawood 1-01,President,,Over Votes,,,,,,0
+Johnson,Leawood 1-02,President,,Over Votes,,,,,,0
+Johnson,Leawood 1-03,President,,Over Votes,,,,,,0
+Johnson,Leawood 1-04,President,,Over Votes,,,,,,0
+Johnson,Leawood 1-05,President,,Over Votes,,,,,,0
+Johnson,Leawood 1-06,President,,Over Votes,,,,,,0
+Johnson,Leawood 2-01,President,,Over Votes,,,,,,0
+Johnson,Leawood 2-02,President,,Over Votes,,,,,,0
+Johnson,Leawood 2-03,President,,Over Votes,,,,,,0
+Johnson,Leawood 2-04,President,,Over Votes,,,,,,0
+Johnson,Leawood 2-05,President,,Over Votes,,,,,,0
+Johnson,Leawood 2-06,President,,Over Votes,,,,,,0
+Johnson,Leawood 3-01,President,,Over Votes,,,,,,0
+Johnson,Leawood 3-02,President,,Over Votes,,,,,,0
+Johnson,Leawood 3-03,President,,Over Votes,,,,,,0
+Johnson,Leawood 3-04,President,,Over Votes,,,,,,0
+Johnson,Leawood 3-05,President,,Over Votes,,,,,,0
+Johnson,Leawood 3-06,President,,Over Votes,,,,,,0
+Johnson,Leawood 3-07,President,,Over Votes,,,,,,0
+Johnson,Leawood 4-01,President,,Over Votes,,,,,,0
+Johnson,Leawood 4-02,President,,Over Votes,,,,,,0
+Johnson,Leawood 4-03,President,,Over Votes,,,,,,0
+Johnson,Leawood 4-04,President,,Over Votes,,,,,,0
+Johnson,Leawood 4-05,President,,Over Votes,,,,,,0
+Johnson,Leawood 4-06,President,,Over Votes,,,,,,0
+Johnson,Leawood 4-07,President,,Over Votes,,,,,,0
+Johnson,Leawood 4-08,President,,Over Votes,,,,,,0
+Johnson,Lenexa 1-01,President,,Over Votes,,,,,,0
+Johnson,Lenexa 1-02,President,,Over Votes,,,,,,0
+Johnson,Lenexa 1-03,President,,Over Votes,,,,,,0
+Johnson,Lenexa 1-04,President,,Over Votes,,,,,,0
+Johnson,Lenexa 1-05,President,,Over Votes,,,,,,0
+Johnson,Lenexa 1-06,President,,Over Votes,,,,,,0
+Johnson,Lenexa 1-07,President,,Over Votes,,,,,,0
+Johnson,Lenexa 1-08,President,,Over Votes,,,,,,0
+Johnson,Lenexa 1-09,President,,Over Votes,,,,,,0
+Johnson,Lenexa 2-01,President,,Over Votes,,,,,,0
+Johnson,Lenexa 2-02,President,,Over Votes,,,,,,0
+Johnson,Lenexa 2-03,President,,Over Votes,,,,,,0
+Johnson,Lenexa 2-04,President,,Over Votes,,,,,,0
+Johnson,Lenexa 2-05,President,,Over Votes,,,,,,0
+Johnson,Lenexa 2-06,President,,Over Votes,,,,,,0
+Johnson,Lenexa 2-07,President,,Over Votes,,,,,,0
+Johnson,Lenexa 2-08,President,,Over Votes,,,,,,0
+Johnson,Lenexa 3-01,President,,Over Votes,,,,,,0
+Johnson,Lenexa 3-02,President,,Over Votes,,,,,,0
+Johnson,Lenexa 3-03,President,,Over Votes,,,,,,0
+Johnson,Lenexa 3-04,President,,Over Votes,,,,,,0
+Johnson,Lenexa 3-05,President,,Over Votes,,,,,,0
+Johnson,Lenexa 3-06,President,,Over Votes,,,,,,0
+Johnson,Lenexa 3-07,President,,Over Votes,,,,,,0
+Johnson,Lenexa 3-08,President,,Over Votes,,,,,,0
+Johnson,Lenexa 4-01,President,,Over Votes,,,,,,0
+Johnson,Lenexa 4-02,President,,Over Votes,,,,,,0
+Johnson,Lenexa 4-03,President,,Over Votes,,,,,,0
+Johnson,Lenexa 4-04,President,,Over Votes,,,,,,0
+Johnson,Lenexa 4-05,President,,Over Votes,,,,,,0
+Johnson,Lenexa 4-06,President,,Over Votes,,,,,,0
+Johnson,Lenexa 4-07,President,,Over Votes,,,,,,0
+Johnson,Lenexa 4-08,President,,Over Votes,,,,,,0
+Johnson,Lenexa 4-09,President,,Over Votes,,,,,,0
+Johnson,Lenexa 4-10,President,,Over Votes,,,,,,0
+Johnson,Lenexa 4-11,President,,Over Votes,,,,,,0
+Johnson,Lexington Twp 0-01,President,,Over Votes,,,,,,0
+Johnson,Lexington Twp 0-02,President,,Over Votes,,,,,,0
+Johnson,Lexington Twp 0-03,President,,Over Votes,,,,,,0
+Johnson,Lexington Twp 0-04,President,,Over Votes,,,,,,0
+Johnson,Lexington Twp 0-05,President,,Over Votes,,,,,,0
+Johnson,McCamish Twp 0-01,President,,Over Votes,,,,,,0
+Johnson,McCamish Twp 0-02,President,,Over Votes,,,,,,0
+Johnson,McCamish Twp 0-03,President,,Over Votes,,,,,,0
+Johnson,Merriam 1-01,President,,Over Votes,,,,,,0
+Johnson,Merriam 1-02,President,,Over Votes,,,,,,0
+Johnson,Merriam 2-01,President,,Over Votes,,,,,,0
+Johnson,Merriam 2-02,President,,Over Votes,,,,,,0
+Johnson,Merriam 2-03,President,,Over Votes,,,,,,0
+Johnson,Merriam 3-01,President,,Over Votes,,,,,,0
+Johnson,Merriam 3-02,President,,Over Votes,,,,,,0
+Johnson,Merriam 4-01,President,,Over Votes,,,,,,0
+Johnson,Merriam 4-02,President,,Over Votes,,,,,,0
+Johnson,Merriam 4-03,President,,Over Votes,,,,,,0
+Johnson,Mission 1-01,President,,Over Votes,,,,,,0
+Johnson,Mission 1-02,President,,Over Votes,,,,,,0
+Johnson,Mission 2-01,President,,Over Votes,,,,,,0
+Johnson,Mission 2-02,President,,Over Votes,,,,,,0
+Johnson,Mission 3-01,President,,Over Votes,,,,,,0
+Johnson,Mission 3-02,President,,Over Votes,,,,,,0
+Johnson,Mission 4-01,President,,Over Votes,,,,,,1
+Johnson,Mission 4-02,President,,Over Votes,,,,,,0
+Johnson,Mission 4-03,President,,Over Votes,,,,,,0
+Johnson,Mission Hills 0-01,President,,Over Votes,,,,,,0
+Johnson,Mission Hills 0-02,President,,Over Votes,,,,,,0
+Johnson,Mission Hills 0-03,President,,Over Votes,,,,,,0
+Johnson,Mission Hills 0-04,President,,Over Votes,,,,,,0
+Johnson,Mission Woods 0-01,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-01,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-02,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-03,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-04,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-05,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-06,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-07,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-08,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-09,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-10,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-11,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-12,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-13,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-14,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-15,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-16,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-17,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-18,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-19,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-20,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-21,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-22,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-23,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-24,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-25,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-26,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-27,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-28,President,,Over Votes,,,,,,0
+Johnson,Olathe 1-29,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-01,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-02,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-03,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-04,President,,Over Votes,,,,,,1
+Johnson,Olathe 2-05,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-06,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-07,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-08,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-09,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-10,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-11,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-12,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-13,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-14,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-15,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-16,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-17,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-18,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-19,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-20,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-21,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-22,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-23,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-24,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-25,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-26,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-27,President,,Over Votes,,,,,,0
+Johnson,Olathe 2-28,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-01,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-02,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-03,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-04,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-05,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-06,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-07,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-08,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-09,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-10,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-11,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-12,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-13,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-14,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-15,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-16,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-17,President,,Over Votes,,,,,,1
+Johnson,Olathe 3-18,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-19,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-20,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-21,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-22,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-23,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-24,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-25,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-26,President,,Over Votes,,,,,,0
+Johnson,Olathe 3-27,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-01,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-02,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-03,President,,Over Votes,,,,,,4
+Johnson,Olathe 4-04,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-05,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-06,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-07,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-08,President,,Over Votes,,,,,,1
+Johnson,Olathe 4-09,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-10,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-11,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-12,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-13,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-14,President,,Over Votes,,,,,,1
+Johnson,Olathe 4-15,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-16,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-17,President,,Over Votes,,,,,,0
+Johnson,Olathe 4-18,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-01,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-02,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-03,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-04,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-05,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-06,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-07,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-08,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-09,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-10,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-11,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-12,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-13,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-14,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-17,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-24,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-25,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-26,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-27,President,,Over Votes,,,,,,0
+Johnson,Olathe Twp 0-32,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-01,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-02,President,,Over Votes,,,,,,1
+Johnson,Overland Park 1-03,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-04,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-05,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-06,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-07,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-08,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-09,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-10,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-11,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-12,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-13,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-14,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-15,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-16,President,,Over Votes,,,,,,1
+Johnson,Overland Park 1-17,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-18,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-19,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-20,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-21,President,,Over Votes,,,,,,0
+Johnson,Overland Park 1-22,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-01,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-02,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-03,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-04,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-05,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-06,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-07,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-08,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-09,President,,Over Votes,,,,,,2
+Johnson,Overland Park 2-10,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-11,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-12,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-13,President,,Over Votes,,,,,,1
+Johnson,Overland Park 2-14,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-15,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-16,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-17,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-18,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-19,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-20,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-21,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-22,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-23,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-24,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-25,President,,Over Votes,,,,,,0
+Johnson,Overland Park 2-26,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-01,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-02,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-03,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-04,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-05,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-06,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-07,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-08,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-09,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-10,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-11,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-12,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-13,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-14,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-15,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-16,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-17,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-18,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-19,President,,Over Votes,,,,,,0
+Johnson,Overland Park 3-20,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-01,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-02,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-03,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-04,President,,Over Votes,,,,,,1
+Johnson,Overland Park 4-05,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-06,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-07,President,,Over Votes,,,,,,1
+Johnson,Overland Park 4-08,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-09,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-10,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-11,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-12,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-13,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-14,President,,Over Votes,,,,,,1
+Johnson,Overland Park 4-15,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-16,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-17,President,,Over Votes,,,,,,0
+Johnson,Overland Park 4-18,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-01,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-02,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-03,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-04,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-05,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-06,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-07,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-08,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-09,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-10,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-11,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-12,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-13,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-14,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-15,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-16,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-17,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-18,President,,Over Votes,,,,,,0
+Johnson,Overland Park 5-19,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-01,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-02,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-03,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-04,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-05,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-06,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-07,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-08,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-09,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-10,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-11,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-12,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-13,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-14,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-15,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-16,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-17,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-18,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-19,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-20,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-21,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-22,President,,Over Votes,,,,,,0
+Johnson,Overland Park 6-23,President,,Over Votes,,,,,,0
+Johnson,Oxford Twp 0-01,President,,Over Votes,,,,,,0
+Johnson,Oxford Twp 0-02,President,,Over Votes,,,,,,0
+Johnson,Oxford Twp 0-03,President,,Over Votes,,,,,,0
+Johnson,Oxford Twp 0-04,President,,Over Votes,,,,,,0
+Johnson,Oxford Twp 0-05,President,,Over Votes,,,,,,0
+Johnson,Oxford Twp 0-08,President,,Over Votes,,,,,,0
+Johnson,Oxford Twp 0-09,President,,Over Votes,,,,,,0
+Johnson,Oxford Twp 0-10,President,,Over Votes,,,,,,0
+Johnson,Oxford Twp 0-11,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 1-01,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 1-02,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 1-03,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 2-01,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 2-02,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 2-03,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 3-01,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 3-02,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 3-03,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 4-01,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 4-02,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 4-03,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 5-01,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 5-02,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 5-03,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 6-01,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 6-02,President,,Over Votes,,,,,,0
+Johnson,Prairie Village 6-03,President,,Over Votes,,,,,,0
+Johnson,Roeland Park 1-01,President,,Over Votes,,,,,,0
+Johnson,Roeland Park 1-02,President,,Over Votes,,,,,,0
+Johnson,Roeland Park 1-03,President,,Over Votes,,,,,,0
+Johnson,Roeland Park 2-01,President,,Over Votes,,,,,,0
+Johnson,Roeland Park 2-02,President,,Over Votes,,,,,,0
+Johnson,Roeland Park 3-01,President,,Over Votes,,,,,,0
+Johnson,Roeland Park 3-02,President,,Over Votes,,,,,,0
+Johnson,Roeland Park 4-01,President,,Over Votes,,,,,,0
+Johnson,Roeland Park 4-02,President,,Over Votes,,,,,,0
+Johnson,Shawnee 1-01,President,,Over Votes,,,,,,0
+Johnson,Shawnee 1-02,President,,Over Votes,,,,,,0
+Johnson,Shawnee 1-03,President,,Over Votes,,,,,,0
+Johnson,Shawnee 1-04,President,,Over Votes,,,,,,0
+Johnson,Shawnee 1-05,President,,Over Votes,,,,,,0
+Johnson,Shawnee 1-06,President,,Over Votes,,,,,,0
+Johnson,Shawnee 1-07,President,,Over Votes,,,,,,0
+Johnson,Shawnee 1-08,President,,Over Votes,,,,,,0
+Johnson,Shawnee 1-09,President,,Over Votes,,,,,,0
+Johnson,Shawnee 1-10,President,,Over Votes,,,,,,0
+Johnson,Shawnee 1-11,President,,Over Votes,,,,,,0
+Johnson,Shawnee 1-12,President,,Over Votes,,,,,,0
+Johnson,Shawnee 2-01,President,,Over Votes,,,,,,0
+Johnson,Shawnee 2-02,President,,Over Votes,,,,,,0
+Johnson,Shawnee 2-03,President,,Over Votes,,,,,,0
+Johnson,Shawnee 2-04,President,,Over Votes,,,,,,0
+Johnson,Shawnee 2-05,President,,Over Votes,,,,,,1
+Johnson,Shawnee 2-06,President,,Over Votes,,,,,,0
+Johnson,Shawnee 2-07,President,,Over Votes,,,,,,0
+Johnson,Shawnee 2-08,President,,Over Votes,,,,,,0
+Johnson,Shawnee 2-09,President,,Over Votes,,,,,,0
+Johnson,Shawnee 2-10,President,,Over Votes,,,,,,0
+Johnson,Shawnee 2-11,President,,Over Votes,,,,,,0
+Johnson,Shawnee 2-12,President,,Over Votes,,,,,,0
+Johnson,Shawnee 2-13,President,,Over Votes,,,,,,0
+Johnson,Shawnee 3-01,President,,Over Votes,,,,,,0
+Johnson,Shawnee 3-02,President,,Over Votes,,,,,,0
+Johnson,Shawnee 3-03,President,,Over Votes,,,,,,0
+Johnson,Shawnee 3-04,President,,Over Votes,,,,,,0
+Johnson,Shawnee 3-05,President,,Over Votes,,,,,,0
+Johnson,Shawnee 3-06,President,,Over Votes,,,,,,0
+Johnson,Shawnee 3-07,President,,Over Votes,,,,,,0
+Johnson,Shawnee 3-08,President,,Over Votes,,,,,,0
+Johnson,Shawnee 3-09,President,,Over Votes,,,,,,0
+Johnson,Shawnee 4-01,President,,Over Votes,,,,,,0
+Johnson,Shawnee 4-02,President,,Over Votes,,,,,,0
+Johnson,Shawnee 4-03,President,,Over Votes,,,,,,0
+Johnson,Shawnee 4-04,President,,Over Votes,,,,,,0
+Johnson,Shawnee 4-05,President,,Over Votes,,,,,,0
+Johnson,Shawnee 4-06,President,,Over Votes,,,,,,0
+Johnson,Shawnee 4-07,President,,Over Votes,,,,,,0
+Johnson,Shawnee 4-08,President,,Over Votes,,,,,,0
+Johnson,Shawnee 4-09,President,,Over Votes,,,,,,0
+Johnson,Shawnee 4-10,President,,Over Votes,,,,,,0
+Johnson,Shawnee 4-11,President,,Over Votes,,,,,,0
+Johnson,Shawnee 4-12,President,,Over Votes,,,,,,0
+Johnson,Shawnee 4-13,President,,Over Votes,,,,,,0
+Johnson,Spring Hill 0-01,President,,Over Votes,,,,,,0
+Johnson,Spring Hill 0-02,President,,Over Votes,,,,,,0
+Johnson,Spring Hill 0-03,President,,Over Votes,,,,,,0
+Johnson,Spring Hill 0-04,President,,Over Votes,,,,,,0
+Johnson,Spring Hill Twp 0-01,President,,Over Votes,,,,,,0
+Johnson,Spring Hill Twp 0-02,President,,Over Votes,,,,,,0
+Johnson,Spring Hill Twp 0-03,President,,Over Votes,,,,,,0
+Johnson,Spring Hill Twp 0-04,President,,Over Votes,,,,,,0
+Johnson,Spring Hill Twp 0-05,President,,Over Votes,,,,,,0
+Johnson,Westwood 0-01,President,,Over Votes,,,,,,0
+Johnson,Westwood 0-02,President,,Over Votes,,,,,,0
+Johnson,Westwood Hills 0-01,President,,Over Votes,,,,,,0
+Johnson,Total,President,,Over Votes,,,,,,19
+Johnson,Aubry Twp 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Aubry Twp 0-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Aubry Twp 0-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Aubry Twp 0-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Aubry Twp 0-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Aubry Twp 0-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Bonner Springs 4-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,De Soto 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,De Soto 0-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,De Soto 0-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,De Soto 0-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,De Soto 0-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,De Soto 0-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,De Soto 0-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,De Soto 0-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Edgerton 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Edgerton 0-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Edgerton 0-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Edgerton 0-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Edgerton 0-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Edgerton 0-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Edgerton 0-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Edgerton 0-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Fairway 1-00,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Fairway 2-00,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Fairway 3-00,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Fairway 4-00,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Gardner 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Gardner 0-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner 0-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner 0-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Gardner 0-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner 0-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Gardner 0-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner 0-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner 0-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Gardner 0-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Gardner 0-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner 0-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner 0-13,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Gardner 0-14,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,5
+Johnson,Gardner 0-15,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner Twp 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Gardner Twp 0-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner Twp 0-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner Twp 0-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner Twp 0-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner Twp 0-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner Twp 0-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner Twp 0-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner Twp 0-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner Twp 0-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Gardner Twp 0-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Gardner Twp 0-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lake Quivira 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Leawood 1-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Leawood 1-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Leawood 1-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Leawood 1-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Leawood 1-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Leawood 1-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Leawood 2-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Leawood 2-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Leawood 2-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Leawood 2-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Leawood 2-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Leawood 2-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Leawood 3-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Leawood 3-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Leawood 3-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Leawood 3-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Leawood 3-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Leawood 3-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Leawood 3-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Leawood 4-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Leawood 4-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Leawood 4-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Leawood 4-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Leawood 4-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Leawood 4-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Leawood 4-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Leawood 4-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Lenexa 1-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lenexa 1-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,5
+Johnson,Lenexa 1-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Lenexa 1-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Lenexa 1-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Lenexa 1-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lenexa 1-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Lenexa 1-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lenexa 1-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lenexa 2-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Lenexa 2-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lenexa 2-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Lenexa 2-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Lenexa 2-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Lenexa 2-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lenexa 2-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Lenexa 2-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lenexa 3-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Lenexa 3-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lenexa 3-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Lenexa 3-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Lenexa 3-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Lenexa 3-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Lenexa 3-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Lenexa 3-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Lenexa 4-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Lenexa 4-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Lenexa 4-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lenexa 4-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Lenexa 4-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Lenexa 4-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Lenexa 4-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Lenexa 4-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Lenexa 4-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Lenexa 4-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Lenexa 4-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lexington Twp 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lexington Twp 0-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lexington Twp 0-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lexington Twp 0-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Lexington Twp 0-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,McCamish Twp 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,McCamish Twp 0-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,McCamish Twp 0-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Merriam 1-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Merriam 1-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,5
+Johnson,Merriam 2-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Merriam 2-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Merriam 2-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Merriam 3-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Merriam 3-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Merriam 4-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Merriam 4-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Merriam 4-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Mission 1-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Mission 1-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Mission 2-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Mission 2-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Mission 3-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Mission 3-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Mission 4-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Mission 4-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Mission 4-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Mission Hills 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Mission Hills 0-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Mission Hills 0-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Mission Hills 0-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Mission Woods 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 1-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,5
+Johnson,Olathe 1-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 1-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 1-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Olathe 1-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Olathe 1-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 1-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 1-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 1-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 1-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 1-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 1-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 1-13,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 1-14,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 1-15,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 1-16,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Olathe 1-17,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 1-18,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 1-19,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Olathe 1-20,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,5
+Johnson,Olathe 1-21,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Olathe 1-22,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Olathe 1-23,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 1-24,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 1-25,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 1-26,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 1-27,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 1-28,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 1-29,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 2-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 2-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Olathe 2-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 2-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 2-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 2-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 2-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Olathe 2-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,7
+Johnson,Olathe 2-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 2-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,7
+Johnson,Olathe 2-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Olathe 2-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Olathe 2-13,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 2-14,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 2-15,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 2-16,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 2-17,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 2-18,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 2-19,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 2-20,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 2-21,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 2-22,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 2-23,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 2-24,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 2-25,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 2-26,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 2-27,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 2-28,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 3-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 3-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 3-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 3-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 3-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 3-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Olathe 3-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 3-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 3-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Olathe 3-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 3-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 3-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,6
+Johnson,Olathe 3-13,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 3-14,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 3-15,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 3-16,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 3-17,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 3-18,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 3-19,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 3-20,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 3-21,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 3-22,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 3-23,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 3-24,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 3-25,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 3-26,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 3-27,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 4-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 4-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 4-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Olathe 4-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 4-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 4-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Olathe 4-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 4-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe 4-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Olathe 4-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 4-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 4-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Olathe 4-13,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Olathe 4-14,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe 4-15,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 4-16,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 4-17,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe 4-18,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe Twp 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Olathe Twp 0-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Olathe Twp 0-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-13,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-14,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-17,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-24,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-25,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-26,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-27,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Olathe Twp 0-32,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 1-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 1-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 1-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 1-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 1-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 1-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 1-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 1-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 1-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 1-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,6
+Johnson,Overland Park 1-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 1-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,5
+Johnson,Overland Park 1-13,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 1-14,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Overland Park 1-15,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 1-16,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 1-17,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,5
+Johnson,Overland Park 1-18,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 1-19,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 1-20,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 1-21,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 1-22,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 2-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 2-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 2-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 2-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 2-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 2-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 2-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 2-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 2-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Overland Park 2-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 2-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 2-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 2-13,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 2-14,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 2-15,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 2-16,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 2-17,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 2-18,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 2-19,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 2-20,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 2-21,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 2-22,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 2-23,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 2-24,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 2-25,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 2-26,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 3-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 3-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 3-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 3-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 3-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 3-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Overland Park 3-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 3-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 3-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 3-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 3-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 3-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 3-13,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Overland Park 3-14,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Overland Park 3-15,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 3-16,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 3-17,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 3-18,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 3-19,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 3-20,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 4-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 4-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 4-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 4-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 4-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 4-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 4-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 4-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 4-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 4-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 4-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 4-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 4-13,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 4-14,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 4-15,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 4-16,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 4-17,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 4-18,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 5-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 5-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 5-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Overland Park 5-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 5-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 5-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 5-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 5-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 5-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 5-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 5-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 5-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 5-13,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 5-14,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 5-15,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 5-16,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 5-17,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 5-18,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 5-19,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 6-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 6-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 6-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 6-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 6-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 6-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 6-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 6-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 6-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 6-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Overland Park 6-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Overland Park 6-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 6-13,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 6-14,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 6-15,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 6-16,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 6-17,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 6-18,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 6-19,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,5
+Johnson,Overland Park 6-20,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 6-21,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Overland Park 6-22,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Overland Park 6-23,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Oxford Twp 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Oxford Twp 0-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Oxford Twp 0-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Oxford Twp 0-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Oxford Twp 0-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Oxford Twp 0-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Oxford Twp 0-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Oxford Twp 0-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Oxford Twp 0-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Prairie Village 1-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Prairie Village 1-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Prairie Village 1-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Prairie Village 2-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Prairie Village 2-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Prairie Village 2-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Prairie Village 3-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Prairie Village 3-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Prairie Village 3-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Prairie Village 4-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Prairie Village 4-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Prairie Village 4-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Prairie Village 5-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Prairie Village 5-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Prairie Village 5-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Prairie Village 6-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Prairie Village 6-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Prairie Village 6-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Roeland Park 1-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Roeland Park 1-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Roeland Park 1-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Roeland Park 2-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Roeland Park 2-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Roeland Park 3-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Roeland Park 3-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Roeland Park 4-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Roeland Park 4-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Shawnee 1-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,6
+Johnson,Shawnee 1-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Shawnee 1-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,7
+Johnson,Shawnee 1-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Shawnee 1-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Shawnee 1-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Shawnee 1-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Shawnee 1-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Shawnee 1-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Shawnee 1-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Shawnee 1-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Shawnee 1-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Shawnee 2-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Shawnee 2-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Shawnee 2-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Shawnee 2-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Shawnee 2-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Shawnee 2-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Shawnee 2-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Shawnee 2-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Shawnee 2-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Shawnee 2-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Shawnee 2-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,4
+Johnson,Shawnee 2-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Shawnee 2-13,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Shawnee 3-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Shawnee 3-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Shawnee 3-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Shawnee 3-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Shawnee 3-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Shawnee 3-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Shawnee 3-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Shawnee 3-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Shawnee 3-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Shawnee 4-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Shawnee 4-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Shawnee 4-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Shawnee 4-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Shawnee 4-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Shawnee 4-06,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Shawnee 4-07,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Shawnee 4-08,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Shawnee 4-09,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Shawnee 4-10,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Shawnee 4-11,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,2
+Johnson,Shawnee 4-12,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Shawnee 4-13,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Spring Hill 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,5
+Johnson,Spring Hill 0-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Spring Hill 0-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Spring Hill 0-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Spring Hill Twp 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,3
+Johnson,Spring Hill Twp 0-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Spring Hill Twp 0-03,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Spring Hill Twp 0-04,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Spring Hill Twp 0-05,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Westwood 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Westwood 0-02,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,1
+Johnson,Westwood Hills 0-01,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,0
+Johnson,Total,President,,"Baldwin, Chuck",Chuck,,Baldwin,,Reform,611
+Johnson,Aubry Twp 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Aubry Twp 0-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,15
+Johnson,Aubry Twp 0-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Aubry Twp 0-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Aubry Twp 0-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Aubry Twp 0-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,2
+Johnson,Bonner Springs 4-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,De Soto 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,21
+Johnson,De Soto 0-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,De Soto 0-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,De Soto 0-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,De Soto 0-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,De Soto 0-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,De Soto 0-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,De Soto 0-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Edgerton 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,20
+Johnson,Edgerton 0-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Edgerton 0-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Edgerton 0-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Edgerton 0-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Edgerton 0-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Edgerton 0-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Edgerton 0-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Fairway 1-00,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Fairway 2-00,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Fairway 3-00,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Fairway 4-00,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Gardner 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,23
+Johnson,Gardner 0-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Gardner 0-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,28
+Johnson,Gardner 0-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,19
+Johnson,Gardner 0-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Gardner 0-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,30
+Johnson,Gardner 0-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Gardner 0-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Gardner 0-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,19
+Johnson,Gardner 0-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,22
+Johnson,Gardner 0-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Gardner 0-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Gardner 0-13,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Gardner 0-14,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Gardner 0-15,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Gardner Twp 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Gardner Twp 0-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Gardner Twp 0-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Gardner Twp 0-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Gardner Twp 0-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Gardner Twp 0-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Gardner Twp 0-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Gardner Twp 0-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Gardner Twp 0-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Gardner Twp 0-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Gardner Twp 0-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Gardner Twp 0-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Lake Quivira 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,3
+Johnson,Leawood 1-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Leawood 1-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Leawood 1-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Leawood 1-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Leawood 1-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Leawood 1-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Leawood 2-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Leawood 2-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,15
+Johnson,Leawood 2-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Leawood 2-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Leawood 2-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Leawood 2-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Leawood 3-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Leawood 3-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Leawood 3-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Leawood 3-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,2
+Johnson,Leawood 3-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,19
+Johnson,Leawood 3-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Leawood 3-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Leawood 4-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,2
+Johnson,Leawood 4-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Leawood 4-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Leawood 4-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Leawood 4-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Leawood 4-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Leawood 4-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Leawood 4-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Lenexa 1-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Lenexa 1-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Lenexa 1-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,17
+Johnson,Lenexa 1-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,17
+Johnson,Lenexa 1-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,25
+Johnson,Lenexa 1-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Lenexa 1-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Lenexa 1-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Lenexa 1-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Lenexa 2-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Lenexa 2-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,3
+Johnson,Lenexa 2-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Lenexa 2-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Lenexa 2-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,21
+Johnson,Lenexa 2-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Lenexa 2-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,26
+Johnson,Lenexa 2-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Lenexa 3-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Lenexa 3-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,17
+Johnson,Lenexa 3-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,25
+Johnson,Lenexa 3-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,23
+Johnson,Lenexa 3-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Lenexa 3-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,17
+Johnson,Lenexa 3-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Lenexa 3-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,15
+Johnson,Lenexa 4-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Lenexa 4-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Lenexa 4-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,15
+Johnson,Lenexa 4-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Lenexa 4-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Lenexa 4-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,20
+Johnson,Lenexa 4-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Lenexa 4-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Lenexa 4-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Lenexa 4-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Lenexa 4-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Lexington Twp 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Lexington Twp 0-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Lexington Twp 0-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Lexington Twp 0-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Lexington Twp 0-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,McCamish Twp 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,2
+Johnson,McCamish Twp 0-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,McCamish Twp 0-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Merriam 1-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Merriam 1-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Merriam 2-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,25
+Johnson,Merriam 2-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Merriam 2-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Merriam 3-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Merriam 3-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Merriam 4-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,17
+Johnson,Merriam 4-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Merriam 4-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Mission 1-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Mission 1-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Mission 2-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Mission 2-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,21
+Johnson,Mission 3-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,24
+Johnson,Mission 3-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Mission 4-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Mission 4-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Mission 4-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Mission Hills 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Mission Hills 0-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Mission Hills 0-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Mission Hills 0-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Mission Woods 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,3
+Johnson,Olathe 1-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Olathe 1-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,15
+Johnson,Olathe 1-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Olathe 1-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Olathe 1-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,23
+Johnson,Olathe 1-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Olathe 1-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 1-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Olathe 1-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,21
+Johnson,Olathe 1-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 1-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Olathe 1-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 1-13,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 1-14,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Olathe 1-15,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,20
+Johnson,Olathe 1-16,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,15
+Johnson,Olathe 1-17,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Olathe 1-18,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Olathe 1-19,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Olathe 1-20,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Olathe 1-21,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,19
+Johnson,Olathe 1-22,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,17
+Johnson,Olathe 1-23,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 1-24,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 1-25,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 1-26,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 1-27,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,17
+Johnson,Olathe 1-28,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,3
+Johnson,Olathe 1-29,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 2-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Olathe 2-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Olathe 2-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Olathe 2-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,24
+Johnson,Olathe 2-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,23
+Johnson,Olathe 2-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Olathe 2-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,21
+Johnson,Olathe 2-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Olathe 2-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,2
+Johnson,Olathe 2-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,30
+Johnson,Olathe 2-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,33
+Johnson,Olathe 2-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Olathe 2-13,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,20
+Johnson,Olathe 2-14,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Olathe 2-15,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Olathe 2-16,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 2-17,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 2-18,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 2-19,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 2-20,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 2-21,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 2-22,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,19
+Johnson,Olathe 2-23,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Olathe 2-24,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 2-25,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 2-26,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 2-27,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 2-28,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,2
+Johnson,Olathe 3-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Olathe 3-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,20
+Johnson,Olathe 3-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Olathe 3-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,25
+Johnson,Olathe 3-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Olathe 3-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Olathe 3-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Olathe 3-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,15
+Johnson,Olathe 3-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Olathe 3-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Olathe 3-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Olathe 3-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Olathe 3-13,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Olathe 3-14,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 3-15,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Olathe 3-16,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Olathe 3-17,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Olathe 3-18,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Olathe 3-19,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Olathe 3-20,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Olathe 3-21,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Olathe 3-22,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Olathe 3-23,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,24
+Johnson,Olathe 3-24,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 3-25,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 3-26,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Olathe 3-27,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Olathe 4-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Olathe 4-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Olathe 4-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Olathe 4-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Olathe 4-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Olathe 4-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,22
+Johnson,Olathe 4-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,23
+Johnson,Olathe 4-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Olathe 4-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,36
+Johnson,Olathe 4-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Olathe 4-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Olathe 4-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Olathe 4-13,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,20
+Johnson,Olathe 4-14,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Olathe 4-15,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,3
+Johnson,Olathe 4-16,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 4-17,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe 4-18,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Olathe Twp 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Olathe Twp 0-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Olathe Twp 0-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Olathe Twp 0-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Olathe Twp 0-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-13,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-14,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-17,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-24,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-25,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-26,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-27,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Olathe Twp 0-32,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Overland Park 1-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,22
+Johnson,Overland Park 1-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Overland Park 1-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Overland Park 1-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,2
+Johnson,Overland Park 1-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Overland Park 1-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Overland Park 1-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Overland Park 1-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,19
+Johnson,Overland Park 1-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Overland Park 1-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,25
+Johnson,Overland Park 1-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Overland Park 1-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,21
+Johnson,Overland Park 1-13,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,27
+Johnson,Overland Park 1-14,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,20
+Johnson,Overland Park 1-15,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Overland Park 1-16,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,28
+Johnson,Overland Park 1-17,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Overland Park 1-18,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Overland Park 1-19,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Overland Park 1-20,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Overland Park 1-21,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Overland Park 1-22,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Overland Park 2-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Overland Park 2-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Overland Park 2-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Overland Park 2-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Overland Park 2-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Overland Park 2-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,20
+Johnson,Overland Park 2-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Overland Park 2-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Overland Park 2-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Overland Park 2-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,15
+Johnson,Overland Park 2-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,15
+Johnson,Overland Park 2-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Overland Park 2-13,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Overland Park 2-14,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Overland Park 2-15,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,23
+Johnson,Overland Park 2-16,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Overland Park 2-17,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Overland Park 2-18,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,24
+Johnson,Overland Park 2-19,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Overland Park 2-20,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Overland Park 2-21,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Overland Park 2-22,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Overland Park 2-23,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,2
+Johnson,Overland Park 2-24,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Overland Park 2-25,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Overland Park 2-26,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Overland Park 3-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Overland Park 3-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Overland Park 3-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Overland Park 3-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Overland Park 3-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Overland Park 3-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Overland Park 3-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Overland Park 3-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Overland Park 3-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Overland Park 3-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Overland Park 3-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Overland Park 3-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,19
+Johnson,Overland Park 3-13,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Overland Park 3-14,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Overland Park 3-15,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Overland Park 3-16,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Overland Park 3-17,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Overland Park 3-18,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Overland Park 3-19,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Overland Park 3-20,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Overland Park 4-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Overland Park 4-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,17
+Johnson,Overland Park 4-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Overland Park 4-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Overland Park 4-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Overland Park 4-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Overland Park 4-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Overland Park 4-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,3
+Johnson,Overland Park 4-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Overland Park 4-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Overland Park 4-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Overland Park 4-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Overland Park 4-13,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Overland Park 4-14,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Overland Park 4-15,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Overland Park 4-16,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Overland Park 4-17,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Overland Park 4-18,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Overland Park 5-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Overland Park 5-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Overland Park 5-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Overland Park 5-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,21
+Johnson,Overland Park 5-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Overland Park 5-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Overland Park 5-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Overland Park 5-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,25
+Johnson,Overland Park 5-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Overland Park 5-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Overland Park 5-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,19
+Johnson,Overland Park 5-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Overland Park 5-13,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Overland Park 5-14,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Overland Park 5-15,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Overland Park 5-16,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Overland Park 5-17,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Overland Park 5-18,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Overland Park 5-19,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Overland Park 6-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Overland Park 6-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Overland Park 6-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Overland Park 6-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Overland Park 6-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Overland Park 6-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Overland Park 6-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Overland Park 6-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Overland Park 6-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,15
+Johnson,Overland Park 6-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,19
+Johnson,Overland Park 6-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Overland Park 6-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Overland Park 6-13,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Overland Park 6-14,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Overland Park 6-15,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Overland Park 6-16,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Overland Park 6-17,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Overland Park 6-18,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Overland Park 6-19,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Overland Park 6-20,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Overland Park 6-21,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Overland Park 6-22,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,3
+Johnson,Overland Park 6-23,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Oxford Twp 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Oxford Twp 0-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Oxford Twp 0-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Oxford Twp 0-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Oxford Twp 0-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Oxford Twp 0-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Oxford Twp 0-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Oxford Twp 0-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Oxford Twp 0-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,2
+Johnson,Prairie Village 1-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Prairie Village 1-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Prairie Village 1-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Prairie Village 2-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Prairie Village 2-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,20
+Johnson,Prairie Village 2-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Prairie Village 3-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Prairie Village 3-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Prairie Village 3-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Prairie Village 4-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Prairie Village 4-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Prairie Village 4-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Prairie Village 5-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Prairie Village 5-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Prairie Village 5-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Prairie Village 6-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Prairie Village 6-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,17
+Johnson,Prairie Village 6-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Roeland Park 1-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Roeland Park 1-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Roeland Park 1-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Roeland Park 2-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Roeland Park 2-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Roeland Park 3-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Roeland Park 3-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Roeland Park 4-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Roeland Park 4-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,16
+Johnson,Shawnee 1-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Shawnee 1-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Shawnee 1-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Shawnee 1-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Shawnee 1-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Shawnee 1-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,8
+Johnson,Shawnee 1-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Shawnee 1-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,15
+Johnson,Shawnee 1-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Shawnee 1-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Shawnee 1-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Shawnee 1-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Shawnee 2-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Shawnee 2-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,19
+Johnson,Shawnee 2-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Shawnee 2-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Shawnee 2-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Shawnee 2-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Shawnee 2-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Shawnee 2-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Shawnee 2-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Shawnee 2-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Shawnee 2-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,6
+Johnson,Shawnee 2-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Shawnee 2-13,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Shawnee 3-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Shawnee 3-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,17
+Johnson,Shawnee 3-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Shawnee 3-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Shawnee 3-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Shawnee 3-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,20
+Johnson,Shawnee 3-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,22
+Johnson,Shawnee 3-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,11
+Johnson,Shawnee 3-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Shawnee 4-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,12
+Johnson,Shawnee 4-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,7
+Johnson,Shawnee 4-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4
+Johnson,Shawnee 4-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,9
+Johnson,Shawnee 4-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,18
+Johnson,Shawnee 4-06,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,10
+Johnson,Shawnee 4-07,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Shawnee 4-08,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,3
+Johnson,Shawnee 4-09,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,15
+Johnson,Shawnee 4-10,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Shawnee 4-11,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,14
+Johnson,Shawnee 4-12,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Shawnee 4-13,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,1
+Johnson,Spring Hill 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,29
+Johnson,Spring Hill 0-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Spring Hill 0-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,2
+Johnson,Spring Hill 0-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Spring Hill Twp 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,15
+Johnson,Spring Hill Twp 0-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Spring Hill Twp 0-03,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Spring Hill Twp 0-04,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Spring Hill Twp 0-05,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,0
+Johnson,Westwood 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,13
+Johnson,Westwood 0-02,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,5
+Johnson,Westwood Hills 0-01,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,3
+Johnson,Total,President,,"Johnson, Gary",Gary,,Johnson,,Libertarian,4590
+Johnson,Aubry Twp 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,40
+Johnson,Aubry Twp 0-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,184
+Johnson,Aubry Twp 0-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,132
+Johnson,Aubry Twp 0-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,287
+Johnson,Aubry Twp 0-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,6
+Johnson,Aubry Twp 0-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,16
+Johnson,Bonner Springs 4-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,De Soto 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,336
+Johnson,De Soto 0-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,205
+Johnson,De Soto 0-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,277
+Johnson,De Soto 0-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,De Soto 0-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,De Soto 0-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,39
+Johnson,De Soto 0-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,De Soto 0-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Edgerton 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,227
+Johnson,Edgerton 0-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Edgerton 0-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Edgerton 0-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Edgerton 0-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Edgerton 0-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Edgerton 0-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Edgerton 0-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Fairway 1-00,President,,"Obama, Barack",Barack,,Obama,,Democratic,277
+Johnson,Fairway 2-00,President,,"Obama, Barack",Barack,,Obama,,Democratic,268
+Johnson,Fairway 3-00,President,,"Obama, Barack",Barack,,Obama,,Democratic,323
+Johnson,Fairway 4-00,President,,"Obama, Barack",Barack,,Obama,,Democratic,370
+Johnson,Gardner 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,409
+Johnson,Gardner 0-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,84
+Johnson,Gardner 0-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,350
+Johnson,Gardner 0-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,245
+Johnson,Gardner 0-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Gardner 0-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,311
+Johnson,Gardner 0-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,13
+Johnson,Gardner 0-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,16
+Johnson,Gardner 0-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,399
+Johnson,Gardner 0-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,241
+Johnson,Gardner 0-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Gardner 0-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,11
+Johnson,Gardner 0-13,President,,"Obama, Barack",Barack,,Obama,,Democratic,302
+Johnson,Gardner 0-14,President,,"Obama, Barack",Barack,,Obama,,Democratic,256
+Johnson,Gardner 0-15,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Gardner Twp 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,123
+Johnson,Gardner Twp 0-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,130
+Johnson,Gardner Twp 0-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Gardner Twp 0-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Gardner Twp 0-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,2
+Johnson,Gardner Twp 0-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Gardner Twp 0-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,2
+Johnson,Gardner Twp 0-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,4
+Johnson,Gardner Twp 0-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Gardner Twp 0-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Gardner Twp 0-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,44
+Johnson,Gardner Twp 0-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Lake Quivira 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,216
+Johnson,Leawood 1-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,296
+Johnson,Leawood 1-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,397
+Johnson,Leawood 1-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,337
+Johnson,Leawood 1-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,283
+Johnson,Leawood 1-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,217
+Johnson,Leawood 1-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,84
+Johnson,Leawood 2-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,300
+Johnson,Leawood 2-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,375
+Johnson,Leawood 2-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,337
+Johnson,Leawood 2-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,223
+Johnson,Leawood 2-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,207
+Johnson,Leawood 2-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,130
+Johnson,Leawood 3-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,207
+Johnson,Leawood 3-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,320
+Johnson,Leawood 3-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,180
+Johnson,Leawood 3-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,87
+Johnson,Leawood 3-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,366
+Johnson,Leawood 3-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,314
+Johnson,Leawood 3-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,295
+Johnson,Leawood 4-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,72
+Johnson,Leawood 4-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,235
+Johnson,Leawood 4-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,277
+Johnson,Leawood 4-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,316
+Johnson,Leawood 4-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,295
+Johnson,Leawood 4-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,143
+Johnson,Leawood 4-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,331
+Johnson,Leawood 4-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,108
+Johnson,Lenexa 1-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,205
+Johnson,Lenexa 1-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,438
+Johnson,Lenexa 1-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,512
+Johnson,Lenexa 1-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,380
+Johnson,Lenexa 1-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,354
+Johnson,Lenexa 1-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,326
+Johnson,Lenexa 1-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,258
+Johnson,Lenexa 1-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,132
+Johnson,Lenexa 1-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,6
+Johnson,Lenexa 2-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,308
+Johnson,Lenexa 2-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,73
+Johnson,Lenexa 2-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,325
+Johnson,Lenexa 2-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,238
+Johnson,Lenexa 2-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,497
+Johnson,Lenexa 2-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,194
+Johnson,Lenexa 2-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,379
+Johnson,Lenexa 2-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Lenexa 3-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,421
+Johnson,Lenexa 3-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,534
+Johnson,Lenexa 3-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,449
+Johnson,Lenexa 3-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,265
+Johnson,Lenexa 3-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,352
+Johnson,Lenexa 3-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,315
+Johnson,Lenexa 3-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,339
+Johnson,Lenexa 3-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,350
+Johnson,Lenexa 4-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,194
+Johnson,Lenexa 4-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,354
+Johnson,Lenexa 4-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,280
+Johnson,Lenexa 4-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,226
+Johnson,Lenexa 4-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,179
+Johnson,Lenexa 4-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,321
+Johnson,Lenexa 4-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,291
+Johnson,Lenexa 4-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,312
+Johnson,Lenexa 4-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,280
+Johnson,Lenexa 4-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,212
+Johnson,Lenexa 4-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,61
+Johnson,Lexington Twp 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,214
+Johnson,Lexington Twp 0-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Lexington Twp 0-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,1
+Johnson,Lexington Twp 0-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,1
+Johnson,Lexington Twp 0-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,McCamish Twp 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,41
+Johnson,McCamish Twp 0-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,98
+Johnson,McCamish Twp 0-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Merriam 1-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,245
+Johnson,Merriam 1-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,387
+Johnson,Merriam 2-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,370
+Johnson,Merriam 2-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,1
+Johnson,Merriam 2-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,242
+Johnson,Merriam 3-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,408
+Johnson,Merriam 3-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,290
+Johnson,Merriam 4-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,365
+Johnson,Merriam 4-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,173
+Johnson,Merriam 4-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,227
+Johnson,Mission 1-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,364
+Johnson,Mission 1-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,271
+Johnson,Mission 2-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,251
+Johnson,Mission 2-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,320
+Johnson,Mission 3-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,429
+Johnson,Mission 3-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,202
+Johnson,Mission 4-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,252
+Johnson,Mission 4-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,299
+Johnson,Mission 4-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,185
+Johnson,Mission Hills 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,149
+Johnson,Mission Hills 0-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,227
+Johnson,Mission Hills 0-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,109
+Johnson,Mission Hills 0-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,244
+Johnson,Mission Woods 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,54
+Johnson,Olathe 1-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,349
+Johnson,Olathe 1-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,233
+Johnson,Olathe 1-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,191
+Johnson,Olathe 1-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,345
+Johnson,Olathe 1-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,298
+Johnson,Olathe 1-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,188
+Johnson,Olathe 1-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe 1-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,444
+Johnson,Olathe 1-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,316
+Johnson,Olathe 1-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,3
+Johnson,Olathe 1-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,71
+Johnson,Olathe 1-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,18
+Johnson,Olathe 1-13,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe 1-14,President,,"Obama, Barack",Barack,,Obama,,Democratic,248
+Johnson,Olathe 1-15,President,,"Obama, Barack",Barack,,Obama,,Democratic,258
+Johnson,Olathe 1-16,President,,"Obama, Barack",Barack,,Obama,,Democratic,317
+Johnson,Olathe 1-17,President,,"Obama, Barack",Barack,,Obama,,Democratic,61
+Johnson,Olathe 1-18,President,,"Obama, Barack",Barack,,Obama,,Democratic,85
+Johnson,Olathe 1-19,President,,"Obama, Barack",Barack,,Obama,,Democratic,157
+Johnson,Olathe 1-20,President,,"Obama, Barack",Barack,,Obama,,Democratic,280
+Johnson,Olathe 1-21,President,,"Obama, Barack",Barack,,Obama,,Democratic,407
+Johnson,Olathe 1-22,President,,"Obama, Barack",Barack,,Obama,,Democratic,347
+Johnson,Olathe 1-23,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe 1-24,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe 1-25,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe 1-26,President,,"Obama, Barack",Barack,,Obama,,Democratic,4
+Johnson,Olathe 1-27,President,,"Obama, Barack",Barack,,Obama,,Democratic,243
+Johnson,Olathe 1-28,President,,"Obama, Barack",Barack,,Obama,,Democratic,80
+Johnson,Olathe 1-29,President,,"Obama, Barack",Barack,,Obama,,Democratic,45
+Johnson,Olathe 2-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,124
+Johnson,Olathe 2-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,182
+Johnson,Olathe 2-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,264
+Johnson,Olathe 2-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,363
+Johnson,Olathe 2-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,382
+Johnson,Olathe 2-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,182
+Johnson,Olathe 2-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,380
+Johnson,Olathe 2-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,444
+Johnson,Olathe 2-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,153
+Johnson,Olathe 2-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,644
+Johnson,Olathe 2-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,472
+Johnson,Olathe 2-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,229
+Johnson,Olathe 2-13,President,,"Obama, Barack",Barack,,Obama,,Democratic,295
+Johnson,Olathe 2-14,President,,"Obama, Barack",Barack,,Obama,,Democratic,263
+Johnson,Olathe 2-15,President,,"Obama, Barack",Barack,,Obama,,Democratic,137
+Johnson,Olathe 2-16,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe 2-17,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe 2-18,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe 2-19,President,,"Obama, Barack",Barack,,Obama,,Democratic,1
+Johnson,Olathe 2-20,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe 2-21,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe 2-22,President,,"Obama, Barack",Barack,,Obama,,Democratic,381
+Johnson,Olathe 2-23,President,,"Obama, Barack",Barack,,Obama,,Democratic,305
+Johnson,Olathe 2-24,President,,"Obama, Barack",Barack,,Obama,,Democratic,3
+Johnson,Olathe 2-25,President,,"Obama, Barack",Barack,,Obama,,Democratic,7
+Johnson,Olathe 2-26,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe 2-27,President,,"Obama, Barack",Barack,,Obama,,Democratic,1
+Johnson,Olathe 2-28,President,,"Obama, Barack",Barack,,Obama,,Democratic,117
+Johnson,Olathe 3-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,188
+Johnson,Olathe 3-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,420
+Johnson,Olathe 3-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,155
+Johnson,Olathe 3-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,352
+Johnson,Olathe 3-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,233
+Johnson,Olathe 3-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,187
+Johnson,Olathe 3-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,228
+Johnson,Olathe 3-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,302
+Johnson,Olathe 3-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,180
+Johnson,Olathe 3-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,330
+Johnson,Olathe 3-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,241
+Johnson,Olathe 3-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,358
+Johnson,Olathe 3-13,President,,"Obama, Barack",Barack,,Obama,,Democratic,336
+Johnson,Olathe 3-14,President,,"Obama, Barack",Barack,,Obama,,Democratic,2
+Johnson,Olathe 3-15,President,,"Obama, Barack",Barack,,Obama,,Democratic,233
+Johnson,Olathe 3-16,President,,"Obama, Barack",Barack,,Obama,,Democratic,269
+Johnson,Olathe 3-17,President,,"Obama, Barack",Barack,,Obama,,Democratic,326
+Johnson,Olathe 3-18,President,,"Obama, Barack",Barack,,Obama,,Democratic,308
+Johnson,Olathe 3-19,President,,"Obama, Barack",Barack,,Obama,,Democratic,142
+Johnson,Olathe 3-20,President,,"Obama, Barack",Barack,,Obama,,Democratic,186
+Johnson,Olathe 3-21,President,,"Obama, Barack",Barack,,Obama,,Democratic,102
+Johnson,Olathe 3-22,President,,"Obama, Barack",Barack,,Obama,,Democratic,312
+Johnson,Olathe 3-23,President,,"Obama, Barack",Barack,,Obama,,Democratic,338
+Johnson,Olathe 3-24,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe 3-25,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe 3-26,President,,"Obama, Barack",Barack,,Obama,,Democratic,50
+Johnson,Olathe 3-27,President,,"Obama, Barack",Barack,,Obama,,Democratic,118
+Johnson,Olathe 4-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,393
+Johnson,Olathe 4-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,461
+Johnson,Olathe 4-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,271
+Johnson,Olathe 4-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,268
+Johnson,Olathe 4-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,338
+Johnson,Olathe 4-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,466
+Johnson,Olathe 4-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,446
+Johnson,Olathe 4-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,265
+Johnson,Olathe 4-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,384
+Johnson,Olathe 4-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,213
+Johnson,Olathe 4-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,226
+Johnson,Olathe 4-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,392
+Johnson,Olathe 4-13,President,,"Obama, Barack",Barack,,Obama,,Democratic,233
+Johnson,Olathe 4-14,President,,"Obama, Barack",Barack,,Obama,,Democratic,406
+Johnson,Olathe 4-15,President,,"Obama, Barack",Barack,,Obama,,Democratic,53
+Johnson,Olathe 4-16,President,,"Obama, Barack",Barack,,Obama,,Democratic,2
+Johnson,Olathe 4-17,President,,"Obama, Barack",Barack,,Obama,,Democratic,1
+Johnson,Olathe 4-18,President,,"Obama, Barack",Barack,,Obama,,Democratic,181
+Johnson,Olathe Twp 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,136
+Johnson,Olathe Twp 0-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,17
+Johnson,Olathe Twp 0-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,22
+Johnson,Olathe Twp 0-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe Twp 0-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe Twp 0-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,1
+Johnson,Olathe Twp 0-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,1
+Johnson,Olathe Twp 0-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,4
+Johnson,Olathe Twp 0-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe Twp 0-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,4
+Johnson,Olathe Twp 0-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,1
+Johnson,Olathe Twp 0-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe Twp 0-13,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe Twp 0-14,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe Twp 0-17,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe Twp 0-24,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe Twp 0-25,President,,"Obama, Barack",Barack,,Obama,,Democratic,1
+Johnson,Olathe Twp 0-26,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe Twp 0-27,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Olathe Twp 0-32,President,,"Obama, Barack",Barack,,Obama,,Democratic,8
+Johnson,Overland Park 1-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,406
+Johnson,Overland Park 1-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,462
+Johnson,Overland Park 1-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,341
+Johnson,Overland Park 1-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,111
+Johnson,Overland Park 1-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,262
+Johnson,Overland Park 1-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,426
+Johnson,Overland Park 1-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,452
+Johnson,Overland Park 1-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,398
+Johnson,Overland Park 1-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,219
+Johnson,Overland Park 1-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,446
+Johnson,Overland Park 1-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,215
+Johnson,Overland Park 1-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,475
+Johnson,Overland Park 1-13,President,,"Obama, Barack",Barack,,Obama,,Democratic,282
+Johnson,Overland Park 1-14,President,,"Obama, Barack",Barack,,Obama,,Democratic,399
+Johnson,Overland Park 1-15,President,,"Obama, Barack",Barack,,Obama,,Democratic,196
+Johnson,Overland Park 1-16,President,,"Obama, Barack",Barack,,Obama,,Democratic,472
+Johnson,Overland Park 1-17,President,,"Obama, Barack",Barack,,Obama,,Democratic,223
+Johnson,Overland Park 1-18,President,,"Obama, Barack",Barack,,Obama,,Democratic,311
+Johnson,Overland Park 1-19,President,,"Obama, Barack",Barack,,Obama,,Democratic,376
+Johnson,Overland Park 1-20,President,,"Obama, Barack",Barack,,Obama,,Democratic,206
+Johnson,Overland Park 1-21,President,,"Obama, Barack",Barack,,Obama,,Democratic,102
+Johnson,Overland Park 1-22,President,,"Obama, Barack",Barack,,Obama,,Democratic,105
+Johnson,Overland Park 2-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,252
+Johnson,Overland Park 2-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,323
+Johnson,Overland Park 2-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,278
+Johnson,Overland Park 2-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,350
+Johnson,Overland Park 2-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,377
+Johnson,Overland Park 2-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,313
+Johnson,Overland Park 2-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,253
+Johnson,Overland Park 2-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,300
+Johnson,Overland Park 2-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,297
+Johnson,Overland Park 2-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,186
+Johnson,Overland Park 2-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,308
+Johnson,Overland Park 2-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,238
+Johnson,Overland Park 2-13,President,,"Obama, Barack",Barack,,Obama,,Democratic,216
+Johnson,Overland Park 2-14,President,,"Obama, Barack",Barack,,Obama,,Democratic,239
+Johnson,Overland Park 2-15,President,,"Obama, Barack",Barack,,Obama,,Democratic,374
+Johnson,Overland Park 2-16,President,,"Obama, Barack",Barack,,Obama,,Democratic,255
+Johnson,Overland Park 2-17,President,,"Obama, Barack",Barack,,Obama,,Democratic,291
+Johnson,Overland Park 2-18,President,,"Obama, Barack",Barack,,Obama,,Democratic,433
+Johnson,Overland Park 2-19,President,,"Obama, Barack",Barack,,Obama,,Democratic,249
+Johnson,Overland Park 2-20,President,,"Obama, Barack",Barack,,Obama,,Democratic,198
+Johnson,Overland Park 2-21,President,,"Obama, Barack",Barack,,Obama,,Democratic,257
+Johnson,Overland Park 2-22,President,,"Obama, Barack",Barack,,Obama,,Democratic,327
+Johnson,Overland Park 2-23,President,,"Obama, Barack",Barack,,Obama,,Democratic,245
+Johnson,Overland Park 2-24,President,,"Obama, Barack",Barack,,Obama,,Democratic,458
+Johnson,Overland Park 2-25,President,,"Obama, Barack",Barack,,Obama,,Democratic,308
+Johnson,Overland Park 2-26,President,,"Obama, Barack",Barack,,Obama,,Democratic,159
+Johnson,Overland Park 3-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,415
+Johnson,Overland Park 3-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,319
+Johnson,Overland Park 3-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,228
+Johnson,Overland Park 3-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,397
+Johnson,Overland Park 3-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,362
+Johnson,Overland Park 3-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,421
+Johnson,Overland Park 3-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,334
+Johnson,Overland Park 3-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,280
+Johnson,Overland Park 3-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,462
+Johnson,Overland Park 3-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,208
+Johnson,Overland Park 3-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,289
+Johnson,Overland Park 3-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,341
+Johnson,Overland Park 3-13,President,,"Obama, Barack",Barack,,Obama,,Democratic,545
+Johnson,Overland Park 3-14,President,,"Obama, Barack",Barack,,Obama,,Democratic,438
+Johnson,Overland Park 3-15,President,,"Obama, Barack",Barack,,Obama,,Democratic,226
+Johnson,Overland Park 3-16,President,,"Obama, Barack",Barack,,Obama,,Democratic,299
+Johnson,Overland Park 3-17,President,,"Obama, Barack",Barack,,Obama,,Democratic,219
+Johnson,Overland Park 3-18,President,,"Obama, Barack",Barack,,Obama,,Democratic,350
+Johnson,Overland Park 3-19,President,,"Obama, Barack",Barack,,Obama,,Democratic,322
+Johnson,Overland Park 3-20,President,,"Obama, Barack",Barack,,Obama,,Democratic,401
+Johnson,Overland Park 4-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,233
+Johnson,Overland Park 4-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,307
+Johnson,Overland Park 4-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,311
+Johnson,Overland Park 4-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,386
+Johnson,Overland Park 4-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,309
+Johnson,Overland Park 4-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,265
+Johnson,Overland Park 4-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,261
+Johnson,Overland Park 4-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,285
+Johnson,Overland Park 4-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,176
+Johnson,Overland Park 4-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,170
+Johnson,Overland Park 4-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,397
+Johnson,Overland Park 4-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,493
+Johnson,Overland Park 4-13,President,,"Obama, Barack",Barack,,Obama,,Democratic,160
+Johnson,Overland Park 4-14,President,,"Obama, Barack",Barack,,Obama,,Democratic,166
+Johnson,Overland Park 4-15,President,,"Obama, Barack",Barack,,Obama,,Democratic,395
+Johnson,Overland Park 4-16,President,,"Obama, Barack",Barack,,Obama,,Democratic,262
+Johnson,Overland Park 4-17,President,,"Obama, Barack",Barack,,Obama,,Democratic,346
+Johnson,Overland Park 4-18,President,,"Obama, Barack",Barack,,Obama,,Democratic,99
+Johnson,Overland Park 5-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,337
+Johnson,Overland Park 5-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,196
+Johnson,Overland Park 5-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,234
+Johnson,Overland Park 5-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,331
+Johnson,Overland Park 5-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,337
+Johnson,Overland Park 5-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,330
+Johnson,Overland Park 5-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,258
+Johnson,Overland Park 5-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,449
+Johnson,Overland Park 5-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,379
+Johnson,Overland Park 5-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,351
+Johnson,Overland Park 5-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,487
+Johnson,Overland Park 5-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,114
+Johnson,Overland Park 5-13,President,,"Obama, Barack",Barack,,Obama,,Democratic,489
+Johnson,Overland Park 5-14,President,,"Obama, Barack",Barack,,Obama,,Democratic,329
+Johnson,Overland Park 5-15,President,,"Obama, Barack",Barack,,Obama,,Democratic,336
+Johnson,Overland Park 5-16,President,,"Obama, Barack",Barack,,Obama,,Democratic,229
+Johnson,Overland Park 5-17,President,,"Obama, Barack",Barack,,Obama,,Democratic,166
+Johnson,Overland Park 5-18,President,,"Obama, Barack",Barack,,Obama,,Democratic,314
+Johnson,Overland Park 5-19,President,,"Obama, Barack",Barack,,Obama,,Democratic,30
+Johnson,Overland Park 6-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,296
+Johnson,Overland Park 6-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,235
+Johnson,Overland Park 6-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,284
+Johnson,Overland Park 6-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,236
+Johnson,Overland Park 6-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,379
+Johnson,Overland Park 6-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Overland Park 6-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,66
+Johnson,Overland Park 6-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,229
+Johnson,Overland Park 6-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,409
+Johnson,Overland Park 6-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,344
+Johnson,Overland Park 6-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,323
+Johnson,Overland Park 6-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,143
+Johnson,Overland Park 6-13,President,,"Obama, Barack",Barack,,Obama,,Democratic,337
+Johnson,Overland Park 6-14,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Overland Park 6-15,President,,"Obama, Barack",Barack,,Obama,,Democratic,312
+Johnson,Overland Park 6-16,President,,"Obama, Barack",Barack,,Obama,,Democratic,184
+Johnson,Overland Park 6-17,President,,"Obama, Barack",Barack,,Obama,,Democratic,312
+Johnson,Overland Park 6-18,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Overland Park 6-19,President,,"Obama, Barack",Barack,,Obama,,Democratic,360
+Johnson,Overland Park 6-20,President,,"Obama, Barack",Barack,,Obama,,Democratic,99
+Johnson,Overland Park 6-21,President,,"Obama, Barack",Barack,,Obama,,Democratic,263
+Johnson,Overland Park 6-22,President,,"Obama, Barack",Barack,,Obama,,Democratic,74
+Johnson,Overland Park 6-23,President,,"Obama, Barack",Barack,,Obama,,Democratic,58
+Johnson,Oxford Twp 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,2
+Johnson,Oxford Twp 0-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,168
+Johnson,Oxford Twp 0-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Oxford Twp 0-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,145
+Johnson,Oxford Twp 0-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Oxford Twp 0-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Oxford Twp 0-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,11
+Johnson,Oxford Twp 0-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Oxford Twp 0-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,17
+Johnson,Prairie Village 1-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,451
+Johnson,Prairie Village 1-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,334
+Johnson,Prairie Village 1-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,497
+Johnson,Prairie Village 2-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,403
+Johnson,Prairie Village 2-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,212
+Johnson,Prairie Village 2-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,393
+Johnson,Prairie Village 3-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,260
+Johnson,Prairie Village 3-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,422
+Johnson,Prairie Village 3-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,385
+Johnson,Prairie Village 4-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,329
+Johnson,Prairie Village 4-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,280
+Johnson,Prairie Village 4-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,449
+Johnson,Prairie Village 5-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,373
+Johnson,Prairie Village 5-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,314
+Johnson,Prairie Village 5-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,272
+Johnson,Prairie Village 6-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,423
+Johnson,Prairie Village 6-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,379
+Johnson,Prairie Village 6-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,264
+Johnson,Roeland Park 1-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,247
+Johnson,Roeland Park 1-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,147
+Johnson,Roeland Park 1-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Roeland Park 2-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,205
+Johnson,Roeland Park 2-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,278
+Johnson,Roeland Park 3-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,219
+Johnson,Roeland Park 3-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,346
+Johnson,Roeland Park 4-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,135
+Johnson,Roeland Park 4-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,439
+Johnson,Shawnee 1-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,388
+Johnson,Shawnee 1-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,268
+Johnson,Shawnee 1-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,297
+Johnson,Shawnee 1-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,389
+Johnson,Shawnee 1-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,452
+Johnson,Shawnee 1-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,279
+Johnson,Shawnee 1-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,374
+Johnson,Shawnee 1-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,387
+Johnson,Shawnee 1-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,123
+Johnson,Shawnee 1-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,88
+Johnson,Shawnee 1-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,262
+Johnson,Shawnee 1-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,3
+Johnson,Shawnee 2-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,198
+Johnson,Shawnee 2-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,316
+Johnson,Shawnee 2-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,376
+Johnson,Shawnee 2-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,433
+Johnson,Shawnee 2-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,208
+Johnson,Shawnee 2-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,232
+Johnson,Shawnee 2-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,263
+Johnson,Shawnee 2-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,229
+Johnson,Shawnee 2-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,224
+Johnson,Shawnee 2-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,216
+Johnson,Shawnee 2-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,284
+Johnson,Shawnee 2-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,132
+Johnson,Shawnee 2-13,President,,"Obama, Barack",Barack,,Obama,,Democratic,166
+Johnson,Shawnee 3-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,207
+Johnson,Shawnee 3-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,380
+Johnson,Shawnee 3-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,304
+Johnson,Shawnee 3-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,254
+Johnson,Shawnee 3-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,303
+Johnson,Shawnee 3-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,395
+Johnson,Shawnee 3-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,391
+Johnson,Shawnee 3-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,362
+Johnson,Shawnee 3-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,148
+Johnson,Shawnee 4-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,412
+Johnson,Shawnee 4-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,244
+Johnson,Shawnee 4-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,110
+Johnson,Shawnee 4-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,235
+Johnson,Shawnee 4-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,375
+Johnson,Shawnee 4-06,President,,"Obama, Barack",Barack,,Obama,,Democratic,280
+Johnson,Shawnee 4-07,President,,"Obama, Barack",Barack,,Obama,,Democratic,389
+Johnson,Shawnee 4-08,President,,"Obama, Barack",Barack,,Obama,,Democratic,141
+Johnson,Shawnee 4-09,President,,"Obama, Barack",Barack,,Obama,,Democratic,493
+Johnson,Shawnee 4-10,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Shawnee 4-11,President,,"Obama, Barack",Barack,,Obama,,Democratic,317
+Johnson,Shawnee 4-12,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Shawnee 4-13,President,,"Obama, Barack",Barack,,Obama,,Democratic,42
+Johnson,Spring Hill 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,423
+Johnson,Spring Hill 0-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Spring Hill 0-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,8
+Johnson,Spring Hill 0-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,0
+Johnson,Spring Hill Twp 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,249
+Johnson,Spring Hill Twp 0-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,1
+Johnson,Spring Hill Twp 0-03,President,,"Obama, Barack",Barack,,Obama,,Democratic,31
+Johnson,Spring Hill Twp 0-04,President,,"Obama, Barack",Barack,,Obama,,Democratic,5
+Johnson,Spring Hill Twp 0-05,President,,"Obama, Barack",Barack,,Obama,,Democratic,7
+Johnson,Westwood 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,291
+Johnson,Westwood 0-02,President,,"Obama, Barack",Barack,,Obama,,Democratic,250
+Johnson,Westwood Hills 0-01,President,,"Obama, Barack",Barack,,Obama,,Democratic,145
+Johnson,Total,President,,"Obama, Barack",Barack,,Obama,,Democratic,110526
+Johnson,Aubry Twp 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,84
+Johnson,Aubry Twp 0-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,579
+Johnson,Aubry Twp 0-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,309
+Johnson,Aubry Twp 0-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,708
+Johnson,Aubry Twp 0-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,11
+Johnson,Aubry Twp 0-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,87
+Johnson,Bonner Springs 4-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,De Soto 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,563
+Johnson,De Soto 0-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,316
+Johnson,De Soto 0-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,532
+Johnson,De Soto 0-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,De Soto 0-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,De Soto 0-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,35
+Johnson,De Soto 0-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,2
+Johnson,De Soto 0-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Edgerton 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,421
+Johnson,Edgerton 0-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Edgerton 0-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Edgerton 0-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Edgerton 0-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Edgerton 0-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Edgerton 0-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Edgerton 0-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Fairway 1-00,President,,"Romney, Mitt",Mitt,,Romney,,Republican,341
+Johnson,Fairway 2-00,President,,"Romney, Mitt",Mitt,,Romney,,Republican,276
+Johnson,Fairway 3-00,President,,"Romney, Mitt",Mitt,,Romney,,Republican,390
+Johnson,Fairway 4-00,President,,"Romney, Mitt",Mitt,,Romney,,Republican,224
+Johnson,Gardner 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,796
+Johnson,Gardner 0-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,90
+Johnson,Gardner 0-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,550
+Johnson,Gardner 0-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,423
+Johnson,Gardner 0-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Gardner 0-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,608
+Johnson,Gardner 0-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,13
+Johnson,Gardner 0-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,52
+Johnson,Gardner 0-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,684
+Johnson,Gardner 0-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,458
+Johnson,Gardner 0-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Gardner 0-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,8
+Johnson,Gardner 0-13,President,,"Romney, Mitt",Mitt,,Romney,,Republican,529
+Johnson,Gardner 0-14,President,,"Romney, Mitt",Mitt,,Romney,,Republican,386
+Johnson,Gardner 0-15,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Gardner Twp 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,269
+Johnson,Gardner Twp 0-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,358
+Johnson,Gardner Twp 0-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Gardner Twp 0-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,1
+Johnson,Gardner Twp 0-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,6
+Johnson,Gardner Twp 0-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Gardner Twp 0-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,2
+Johnson,Gardner Twp 0-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,2
+Johnson,Gardner Twp 0-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,2
+Johnson,Gardner Twp 0-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Gardner Twp 0-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,68
+Johnson,Gardner Twp 0-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Lake Quivira 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,452
+Johnson,Leawood 1-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,320
+Johnson,Leawood 1-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,556
+Johnson,Leawood 1-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,512
+Johnson,Leawood 1-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,392
+Johnson,Leawood 1-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,404
+Johnson,Leawood 1-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,85
+Johnson,Leawood 2-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,474
+Johnson,Leawood 2-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,566
+Johnson,Leawood 2-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,591
+Johnson,Leawood 2-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,748
+Johnson,Leawood 2-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,352
+Johnson,Leawood 2-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,270
+Johnson,Leawood 3-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,310
+Johnson,Leawood 3-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,574
+Johnson,Leawood 3-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,391
+Johnson,Leawood 3-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,197
+Johnson,Leawood 3-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,784
+Johnson,Leawood 3-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,772
+Johnson,Leawood 3-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,547
+Johnson,Leawood 4-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,193
+Johnson,Leawood 4-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,504
+Johnson,Leawood 4-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,448
+Johnson,Leawood 4-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,621
+Johnson,Leawood 4-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,611
+Johnson,Leawood 4-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,540
+Johnson,Leawood 4-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,910
+Johnson,Leawood 4-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,373
+Johnson,Lenexa 1-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,297
+Johnson,Lenexa 1-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,577
+Johnson,Lenexa 1-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,683
+Johnson,Lenexa 1-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,442
+Johnson,Lenexa 1-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,455
+Johnson,Lenexa 1-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,662
+Johnson,Lenexa 1-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,291
+Johnson,Lenexa 1-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,116
+Johnson,Lenexa 1-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,12
+Johnson,Lenexa 2-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,733
+Johnson,Lenexa 2-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,221
+Johnson,Lenexa 2-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,756
+Johnson,Lenexa 2-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,859
+Johnson,Lenexa 2-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,415
+Johnson,Lenexa 2-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,494
+Johnson,Lenexa 2-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,719
+Johnson,Lenexa 2-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Lenexa 3-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,307
+Johnson,Lenexa 3-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,433
+Johnson,Lenexa 3-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,604
+Johnson,Lenexa 3-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,438
+Johnson,Lenexa 3-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,236
+Johnson,Lenexa 3-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,350
+Johnson,Lenexa 3-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,497
+Johnson,Lenexa 3-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,544
+Johnson,Lenexa 4-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,223
+Johnson,Lenexa 4-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,457
+Johnson,Lenexa 4-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,197
+Johnson,Lenexa 4-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,216
+Johnson,Lenexa 4-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,177
+Johnson,Lenexa 4-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,351
+Johnson,Lenexa 4-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,379
+Johnson,Lenexa 4-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,336
+Johnson,Lenexa 4-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,395
+Johnson,Lenexa 4-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,190
+Johnson,Lenexa 4-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,59
+Johnson,Lexington Twp 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,561
+Johnson,Lexington Twp 0-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,2
+Johnson,Lexington Twp 0-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,3
+Johnson,Lexington Twp 0-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Lexington Twp 0-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,McCamish Twp 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,145
+Johnson,McCamish Twp 0-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,264
+Johnson,McCamish Twp 0-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Merriam 1-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,232
+Johnson,Merriam 1-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,255
+Johnson,Merriam 2-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,359
+Johnson,Merriam 2-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,1
+Johnson,Merriam 2-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,168
+Johnson,Merriam 3-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,297
+Johnson,Merriam 3-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,255
+Johnson,Merriam 4-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,383
+Johnson,Merriam 4-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,172
+Johnson,Merriam 4-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,192
+Johnson,Mission 1-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,323
+Johnson,Mission 1-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,125
+Johnson,Mission 2-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,169
+Johnson,Mission 2-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,243
+Johnson,Mission 3-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,282
+Johnson,Mission 3-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,158
+Johnson,Mission 4-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,176
+Johnson,Mission 4-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,289
+Johnson,Mission 4-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,168
+Johnson,Mission Hills 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,393
+Johnson,Mission Hills 0-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,455
+Johnson,Mission Hills 0-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,327
+Johnson,Mission Hills 0-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,447
+Johnson,Mission Woods 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,54
+Johnson,Olathe 1-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,451
+Johnson,Olathe 1-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,290
+Johnson,Olathe 1-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,271
+Johnson,Olathe 1-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,473
+Johnson,Olathe 1-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,512
+Johnson,Olathe 1-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,356
+Johnson,Olathe 1-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe 1-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,612
+Johnson,Olathe 1-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,588
+Johnson,Olathe 1-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,3
+Johnson,Olathe 1-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,60
+Johnson,Olathe 1-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,20
+Johnson,Olathe 1-13,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe 1-14,President,,"Romney, Mitt",Mitt,,Romney,,Republican,465
+Johnson,Olathe 1-15,President,,"Romney, Mitt",Mitt,,Romney,,Republican,478
+Johnson,Olathe 1-16,President,,"Romney, Mitt",Mitt,,Romney,,Republican,699
+Johnson,Olathe 1-17,President,,"Romney, Mitt",Mitt,,Romney,,Republican,139
+Johnson,Olathe 1-18,President,,"Romney, Mitt",Mitt,,Romney,,Republican,131
+Johnson,Olathe 1-19,President,,"Romney, Mitt",Mitt,,Romney,,Republican,212
+Johnson,Olathe 1-20,President,,"Romney, Mitt",Mitt,,Romney,,Republican,323
+Johnson,Olathe 1-21,President,,"Romney, Mitt",Mitt,,Romney,,Republican,599
+Johnson,Olathe 1-22,President,,"Romney, Mitt",Mitt,,Romney,,Republican,770
+Johnson,Olathe 1-23,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe 1-24,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe 1-25,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe 1-26,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe 1-27,President,,"Romney, Mitt",Mitt,,Romney,,Republican,308
+Johnson,Olathe 1-28,President,,"Romney, Mitt",Mitt,,Romney,,Republican,131
+Johnson,Olathe 1-29,President,,"Romney, Mitt",Mitt,,Romney,,Republican,84
+Johnson,Olathe 2-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,247
+Johnson,Olathe 2-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,263
+Johnson,Olathe 2-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,355
+Johnson,Olathe 2-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,383
+Johnson,Olathe 2-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,1073
+Johnson,Olathe 2-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,615
+Johnson,Olathe 2-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,641
+Johnson,Olathe 2-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,486
+Johnson,Olathe 2-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,202
+Johnson,Olathe 2-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,889
+Johnson,Olathe 2-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,632
+Johnson,Olathe 2-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,368
+Johnson,Olathe 2-13,President,,"Romney, Mitt",Mitt,,Romney,,Republican,378
+Johnson,Olathe 2-14,President,,"Romney, Mitt",Mitt,,Romney,,Republican,378
+Johnson,Olathe 2-15,President,,"Romney, Mitt",Mitt,,Romney,,Republican,318
+Johnson,Olathe 2-16,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe 2-17,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe 2-18,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe 2-19,President,,"Romney, Mitt",Mitt,,Romney,,Republican,7
+Johnson,Olathe 2-20,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe 2-21,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe 2-22,President,,"Romney, Mitt",Mitt,,Romney,,Republican,720
+Johnson,Olathe 2-23,President,,"Romney, Mitt",Mitt,,Romney,,Republican,522
+Johnson,Olathe 2-24,President,,"Romney, Mitt",Mitt,,Romney,,Republican,11
+Johnson,Olathe 2-25,President,,"Romney, Mitt",Mitt,,Romney,,Republican,2
+Johnson,Olathe 2-26,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe 2-27,President,,"Romney, Mitt",Mitt,,Romney,,Republican,10
+Johnson,Olathe 2-28,President,,"Romney, Mitt",Mitt,,Romney,,Republican,137
+Johnson,Olathe 3-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,220
+Johnson,Olathe 3-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,639
+Johnson,Olathe 3-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,375
+Johnson,Olathe 3-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,541
+Johnson,Olathe 3-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,568
+Johnson,Olathe 3-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,433
+Johnson,Olathe 3-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,396
+Johnson,Olathe 3-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,622
+Johnson,Olathe 3-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,323
+Johnson,Olathe 3-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,659
+Johnson,Olathe 3-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,413
+Johnson,Olathe 3-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,528
+Johnson,Olathe 3-13,President,,"Romney, Mitt",Mitt,,Romney,,Republican,577
+Johnson,Olathe 3-14,President,,"Romney, Mitt",Mitt,,Romney,,Republican,1
+Johnson,Olathe 3-15,President,,"Romney, Mitt",Mitt,,Romney,,Republican,471
+Johnson,Olathe 3-16,President,,"Romney, Mitt",Mitt,,Romney,,Republican,509
+Johnson,Olathe 3-17,President,,"Romney, Mitt",Mitt,,Romney,,Republican,631
+Johnson,Olathe 3-18,President,,"Romney, Mitt",Mitt,,Romney,,Republican,567
+Johnson,Olathe 3-19,President,,"Romney, Mitt",Mitt,,Romney,,Republican,403
+Johnson,Olathe 3-20,President,,"Romney, Mitt",Mitt,,Romney,,Republican,441
+Johnson,Olathe 3-21,President,,"Romney, Mitt",Mitt,,Romney,,Republican,316
+Johnson,Olathe 3-22,President,,"Romney, Mitt",Mitt,,Romney,,Republican,497
+Johnson,Olathe 3-23,President,,"Romney, Mitt",Mitt,,Romney,,Republican,445
+Johnson,Olathe 3-24,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe 3-25,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe 3-26,President,,"Romney, Mitt",Mitt,,Romney,,Republican,44
+Johnson,Olathe 3-27,President,,"Romney, Mitt",Mitt,,Romney,,Republican,292
+Johnson,Olathe 4-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,400
+Johnson,Olathe 4-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,630
+Johnson,Olathe 4-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,240
+Johnson,Olathe 4-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,260
+Johnson,Olathe 4-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,461
+Johnson,Olathe 4-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,622
+Johnson,Olathe 4-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,509
+Johnson,Olathe 4-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,470
+Johnson,Olathe 4-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,654
+Johnson,Olathe 4-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,389
+Johnson,Olathe 4-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,210
+Johnson,Olathe 4-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,654
+Johnson,Olathe 4-13,President,,"Romney, Mitt",Mitt,,Romney,,Republican,249
+Johnson,Olathe 4-14,President,,"Romney, Mitt",Mitt,,Romney,,Republican,581
+Johnson,Olathe 4-15,President,,"Romney, Mitt",Mitt,,Romney,,Republican,36
+Johnson,Olathe 4-16,President,,"Romney, Mitt",Mitt,,Romney,,Republican,1
+Johnson,Olathe 4-17,President,,"Romney, Mitt",Mitt,,Romney,,Republican,4
+Johnson,Olathe 4-18,President,,"Romney, Mitt",Mitt,,Romney,,Republican,151
+Johnson,Olathe Twp 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,225
+Johnson,Olathe Twp 0-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,50
+Johnson,Olathe Twp 0-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,25
+Johnson,Olathe Twp 0-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,2
+Johnson,Olathe Twp 0-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,3
+Johnson,Olathe Twp 0-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe Twp 0-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,1
+Johnson,Olathe Twp 0-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,12
+Johnson,Olathe Twp 0-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe Twp 0-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,14
+Johnson,Olathe Twp 0-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,3
+Johnson,Olathe Twp 0-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe Twp 0-13,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe Twp 0-14,President,,"Romney, Mitt",Mitt,,Romney,,Republican,1
+Johnson,Olathe Twp 0-17,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe Twp 0-24,President,,"Romney, Mitt",Mitt,,Romney,,Republican,3
+Johnson,Olathe Twp 0-25,President,,"Romney, Mitt",Mitt,,Romney,,Republican,7
+Johnson,Olathe Twp 0-26,President,,"Romney, Mitt",Mitt,,Romney,,Republican,4
+Johnson,Olathe Twp 0-27,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Olathe Twp 0-32,President,,"Romney, Mitt",Mitt,,Romney,,Republican,21
+Johnson,Overland Park 1-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,296
+Johnson,Overland Park 1-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,285
+Johnson,Overland Park 1-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,356
+Johnson,Overland Park 1-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,158
+Johnson,Overland Park 1-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,226
+Johnson,Overland Park 1-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,396
+Johnson,Overland Park 1-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,423
+Johnson,Overland Park 1-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,287
+Johnson,Overland Park 1-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,188
+Johnson,Overland Park 1-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,340
+Johnson,Overland Park 1-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,126
+Johnson,Overland Park 1-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,325
+Johnson,Overland Park 1-13,President,,"Romney, Mitt",Mitt,,Romney,,Republican,238
+Johnson,Overland Park 1-14,President,,"Romney, Mitt",Mitt,,Romney,,Republican,307
+Johnson,Overland Park 1-15,President,,"Romney, Mitt",Mitt,,Romney,,Republican,148
+Johnson,Overland Park 1-16,President,,"Romney, Mitt",Mitt,,Romney,,Republican,348
+Johnson,Overland Park 1-17,President,,"Romney, Mitt",Mitt,,Romney,,Republican,164
+Johnson,Overland Park 1-18,President,,"Romney, Mitt",Mitt,,Romney,,Republican,324
+Johnson,Overland Park 1-19,President,,"Romney, Mitt",Mitt,,Romney,,Republican,258
+Johnson,Overland Park 1-20,President,,"Romney, Mitt",Mitt,,Romney,,Republican,197
+Johnson,Overland Park 1-21,President,,"Romney, Mitt",Mitt,,Romney,,Republican,131
+Johnson,Overland Park 1-22,President,,"Romney, Mitt",Mitt,,Romney,,Republican,65
+Johnson,Overland Park 2-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,302
+Johnson,Overland Park 2-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,305
+Johnson,Overland Park 2-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,292
+Johnson,Overland Park 2-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,349
+Johnson,Overland Park 2-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,309
+Johnson,Overland Park 2-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,326
+Johnson,Overland Park 2-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,256
+Johnson,Overland Park 2-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,144
+Johnson,Overland Park 2-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,288
+Johnson,Overland Park 2-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,274
+Johnson,Overland Park 2-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,321
+Johnson,Overland Park 2-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,248
+Johnson,Overland Park 2-13,President,,"Romney, Mitt",Mitt,,Romney,,Republican,175
+Johnson,Overland Park 2-14,President,,"Romney, Mitt",Mitt,,Romney,,Republican,214
+Johnson,Overland Park 2-15,President,,"Romney, Mitt",Mitt,,Romney,,Republican,434
+Johnson,Overland Park 2-16,President,,"Romney, Mitt",Mitt,,Romney,,Republican,258
+Johnson,Overland Park 2-17,President,,"Romney, Mitt",Mitt,,Romney,,Republican,476
+Johnson,Overland Park 2-18,President,,"Romney, Mitt",Mitt,,Romney,,Republican,402
+Johnson,Overland Park 2-19,President,,"Romney, Mitt",Mitt,,Romney,,Republican,275
+Johnson,Overland Park 2-20,President,,"Romney, Mitt",Mitt,,Romney,,Republican,279
+Johnson,Overland Park 2-21,President,,"Romney, Mitt",Mitt,,Romney,,Republican,262
+Johnson,Overland Park 2-22,President,,"Romney, Mitt",Mitt,,Romney,,Republican,308
+Johnson,Overland Park 2-23,President,,"Romney, Mitt",Mitt,,Romney,,Republican,350
+Johnson,Overland Park 2-24,President,,"Romney, Mitt",Mitt,,Romney,,Republican,541
+Johnson,Overland Park 2-25,President,,"Romney, Mitt",Mitt,,Romney,,Republican,377
+Johnson,Overland Park 2-26,President,,"Romney, Mitt",Mitt,,Romney,,Republican,133
+Johnson,Overland Park 3-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,662
+Johnson,Overland Park 3-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,353
+Johnson,Overland Park 3-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,374
+Johnson,Overland Park 3-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,432
+Johnson,Overland Park 3-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,439
+Johnson,Overland Park 3-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,473
+Johnson,Overland Park 3-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,294
+Johnson,Overland Park 3-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,388
+Johnson,Overland Park 3-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,551
+Johnson,Overland Park 3-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,315
+Johnson,Overland Park 3-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,432
+Johnson,Overland Park 3-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,230
+Johnson,Overland Park 3-13,President,,"Romney, Mitt",Mitt,,Romney,,Republican,707
+Johnson,Overland Park 3-14,President,,"Romney, Mitt",Mitt,,Romney,,Republican,424
+Johnson,Overland Park 3-15,President,,"Romney, Mitt",Mitt,,Romney,,Republican,330
+Johnson,Overland Park 3-16,President,,"Romney, Mitt",Mitt,,Romney,,Republican,360
+Johnson,Overland Park 3-17,President,,"Romney, Mitt",Mitt,,Romney,,Republican,309
+Johnson,Overland Park 3-18,President,,"Romney, Mitt",Mitt,,Romney,,Republican,335
+Johnson,Overland Park 3-19,President,,"Romney, Mitt",Mitt,,Romney,,Republican,440
+Johnson,Overland Park 3-20,President,,"Romney, Mitt",Mitt,,Romney,,Republican,504
+Johnson,Overland Park 4-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,389
+Johnson,Overland Park 4-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,694
+Johnson,Overland Park 4-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,806
+Johnson,Overland Park 4-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,775
+Johnson,Overland Park 4-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,569
+Johnson,Overland Park 4-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,416
+Johnson,Overland Park 4-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,313
+Johnson,Overland Park 4-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,526
+Johnson,Overland Park 4-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,578
+Johnson,Overland Park 4-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,418
+Johnson,Overland Park 4-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,541
+Johnson,Overland Park 4-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,765
+Johnson,Overland Park 4-13,President,,"Romney, Mitt",Mitt,,Romney,,Republican,457
+Johnson,Overland Park 4-14,President,,"Romney, Mitt",Mitt,,Romney,,Republican,327
+Johnson,Overland Park 4-15,President,,"Romney, Mitt",Mitt,,Romney,,Republican,722
+Johnson,Overland Park 4-16,President,,"Romney, Mitt",Mitt,,Romney,,Republican,608
+Johnson,Overland Park 4-17,President,,"Romney, Mitt",Mitt,,Romney,,Republican,587
+Johnson,Overland Park 4-18,President,,"Romney, Mitt",Mitt,,Romney,,Republican,105
+Johnson,Overland Park 5-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,505
+Johnson,Overland Park 5-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,250
+Johnson,Overland Park 5-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,407
+Johnson,Overland Park 5-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,417
+Johnson,Overland Park 5-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,316
+Johnson,Overland Park 5-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,485
+Johnson,Overland Park 5-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,775
+Johnson,Overland Park 5-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,805
+Johnson,Overland Park 5-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,686
+Johnson,Overland Park 5-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,506
+Johnson,Overland Park 5-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,547
+Johnson,Overland Park 5-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,137
+Johnson,Overland Park 5-13,President,,"Romney, Mitt",Mitt,,Romney,,Republican,548
+Johnson,Overland Park 5-14,President,,"Romney, Mitt",Mitt,,Romney,,Republican,511
+Johnson,Overland Park 5-15,President,,"Romney, Mitt",Mitt,,Romney,,Republican,434
+Johnson,Overland Park 5-16,President,,"Romney, Mitt",Mitt,,Romney,,Republican,309
+Johnson,Overland Park 5-17,President,,"Romney, Mitt",Mitt,,Romney,,Republican,195
+Johnson,Overland Park 5-18,President,,"Romney, Mitt",Mitt,,Romney,,Republican,369
+Johnson,Overland Park 5-19,President,,"Romney, Mitt",Mitt,,Romney,,Republican,56
+Johnson,Overland Park 6-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,690
+Johnson,Overland Park 6-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,549
+Johnson,Overland Park 6-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,660
+Johnson,Overland Park 6-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,704
+Johnson,Overland Park 6-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,650
+Johnson,Overland Park 6-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,1
+Johnson,Overland Park 6-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,196
+Johnson,Overland Park 6-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,888
+Johnson,Overland Park 6-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,725
+Johnson,Overland Park 6-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,526
+Johnson,Overland Park 6-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,512
+Johnson,Overland Park 6-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,228
+Johnson,Overland Park 6-13,President,,"Romney, Mitt",Mitt,,Romney,,Republican,711
+Johnson,Overland Park 6-14,President,,"Romney, Mitt",Mitt,,Romney,,Republican,3
+Johnson,Overland Park 6-15,President,,"Romney, Mitt",Mitt,,Romney,,Republican,775
+Johnson,Overland Park 6-16,President,,"Romney, Mitt",Mitt,,Romney,,Republican,422
+Johnson,Overland Park 6-17,President,,"Romney, Mitt",Mitt,,Romney,,Republican,560
+Johnson,Overland Park 6-18,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Overland Park 6-19,President,,"Romney, Mitt",Mitt,,Romney,,Republican,633
+Johnson,Overland Park 6-20,President,,"Romney, Mitt",Mitt,,Romney,,Republican,331
+Johnson,Overland Park 6-21,President,,"Romney, Mitt",Mitt,,Romney,,Republican,913
+Johnson,Overland Park 6-22,President,,"Romney, Mitt",Mitt,,Romney,,Republican,266
+Johnson,Overland Park 6-23,President,,"Romney, Mitt",Mitt,,Romney,,Republican,115
+Johnson,Oxford Twp 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Oxford Twp 0-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,410
+Johnson,Oxford Twp 0-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Oxford Twp 0-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,351
+Johnson,Oxford Twp 0-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,15
+Johnson,Oxford Twp 0-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Oxford Twp 0-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,23
+Johnson,Oxford Twp 0-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,2
+Johnson,Oxford Twp 0-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,100
+Johnson,Prairie Village 1-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,439
+Johnson,Prairie Village 1-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,318
+Johnson,Prairie Village 1-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,426
+Johnson,Prairie Village 2-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,336
+Johnson,Prairie Village 2-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,190
+Johnson,Prairie Village 2-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,319
+Johnson,Prairie Village 3-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,272
+Johnson,Prairie Village 3-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,386
+Johnson,Prairie Village 3-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,330
+Johnson,Prairie Village 4-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,464
+Johnson,Prairie Village 4-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,278
+Johnson,Prairie Village 4-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,418
+Johnson,Prairie Village 5-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,473
+Johnson,Prairie Village 5-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,499
+Johnson,Prairie Village 5-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,354
+Johnson,Prairie Village 6-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,404
+Johnson,Prairie Village 6-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,278
+Johnson,Prairie Village 6-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,235
+Johnson,Roeland Park 1-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,144
+Johnson,Roeland Park 1-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,112
+Johnson,Roeland Park 1-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Roeland Park 2-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,175
+Johnson,Roeland Park 2-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,236
+Johnson,Roeland Park 3-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,126
+Johnson,Roeland Park 3-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,250
+Johnson,Roeland Park 4-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,132
+Johnson,Roeland Park 4-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,342
+Johnson,Shawnee 1-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,486
+Johnson,Shawnee 1-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,352
+Johnson,Shawnee 1-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,325
+Johnson,Shawnee 1-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,649
+Johnson,Shawnee 1-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,608
+Johnson,Shawnee 1-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,525
+Johnson,Shawnee 1-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,527
+Johnson,Shawnee 1-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,619
+Johnson,Shawnee 1-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,67
+Johnson,Shawnee 1-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,211
+Johnson,Shawnee 1-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,431
+Johnson,Shawnee 1-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,4
+Johnson,Shawnee 2-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,208
+Johnson,Shawnee 2-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,402
+Johnson,Shawnee 2-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,296
+Johnson,Shawnee 2-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,471
+Johnson,Shawnee 2-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,251
+Johnson,Shawnee 2-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,356
+Johnson,Shawnee 2-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,274
+Johnson,Shawnee 2-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,258
+Johnson,Shawnee 2-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,247
+Johnson,Shawnee 2-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,204
+Johnson,Shawnee 2-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,332
+Johnson,Shawnee 2-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,79
+Johnson,Shawnee 2-13,President,,"Romney, Mitt",Mitt,,Romney,,Republican,162
+Johnson,Shawnee 3-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,402
+Johnson,Shawnee 3-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,714
+Johnson,Shawnee 3-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,555
+Johnson,Shawnee 3-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,525
+Johnson,Shawnee 3-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,676
+Johnson,Shawnee 3-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,508
+Johnson,Shawnee 3-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,647
+Johnson,Shawnee 3-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,638
+Johnson,Shawnee 3-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,399
+Johnson,Shawnee 4-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,632
+Johnson,Shawnee 4-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,358
+Johnson,Shawnee 4-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,156
+Johnson,Shawnee 4-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,143
+Johnson,Shawnee 4-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,459
+Johnson,Shawnee 4-06,President,,"Romney, Mitt",Mitt,,Romney,,Republican,423
+Johnson,Shawnee 4-07,President,,"Romney, Mitt",Mitt,,Romney,,Republican,656
+Johnson,Shawnee 4-08,President,,"Romney, Mitt",Mitt,,Romney,,Republican,241
+Johnson,Shawnee 4-09,President,,"Romney, Mitt",Mitt,,Romney,,Republican,742
+Johnson,Shawnee 4-10,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Shawnee 4-11,President,,"Romney, Mitt",Mitt,,Romney,,Republican,356
+Johnson,Shawnee 4-12,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Shawnee 4-13,President,,"Romney, Mitt",Mitt,,Romney,,Republican,56
+Johnson,Spring Hill 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,854
+Johnson,Spring Hill 0-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Spring Hill 0-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,32
+Johnson,Spring Hill 0-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,0
+Johnson,Spring Hill Twp 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,639
+Johnson,Spring Hill Twp 0-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,1
+Johnson,Spring Hill Twp 0-03,President,,"Romney, Mitt",Mitt,,Romney,,Republican,61
+Johnson,Spring Hill Twp 0-04,President,,"Romney, Mitt",Mitt,,Romney,,Republican,13
+Johnson,Spring Hill Twp 0-05,President,,"Romney, Mitt",Mitt,,Romney,,Republican,6
+Johnson,Westwood 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,174
+Johnson,Westwood 0-02,President,,"Romney, Mitt",Mitt,,Romney,,Republican,193
+Johnson,Westwood Hills 0-01,President,,"Romney, Mitt",Mitt,,Romney,,Republican,99
+Johnson,Total,President,,"Romney, Mitt",Mitt,,Romney,,Republican,158401
+Johnson,Aubry Twp 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,29
+Johnson,Aubry Twp 0-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,146
+Johnson,Aubry Twp 0-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,101
+Johnson,Aubry Twp 0-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,204
+Johnson,Aubry Twp 0-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,2
+Johnson,Aubry Twp 0-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,17
+Johnson,Bonner Springs 4-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,De Soto 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,259
+Johnson,De Soto 0-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,145
+Johnson,De Soto 0-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,206
+Johnson,De Soto 0-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,De Soto 0-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,De Soto 0-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,31
+Johnson,De Soto 0-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,De Soto 0-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Edgerton 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,163
+Johnson,Edgerton 0-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Edgerton 0-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Edgerton 0-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Edgerton 0-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Edgerton 0-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Edgerton 0-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Edgerton 0-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Fairway 1-00,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,157
+Johnson,Fairway 2-00,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,169
+Johnson,Fairway 3-00,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,169
+Johnson,Fairway 4-00,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,271
+Johnson,Gardner 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,275
+Johnson,Gardner 0-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,72
+Johnson,Gardner 0-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,262
+Johnson,Gardner 0-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,172
+Johnson,Gardner 0-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Gardner 0-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,237
+Johnson,Gardner 0-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,10
+Johnson,Gardner 0-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,11
+Johnson,Gardner 0-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,274
+Johnson,Gardner 0-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,182
+Johnson,Gardner 0-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Gardner 0-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,11
+Johnson,Gardner 0-13,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,234
+Johnson,Gardner 0-14,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,190
+Johnson,Gardner 0-15,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Gardner Twp 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,99
+Johnson,Gardner Twp 0-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,120
+Johnson,Gardner Twp 0-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Gardner Twp 0-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Gardner Twp 0-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,2
+Johnson,Gardner Twp 0-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Gardner Twp 0-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,2
+Johnson,Gardner Twp 0-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,3
+Johnson,Gardner Twp 0-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Gardner Twp 0-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Gardner Twp 0-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,35
+Johnson,Gardner Twp 0-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Lake Quivira 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,130
+Johnson,Leawood 1-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,194
+Johnson,Leawood 1-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,228
+Johnson,Leawood 1-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,215
+Johnson,Leawood 1-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,172
+Johnson,Leawood 1-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,162
+Johnson,Leawood 1-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,53
+Johnson,Leawood 2-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,186
+Johnson,Leawood 2-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,239
+Johnson,Leawood 2-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,204
+Johnson,Leawood 2-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,148
+Johnson,Leawood 2-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,147
+Johnson,Leawood 2-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,94
+Johnson,Leawood 3-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,128
+Johnson,Leawood 3-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,204
+Johnson,Leawood 3-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,96
+Johnson,Leawood 3-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,54
+Johnson,Leawood 3-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,243
+Johnson,Leawood 3-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,217
+Johnson,Leawood 3-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,160
+Johnson,Leawood 4-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,34
+Johnson,Leawood 4-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,143
+Johnson,Leawood 4-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,169
+Johnson,Leawood 4-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,191
+Johnson,Leawood 4-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,176
+Johnson,Leawood 4-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,91
+Johnson,Leawood 4-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,204
+Johnson,Leawood 4-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,76
+Johnson,Lenexa 1-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,139
+Johnson,Lenexa 1-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,292
+Johnson,Lenexa 1-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,320
+Johnson,Lenexa 1-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,287
+Johnson,Lenexa 1-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,262
+Johnson,Lenexa 1-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,216
+Johnson,Lenexa 1-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,162
+Johnson,Lenexa 1-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,93
+Johnson,Lenexa 1-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,6
+Johnson,Lenexa 2-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,206
+Johnson,Lenexa 2-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,47
+Johnson,Lenexa 2-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,212
+Johnson,Lenexa 2-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,177
+Johnson,Lenexa 2-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,340
+Johnson,Lenexa 2-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,143
+Johnson,Lenexa 2-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,298
+Johnson,Lenexa 2-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Lenexa 3-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,291
+Johnson,Lenexa 3-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,336
+Johnson,Lenexa 3-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,301
+Johnson,Lenexa 3-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,191
+Johnson,Lenexa 3-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,250
+Johnson,Lenexa 3-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,222
+Johnson,Lenexa 3-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,254
+Johnson,Lenexa 3-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,234
+Johnson,Lenexa 4-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,111
+Johnson,Lenexa 4-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,217
+Johnson,Lenexa 4-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,213
+Johnson,Lenexa 4-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,170
+Johnson,Lenexa 4-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,104
+Johnson,Lenexa 4-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,220
+Johnson,Lenexa 4-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,199
+Johnson,Lenexa 4-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,147
+Johnson,Lenexa 4-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,205
+Johnson,Lenexa 4-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,145
+Johnson,Lenexa 4-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,45
+Johnson,Lexington Twp 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,184
+Johnson,Lexington Twp 0-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,1
+Johnson,Lexington Twp 0-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,1
+Johnson,Lexington Twp 0-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Lexington Twp 0-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,McCamish Twp 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,40
+Johnson,McCamish Twp 0-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,80
+Johnson,McCamish Twp 0-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Merriam 1-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,174
+Johnson,Merriam 1-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,249
+Johnson,Merriam 2-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,276
+Johnson,Merriam 2-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,1
+Johnson,Merriam 2-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,153
+Johnson,Merriam 3-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,278
+Johnson,Merriam 3-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,213
+Johnson,Merriam 4-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,272
+Johnson,Merriam 4-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,123
+Johnson,Merriam 4-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,144
+Johnson,Mission 1-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,259
+Johnson,Mission 1-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,180
+Johnson,Mission 2-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,179
+Johnson,Mission 2-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,228
+Johnson,Mission 3-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,278
+Johnson,Mission 3-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,131
+Johnson,Mission 4-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,149
+Johnson,Mission 4-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,184
+Johnson,Mission 4-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,125
+Johnson,Mission Hills 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,91
+Johnson,Mission Hills 0-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,126
+Johnson,Mission Hills 0-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,60
+Johnson,Mission Hills 0-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,137
+Johnson,Mission Woods 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,38
+Johnson,Olathe 1-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,234
+Johnson,Olathe 1-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,168
+Johnson,Olathe 1-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,143
+Johnson,Olathe 1-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,202
+Johnson,Olathe 1-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,226
+Johnson,Olathe 1-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,115
+Johnson,Olathe 1-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 1-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,286
+Johnson,Olathe 1-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,228
+Johnson,Olathe 1-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,1
+Johnson,Olathe 1-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,49
+Johnson,Olathe 1-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,7
+Johnson,Olathe 1-13,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 1-14,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,182
+Johnson,Olathe 1-15,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,180
+Johnson,Olathe 1-16,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,199
+Johnson,Olathe 1-17,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,33
+Johnson,Olathe 1-18,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,51
+Johnson,Olathe 1-19,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,114
+Johnson,Olathe 1-20,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,199
+Johnson,Olathe 1-21,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,280
+Johnson,Olathe 1-22,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,252
+Johnson,Olathe 1-23,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 1-24,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 1-25,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 1-26,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,2
+Johnson,Olathe 1-27,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,202
+Johnson,Olathe 1-28,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,56
+Johnson,Olathe 1-29,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,24
+Johnson,Olathe 2-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,100
+Johnson,Olathe 2-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,119
+Johnson,Olathe 2-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,199
+Johnson,Olathe 2-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,246
+Johnson,Olathe 2-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,279
+Johnson,Olathe 2-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,126
+Johnson,Olathe 2-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,259
+Johnson,Olathe 2-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,297
+Johnson,Olathe 2-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,83
+Johnson,Olathe 2-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,424
+Johnson,Olathe 2-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,327
+Johnson,Olathe 2-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,159
+Johnson,Olathe 2-13,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,198
+Johnson,Olathe 2-14,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,181
+Johnson,Olathe 2-15,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,90
+Johnson,Olathe 2-16,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 2-17,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 2-18,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 2-19,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,1
+Johnson,Olathe 2-20,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 2-21,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 2-22,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,250
+Johnson,Olathe 2-23,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,207
+Johnson,Olathe 2-24,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,1
+Johnson,Olathe 2-25,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,4
+Johnson,Olathe 2-26,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 2-27,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,1
+Johnson,Olathe 2-28,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,83
+Johnson,Olathe 3-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,123
+Johnson,Olathe 3-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,294
+Johnson,Olathe 3-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,115
+Johnson,Olathe 3-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,229
+Johnson,Olathe 3-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,167
+Johnson,Olathe 3-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,118
+Johnson,Olathe 3-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,153
+Johnson,Olathe 3-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,189
+Johnson,Olathe 3-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,119
+Johnson,Olathe 3-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,234
+Johnson,Olathe 3-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,178
+Johnson,Olathe 3-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,253
+Johnson,Olathe 3-13,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,217
+Johnson,Olathe 3-14,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 3-15,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,162
+Johnson,Olathe 3-16,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,146
+Johnson,Olathe 3-17,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,211
+Johnson,Olathe 3-18,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,193
+Johnson,Olathe 3-19,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,93
+Johnson,Olathe 3-20,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,126
+Johnson,Olathe 3-21,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,64
+Johnson,Olathe 3-22,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,226
+Johnson,Olathe 3-23,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,233
+Johnson,Olathe 3-24,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 3-25,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 3-26,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,27
+Johnson,Olathe 3-27,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,94
+Johnson,Olathe 4-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,274
+Johnson,Olathe 4-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,296
+Johnson,Olathe 4-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,177
+Johnson,Olathe 4-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,180
+Johnson,Olathe 4-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,217
+Johnson,Olathe 4-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,305
+Johnson,Olathe 4-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,312
+Johnson,Olathe 4-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,175
+Johnson,Olathe 4-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,271
+Johnson,Olathe 4-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,159
+Johnson,Olathe 4-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,171
+Johnson,Olathe 4-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,263
+Johnson,Olathe 4-13,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,166
+Johnson,Olathe 4-14,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,266
+Johnson,Olathe 4-15,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,40
+Johnson,Olathe 4-16,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe 4-17,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,1
+Johnson,Olathe 4-18,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,126
+Johnson,Olathe Twp 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,106
+Johnson,Olathe Twp 0-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,14
+Johnson,Olathe Twp 0-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,19
+Johnson,Olathe Twp 0-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe Twp 0-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe Twp 0-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,1
+Johnson,Olathe Twp 0-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe Twp 0-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,3
+Johnson,Olathe Twp 0-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe Twp 0-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,6
+Johnson,Olathe Twp 0-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,1
+Johnson,Olathe Twp 0-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe Twp 0-13,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe Twp 0-14,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe Twp 0-17,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe Twp 0-24,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,1
+Johnson,Olathe Twp 0-25,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,2
+Johnson,Olathe Twp 0-26,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe Twp 0-27,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Olathe Twp 0-32,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,8
+Johnson,Overland Park 1-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,301
+Johnson,Overland Park 1-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,291
+Johnson,Overland Park 1-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,242
+Johnson,Overland Park 1-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,82
+Johnson,Overland Park 1-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,175
+Johnson,Overland Park 1-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,277
+Johnson,Overland Park 1-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,305
+Johnson,Overland Park 1-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,263
+Johnson,Overland Park 1-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,183
+Johnson,Overland Park 1-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,306
+Johnson,Overland Park 1-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,133
+Johnson,Overland Park 1-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,312
+Johnson,Overland Park 1-13,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,210
+Johnson,Overland Park 1-14,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,259
+Johnson,Overland Park 1-15,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,144
+Johnson,Overland Park 1-16,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,325
+Johnson,Overland Park 1-17,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,137
+Johnson,Overland Park 1-18,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,204
+Johnson,Overland Park 1-19,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,226
+Johnson,Overland Park 1-20,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,147
+Johnson,Overland Park 1-21,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,63
+Johnson,Overland Park 1-22,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,78
+Johnson,Overland Park 2-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,165
+Johnson,Overland Park 2-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,198
+Johnson,Overland Park 2-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,179
+Johnson,Overland Park 2-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,230
+Johnson,Overland Park 2-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,238
+Johnson,Overland Park 2-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,222
+Johnson,Overland Park 2-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,153
+Johnson,Overland Park 2-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,195
+Johnson,Overland Park 2-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,207
+Johnson,Overland Park 2-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,110
+Johnson,Overland Park 2-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,218
+Johnson,Overland Park 2-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,147
+Johnson,Overland Park 2-13,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,158
+Johnson,Overland Park 2-14,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,143
+Johnson,Overland Park 2-15,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,271
+Johnson,Overland Park 2-16,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,168
+Johnson,Overland Park 2-17,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,186
+Johnson,Overland Park 2-18,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,274
+Johnson,Overland Park 2-19,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,152
+Johnson,Overland Park 2-20,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,133
+Johnson,Overland Park 2-21,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,168
+Johnson,Overland Park 2-22,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,227
+Johnson,Overland Park 2-23,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,125
+Johnson,Overland Park 2-24,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,273
+Johnson,Overland Park 2-25,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,182
+Johnson,Overland Park 2-26,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,110
+Johnson,Overland Park 3-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,253
+Johnson,Overland Park 3-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,205
+Johnson,Overland Park 3-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,132
+Johnson,Overland Park 3-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,268
+Johnson,Overland Park 3-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,212
+Johnson,Overland Park 3-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,272
+Johnson,Overland Park 3-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,211
+Johnson,Overland Park 3-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,185
+Johnson,Overland Park 3-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,282
+Johnson,Overland Park 3-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,115
+Johnson,Overland Park 3-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,164
+Johnson,Overland Park 3-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,183
+Johnson,Overland Park 3-13,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,345
+Johnson,Overland Park 3-14,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,277
+Johnson,Overland Park 3-15,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,147
+Johnson,Overland Park 3-16,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,181
+Johnson,Overland Park 3-17,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,130
+Johnson,Overland Park 3-18,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,229
+Johnson,Overland Park 3-19,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,206
+Johnson,Overland Park 3-20,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,229
+Johnson,Overland Park 4-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,145
+Johnson,Overland Park 4-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,207
+Johnson,Overland Park 4-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,205
+Johnson,Overland Park 4-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,226
+Johnson,Overland Park 4-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,168
+Johnson,Overland Park 4-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,149
+Johnson,Overland Park 4-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,166
+Johnson,Overland Park 4-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,160
+Johnson,Overland Park 4-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,112
+Johnson,Overland Park 4-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,117
+Johnson,Overland Park 4-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,227
+Johnson,Overland Park 4-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,304
+Johnson,Overland Park 4-13,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,103
+Johnson,Overland Park 4-14,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,103
+Johnson,Overland Park 4-15,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,218
+Johnson,Overland Park 4-16,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,163
+Johnson,Overland Park 4-17,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,213
+Johnson,Overland Park 4-18,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,66
+Johnson,Overland Park 5-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,205
+Johnson,Overland Park 5-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,125
+Johnson,Overland Park 5-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,152
+Johnson,Overland Park 5-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,253
+Johnson,Overland Park 5-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,192
+Johnson,Overland Park 5-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,203
+Johnson,Overland Park 5-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,159
+Johnson,Overland Park 5-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,290
+Johnson,Overland Park 5-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,237
+Johnson,Overland Park 5-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,208
+Johnson,Overland Park 5-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,299
+Johnson,Overland Park 5-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,74
+Johnson,Overland Park 5-13,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,250
+Johnson,Overland Park 5-14,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,198
+Johnson,Overland Park 5-15,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,203
+Johnson,Overland Park 5-16,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,131
+Johnson,Overland Park 5-17,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,92
+Johnson,Overland Park 5-18,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,174
+Johnson,Overland Park 5-19,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,12
+Johnson,Overland Park 6-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,210
+Johnson,Overland Park 6-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,158
+Johnson,Overland Park 6-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,171
+Johnson,Overland Park 6-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,149
+Johnson,Overland Park 6-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,243
+Johnson,Overland Park 6-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Overland Park 6-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,46
+Johnson,Overland Park 6-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,163
+Johnson,Overland Park 6-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,268
+Johnson,Overland Park 6-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,219
+Johnson,Overland Park 6-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,208
+Johnson,Overland Park 6-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,102
+Johnson,Overland Park 6-13,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,192
+Johnson,Overland Park 6-14,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,1
+Johnson,Overland Park 6-15,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,186
+Johnson,Overland Park 6-16,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,107
+Johnson,Overland Park 6-17,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,195
+Johnson,Overland Park 6-18,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Overland Park 6-19,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,235
+Johnson,Overland Park 6-20,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,77
+Johnson,Overland Park 6-21,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,136
+Johnson,Overland Park 6-22,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,59
+Johnson,Overland Park 6-23,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,41
+Johnson,Oxford Twp 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,1
+Johnson,Oxford Twp 0-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,121
+Johnson,Oxford Twp 0-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Oxford Twp 0-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,116
+Johnson,Oxford Twp 0-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Oxford Twp 0-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Oxford Twp 0-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,12
+Johnson,Oxford Twp 0-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Oxford Twp 0-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,15
+Johnson,Prairie Village 1-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,283
+Johnson,Prairie Village 1-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,207
+Johnson,Prairie Village 1-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,296
+Johnson,Prairie Village 2-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,255
+Johnson,Prairie Village 2-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,155
+Johnson,Prairie Village 2-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,253
+Johnson,Prairie Village 3-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,153
+Johnson,Prairie Village 3-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,238
+Johnson,Prairie Village 3-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,253
+Johnson,Prairie Village 4-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,195
+Johnson,Prairie Village 4-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,182
+Johnson,Prairie Village 4-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,264
+Johnson,Prairie Village 5-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,237
+Johnson,Prairie Village 5-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,187
+Johnson,Prairie Village 5-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,155
+Johnson,Prairie Village 6-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,263
+Johnson,Prairie Village 6-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,241
+Johnson,Prairie Village 6-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,191
+Johnson,Roeland Park 1-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,149
+Johnson,Roeland Park 1-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,100
+Johnson,Roeland Park 1-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Roeland Park 2-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,154
+Johnson,Roeland Park 2-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,191
+Johnson,Roeland Park 3-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,136
+Johnson,Roeland Park 3-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,218
+Johnson,Roeland Park 4-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,88
+Johnson,Roeland Park 4-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,298
+Johnson,Shawnee 1-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,292
+Johnson,Shawnee 1-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,151
+Johnson,Shawnee 1-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,191
+Johnson,Shawnee 1-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,250
+Johnson,Shawnee 1-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,313
+Johnson,Shawnee 1-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,182
+Johnson,Shawnee 1-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,259
+Johnson,Shawnee 1-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,246
+Johnson,Shawnee 1-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,72
+Johnson,Shawnee 1-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,54
+Johnson,Shawnee 1-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,157
+Johnson,Shawnee 1-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,4
+Johnson,Shawnee 2-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,149
+Johnson,Shawnee 2-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,232
+Johnson,Shawnee 2-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,242
+Johnson,Shawnee 2-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,304
+Johnson,Shawnee 2-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,157
+Johnson,Shawnee 2-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,169
+Johnson,Shawnee 2-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,187
+Johnson,Shawnee 2-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,168
+Johnson,Shawnee 2-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,177
+Johnson,Shawnee 2-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,138
+Johnson,Shawnee 2-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,185
+Johnson,Shawnee 2-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,95
+Johnson,Shawnee 2-13,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,93
+Johnson,Shawnee 3-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,131
+Johnson,Shawnee 3-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,246
+Johnson,Shawnee 3-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,210
+Johnson,Shawnee 3-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,154
+Johnson,Shawnee 3-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,200
+Johnson,Shawnee 3-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,270
+Johnson,Shawnee 3-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,262
+Johnson,Shawnee 3-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,216
+Johnson,Shawnee 3-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,118
+Johnson,Shawnee 4-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,293
+Johnson,Shawnee 4-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,157
+Johnson,Shawnee 4-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,80
+Johnson,Shawnee 4-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,172
+Johnson,Shawnee 4-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,262
+Johnson,Shawnee 4-06,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,215
+Johnson,Shawnee 4-07,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,264
+Johnson,Shawnee 4-08,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,87
+Johnson,Shawnee 4-09,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,353
+Johnson,Shawnee 4-10,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Shawnee 4-11,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,224
+Johnson,Shawnee 4-12,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Shawnee 4-13,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,24
+Johnson,Spring Hill 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,322
+Johnson,Spring Hill 0-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Spring Hill 0-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,4
+Johnson,Spring Hill 0-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Spring Hill Twp 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,200
+Johnson,Spring Hill Twp 0-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,0
+Johnson,Spring Hill Twp 0-03,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,19
+Johnson,Spring Hill Twp 0-04,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,3
+Johnson,Spring Hill Twp 0-05,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,4
+Johnson,Westwood 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,205
+Johnson,Westwood 0-02,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,152
+Johnson,Westwood Hills 0-01,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,83
+Johnson,Total,U.S. House,3,"Balam, Joel",Joel,,Balam,,Libertarian,73018
+Johnson,Aubry Twp 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,92
+Johnson,Aubry Twp 0-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,596
+Johnson,Aubry Twp 0-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,316
+Johnson,Aubry Twp 0-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,731
+Johnson,Aubry Twp 0-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,13
+Johnson,Aubry Twp 0-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,87
+Johnson,Bonner Springs 4-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,De Soto 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,610
+Johnson,De Soto 0-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,349
+Johnson,De Soto 0-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,565
+Johnson,De Soto 0-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,De Soto 0-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,De Soto 0-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,40
+Johnson,De Soto 0-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,2
+Johnson,De Soto 0-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Edgerton 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,455
+Johnson,Edgerton 0-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Edgerton 0-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Edgerton 0-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Edgerton 0-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Edgerton 0-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Edgerton 0-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Edgerton 0-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Fairway 1-00,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,396
+Johnson,Fairway 2-00,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,308
+Johnson,Fairway 3-00,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,462
+Johnson,Fairway 4-00,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,271
+Johnson,Gardner 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,879
+Johnson,Gardner 0-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,110
+Johnson,Gardner 0-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,581
+Johnson,Gardner 0-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,458
+Johnson,Gardner 0-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Gardner 0-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,654
+Johnson,Gardner 0-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,15
+Johnson,Gardner 0-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,54
+Johnson,Gardner 0-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,738
+Johnson,Gardner 0-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,498
+Johnson,Gardner 0-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Gardner 0-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,7
+Johnson,Gardner 0-13,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,573
+Johnson,Gardner 0-14,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,423
+Johnson,Gardner 0-15,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Gardner Twp 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,267
+Johnson,Gardner Twp 0-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,350
+Johnson,Gardner Twp 0-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Gardner Twp 0-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,1
+Johnson,Gardner Twp 0-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,6
+Johnson,Gardner Twp 0-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Gardner Twp 0-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,2
+Johnson,Gardner Twp 0-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,2
+Johnson,Gardner Twp 0-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,2
+Johnson,Gardner Twp 0-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Gardner Twp 0-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,76
+Johnson,Gardner Twp 0-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Lake Quivira 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,486
+Johnson,Leawood 1-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,363
+Johnson,Leawood 1-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,636
+Johnson,Leawood 1-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,563
+Johnson,Leawood 1-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,435
+Johnson,Leawood 1-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,419
+Johnson,Leawood 1-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,96
+Johnson,Leawood 2-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,530
+Johnson,Leawood 2-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,626
+Johnson,Leawood 2-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,633
+Johnson,Leawood 2-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,765
+Johnson,Leawood 2-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,378
+Johnson,Leawood 2-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,284
+Johnson,Leawood 3-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,347
+Johnson,Leawood 3-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,619
+Johnson,Leawood 3-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,429
+Johnson,Leawood 3-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,200
+Johnson,Leawood 3-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,819
+Johnson,Leawood 3-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,805
+Johnson,Leawood 3-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,617
+Johnson,Leawood 4-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,211
+Johnson,Leawood 4-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,536
+Johnson,Leawood 4-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,517
+Johnson,Leawood 4-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,676
+Johnson,Leawood 4-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,642
+Johnson,Leawood 4-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,567
+Johnson,Leawood 4-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,952
+Johnson,Leawood 4-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,370
+Johnson,Lenexa 1-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,326
+Johnson,Lenexa 1-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,658
+Johnson,Lenexa 1-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,775
+Johnson,Lenexa 1-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,480
+Johnson,Lenexa 1-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,502
+Johnson,Lenexa 1-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,704
+Johnson,Lenexa 1-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,344
+Johnson,Lenexa 1-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,139
+Johnson,Lenexa 1-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,10
+Johnson,Lenexa 2-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,771
+Johnson,Lenexa 2-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,228
+Johnson,Lenexa 2-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,799
+Johnson,Lenexa 2-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,874
+Johnson,Lenexa 2-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,498
+Johnson,Lenexa 2-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,511
+Johnson,Lenexa 2-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,756
+Johnson,Lenexa 2-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Lenexa 3-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,379
+Johnson,Lenexa 3-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,547
+Johnson,Lenexa 3-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,680
+Johnson,Lenexa 3-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,482
+Johnson,Lenexa 3-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,297
+Johnson,Lenexa 3-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,388
+Johnson,Lenexa 3-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,539
+Johnson,Lenexa 3-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,614
+Johnson,Lenexa 4-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,275
+Johnson,Lenexa 4-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,535
+Johnson,Lenexa 4-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,228
+Johnson,Lenexa 4-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,242
+Johnson,Lenexa 4-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,228
+Johnson,Lenexa 4-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,406
+Johnson,Lenexa 4-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,427
+Johnson,Lenexa 4-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,431
+Johnson,Lenexa 4-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,432
+Johnson,Lenexa 4-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,223
+Johnson,Lenexa 4-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,72
+Johnson,Lexington Twp 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,555
+Johnson,Lexington Twp 0-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,2
+Johnson,Lexington Twp 0-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,3
+Johnson,Lexington Twp 0-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,1
+Johnson,Lexington Twp 0-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,McCamish Twp 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,139
+Johnson,McCamish Twp 0-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,272
+Johnson,McCamish Twp 0-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Merriam 1-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,278
+Johnson,Merriam 1-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,321
+Johnson,Merriam 2-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,411
+Johnson,Merriam 2-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,1
+Johnson,Merriam 2-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,217
+Johnson,Merriam 3-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,352
+Johnson,Merriam 3-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,297
+Johnson,Merriam 4-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,427
+Johnson,Merriam 4-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,194
+Johnson,Merriam 4-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,239
+Johnson,Mission 1-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,382
+Johnson,Mission 1-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,168
+Johnson,Mission 2-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,212
+Johnson,Mission 2-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,285
+Johnson,Mission 3-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,380
+Johnson,Mission 3-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,188
+Johnson,Mission 4-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,221
+Johnson,Mission 4-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,360
+Johnson,Mission 4-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,210
+Johnson,Mission Hills 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,405
+Johnson,Mission Hills 0-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,504
+Johnson,Mission Hills 0-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,347
+Johnson,Mission Hills 0-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,479
+Johnson,Mission Woods 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,64
+Johnson,Olathe 1-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,518
+Johnson,Olathe 1-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,327
+Johnson,Olathe 1-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,296
+Johnson,Olathe 1-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,552
+Johnson,Olathe 1-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,553
+Johnson,Olathe 1-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,389
+Johnson,Olathe 1-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe 1-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,715
+Johnson,Olathe 1-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,630
+Johnson,Olathe 1-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,5
+Johnson,Olathe 1-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,74
+Johnson,Olathe 1-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,26
+Johnson,Olathe 1-13,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe 1-14,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,488
+Johnson,Olathe 1-15,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,522
+Johnson,Olathe 1-16,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,747
+Johnson,Olathe 1-17,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,156
+Johnson,Olathe 1-18,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,153
+Johnson,Olathe 1-19,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,236
+Johnson,Olathe 1-20,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,365
+Johnson,Olathe 1-21,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,667
+Johnson,Olathe 1-22,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,814
+Johnson,Olathe 1-23,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe 1-24,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe 1-25,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe 1-26,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,2
+Johnson,Olathe 1-27,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,326
+Johnson,Olathe 1-28,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,135
+Johnson,Olathe 1-29,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,94
+Johnson,Olathe 2-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,262
+Johnson,Olathe 2-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,293
+Johnson,Olathe 2-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,375
+Johnson,Olathe 2-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,445
+Johnson,Olathe 2-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,1112
+Johnson,Olathe 2-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,636
+Johnson,Olathe 2-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,704
+Johnson,Olathe 2-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,564
+Johnson,Olathe 2-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,231
+Johnson,Olathe 2-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,1022
+Johnson,Olathe 2-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,717
+Johnson,Olathe 2-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,398
+Johnson,Olathe 2-13,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,441
+Johnson,Olathe 2-14,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,429
+Johnson,Olathe 2-15,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,340
+Johnson,Olathe 2-16,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe 2-17,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe 2-18,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe 2-19,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,6
+Johnson,Olathe 2-20,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe 2-21,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe 2-22,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,764
+Johnson,Olathe 2-23,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,576
+Johnson,Olathe 2-24,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,12
+Johnson,Olathe 2-25,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,3
+Johnson,Olathe 2-26,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe 2-27,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,10
+Johnson,Olathe 2-28,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,158
+Johnson,Olathe 3-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,252
+Johnson,Olathe 3-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,708
+Johnson,Olathe 3-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,392
+Johnson,Olathe 3-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,614
+Johnson,Olathe 3-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,586
+Johnson,Olathe 3-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,470
+Johnson,Olathe 3-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,428
+Johnson,Olathe 3-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,674
+Johnson,Olathe 3-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,353
+Johnson,Olathe 3-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,712
+Johnson,Olathe 3-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,451
+Johnson,Olathe 3-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,582
+Johnson,Olathe 3-13,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,637
+Johnson,Olathe 3-14,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,3
+Johnson,Olathe 3-15,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,504
+Johnson,Olathe 3-16,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,571
+Johnson,Olathe 3-17,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,681
+Johnson,Olathe 3-18,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,617
+Johnson,Olathe 3-19,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,427
+Johnson,Olathe 3-20,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,466
+Johnson,Olathe 3-21,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,328
+Johnson,Olathe 3-22,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,520
+Johnson,Olathe 3-23,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,499
+Johnson,Olathe 3-24,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe 3-25,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe 3-26,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,54
+Johnson,Olathe 3-27,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,281
+Johnson,Olathe 4-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,451
+Johnson,Olathe 4-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,705
+Johnson,Olathe 4-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,291
+Johnson,Olathe 4-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,304
+Johnson,Olathe 4-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,521
+Johnson,Olathe 4-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,700
+Johnson,Olathe 4-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,570
+Johnson,Olathe 4-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,514
+Johnson,Olathe 4-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,715
+Johnson,Olathe 4-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,410
+Johnson,Olathe 4-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,238
+Johnson,Olathe 4-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,714
+Johnson,Olathe 4-13,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,298
+Johnson,Olathe 4-14,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,629
+Johnson,Olathe 4-15,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,45
+Johnson,Olathe 4-16,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,3
+Johnson,Olathe 4-17,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,4
+Johnson,Olathe 4-18,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,186
+Johnson,Olathe Twp 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,235
+Johnson,Olathe Twp 0-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,53
+Johnson,Olathe Twp 0-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,28
+Johnson,Olathe Twp 0-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,2
+Johnson,Olathe Twp 0-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,3
+Johnson,Olathe Twp 0-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe Twp 0-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,1
+Johnson,Olathe Twp 0-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,13
+Johnson,Olathe Twp 0-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe Twp 0-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,11
+Johnson,Olathe Twp 0-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,3
+Johnson,Olathe Twp 0-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe Twp 0-13,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe Twp 0-14,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,1
+Johnson,Olathe Twp 0-17,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe Twp 0-24,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,2
+Johnson,Olathe Twp 0-25,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,6
+Johnson,Olathe Twp 0-26,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,4
+Johnson,Olathe Twp 0-27,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Olathe Twp 0-32,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,20
+Johnson,Overland Park 1-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,367
+Johnson,Overland Park 1-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,351
+Johnson,Overland Park 1-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,391
+Johnson,Overland Park 1-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,173
+Johnson,Overland Park 1-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,275
+Johnson,Overland Park 1-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,486
+Johnson,Overland Park 1-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,514
+Johnson,Overland Park 1-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,358
+Johnson,Overland Park 1-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,208
+Johnson,Overland Park 1-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,406
+Johnson,Overland Park 1-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,160
+Johnson,Overland Park 1-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,410
+Johnson,Overland Park 1-13,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,289
+Johnson,Overland Park 1-14,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,398
+Johnson,Overland Park 1-15,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,169
+Johnson,Overland Park 1-16,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,443
+Johnson,Overland Park 1-17,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,221
+Johnson,Overland Park 1-18,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,388
+Johnson,Overland Park 1-19,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,318
+Johnson,Overland Park 1-20,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,225
+Johnson,Overland Park 1-21,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,145
+Johnson,Overland Park 1-22,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,84
+Johnson,Overland Park 2-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,360
+Johnson,Overland Park 2-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,381
+Johnson,Overland Park 2-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,343
+Johnson,Overland Park 2-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,418
+Johnson,Overland Park 2-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,386
+Johnson,Overland Park 2-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,384
+Johnson,Overland Park 2-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,309
+Johnson,Overland Park 2-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,212
+Johnson,Overland Park 2-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,342
+Johnson,Overland Park 2-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,331
+Johnson,Overland Park 2-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,361
+Johnson,Overland Park 2-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,301
+Johnson,Overland Park 2-13,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,206
+Johnson,Overland Park 2-14,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,273
+Johnson,Overland Park 2-15,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,488
+Johnson,Overland Park 2-16,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,303
+Johnson,Overland Park 2-17,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,520
+Johnson,Overland Park 2-18,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,488
+Johnson,Overland Park 2-19,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,331
+Johnson,Overland Park 2-20,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,312
+Johnson,Overland Park 2-21,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,308
+Johnson,Overland Park 2-22,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,363
+Johnson,Overland Park 2-23,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,421
+Johnson,Overland Park 2-24,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,626
+Johnson,Overland Park 2-25,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,459
+Johnson,Overland Park 2-26,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,150
+Johnson,Overland Park 3-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,736
+Johnson,Overland Park 3-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,409
+Johnson,Overland Park 3-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,417
+Johnson,Overland Park 3-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,504
+Johnson,Overland Park 3-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,500
+Johnson,Overland Park 3-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,571
+Johnson,Overland Park 3-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,369
+Johnson,Overland Park 3-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,437
+Johnson,Overland Park 3-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,640
+Johnson,Overland Park 3-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,349
+Johnson,Overland Park 3-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,505
+Johnson,Overland Park 3-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,299
+Johnson,Overland Park 3-13,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,800
+Johnson,Overland Park 3-14,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,490
+Johnson,Overland Park 3-15,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,376
+Johnson,Overland Park 3-16,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,444
+Johnson,Overland Park 3-17,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,360
+Johnson,Overland Park 3-18,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,407
+Johnson,Overland Park 3-19,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,487
+Johnson,Overland Park 3-20,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,597
+Johnson,Overland Park 4-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,419
+Johnson,Overland Park 4-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,746
+Johnson,Overland Park 4-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,851
+Johnson,Overland Park 4-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,849
+Johnson,Overland Park 4-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,645
+Johnson,Overland Park 4-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,474
+Johnson,Overland Park 4-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,355
+Johnson,Overland Park 4-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,584
+Johnson,Overland Park 4-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,611
+Johnson,Overland Park 4-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,445
+Johnson,Overland Park 4-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,630
+Johnson,Overland Park 4-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,852
+Johnson,Overland Park 4-13,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,488
+Johnson,Overland Park 4-14,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,365
+Johnson,Overland Park 4-15,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,817
+Johnson,Overland Park 4-16,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,634
+Johnson,Overland Park 4-17,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,658
+Johnson,Overland Park 4-18,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,120
+Johnson,Overland Park 5-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,579
+Johnson,Overland Park 5-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,306
+Johnson,Overland Park 5-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,447
+Johnson,Overland Park 5-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,461
+Johnson,Overland Park 5-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,378
+Johnson,Overland Park 5-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,546
+Johnson,Overland Park 5-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,818
+Johnson,Overland Park 5-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,882
+Johnson,Overland Park 5-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,756
+Johnson,Overland Park 5-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,591
+Johnson,Overland Park 5-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,668
+Johnson,Overland Park 5-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,152
+Johnson,Overland Park 5-13,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,662
+Johnson,Overland Park 5-14,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,555
+Johnson,Overland Park 5-15,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,503
+Johnson,Overland Park 5-16,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,356
+Johnson,Overland Park 5-17,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,239
+Johnson,Overland Park 5-18,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,434
+Johnson,Overland Park 5-19,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,60
+Johnson,Overland Park 6-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,718
+Johnson,Overland Park 6-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,582
+Johnson,Overland Park 6-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,715
+Johnson,Overland Park 6-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,732
+Johnson,Overland Park 6-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,722
+Johnson,Overland Park 6-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,1
+Johnson,Overland Park 6-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,206
+Johnson,Overland Park 6-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,906
+Johnson,Overland Park 6-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,791
+Johnson,Overland Park 6-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,595
+Johnson,Overland Park 6-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,571
+Johnson,Overland Park 6-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,255
+Johnson,Overland Park 6-13,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,780
+Johnson,Overland Park 6-14,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,2
+Johnson,Overland Park 6-15,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,838
+Johnson,Overland Park 6-16,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,458
+Johnson,Overland Park 6-17,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,613
+Johnson,Overland Park 6-18,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Overland Park 6-19,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,702
+Johnson,Overland Park 6-20,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,327
+Johnson,Overland Park 6-21,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,963
+Johnson,Overland Park 6-22,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,266
+Johnson,Overland Park 6-23,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,121
+Johnson,Oxford Twp 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Oxford Twp 0-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,432
+Johnson,Oxford Twp 0-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Oxford Twp 0-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,355
+Johnson,Oxford Twp 0-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,14
+Johnson,Oxford Twp 0-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Oxford Twp 0-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,19
+Johnson,Oxford Twp 0-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,2
+Johnson,Oxford Twp 0-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,96
+Johnson,Prairie Village 1-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,514
+Johnson,Prairie Village 1-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,372
+Johnson,Prairie Village 1-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,530
+Johnson,Prairie Village 2-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,400
+Johnson,Prairie Village 2-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,236
+Johnson,Prairie Village 2-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,385
+Johnson,Prairie Village 3-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,329
+Johnson,Prairie Village 3-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,472
+Johnson,Prairie Village 3-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,393
+Johnson,Prairie Village 4-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,532
+Johnson,Prairie Village 4-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,330
+Johnson,Prairie Village 4-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,502
+Johnson,Prairie Village 5-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,527
+Johnson,Prairie Village 5-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,560
+Johnson,Prairie Village 5-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,405
+Johnson,Prairie Village 6-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,487
+Johnson,Prairie Village 6-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,346
+Johnson,Prairie Village 6-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,263
+Johnson,Roeland Park 1-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,197
+Johnson,Roeland Park 1-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,137
+Johnson,Roeland Park 1-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Roeland Park 2-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,202
+Johnson,Roeland Park 2-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,268
+Johnson,Roeland Park 3-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,162
+Johnson,Roeland Park 3-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,311
+Johnson,Roeland Park 4-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,156
+Johnson,Roeland Park 4-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,407
+Johnson,Shawnee 1-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,537
+Johnson,Shawnee 1-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,417
+Johnson,Shawnee 1-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,382
+Johnson,Shawnee 1-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,719
+Johnson,Shawnee 1-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,687
+Johnson,Shawnee 1-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,570
+Johnson,Shawnee 1-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,579
+Johnson,Shawnee 1-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,683
+Johnson,Shawnee 1-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,89
+Johnson,Shawnee 1-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,231
+Johnson,Shawnee 1-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,505
+Johnson,Shawnee 1-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,5
+Johnson,Shawnee 2-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,235
+Johnson,Shawnee 2-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,442
+Johnson,Shawnee 2-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,366
+Johnson,Shawnee 2-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,528
+Johnson,Shawnee 2-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,273
+Johnson,Shawnee 2-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,402
+Johnson,Shawnee 2-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,309
+Johnson,Shawnee 2-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,277
+Johnson,Shawnee 2-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,270
+Johnson,Shawnee 2-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,246
+Johnson,Shawnee 2-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,395
+Johnson,Shawnee 2-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,100
+Johnson,Shawnee 2-13,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,212
+Johnson,Shawnee 3-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,442
+Johnson,Shawnee 3-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,797
+Johnson,Shawnee 3-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,617
+Johnson,Shawnee 3-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,579
+Johnson,Shawnee 3-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,728
+Johnson,Shawnee 3-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,567
+Johnson,Shawnee 3-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,727
+Johnson,Shawnee 3-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,730
+Johnson,Shawnee 3-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,425
+Johnson,Shawnee 4-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,706
+Johnson,Shawnee 4-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,409
+Johnson,Shawnee 4-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,173
+Johnson,Shawnee 4-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,178
+Johnson,Shawnee 4-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,512
+Johnson,Shawnee 4-06,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,451
+Johnson,Shawnee 4-07,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,721
+Johnson,Shawnee 4-08,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,257
+Johnson,Shawnee 4-09,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,808
+Johnson,Shawnee 4-10,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Shawnee 4-11,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,391
+Johnson,Shawnee 4-12,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Shawnee 4-13,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,74
+Johnson,Spring Hill 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,906
+Johnson,Spring Hill 0-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Spring Hill 0-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,34
+Johnson,Spring Hill 0-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,0
+Johnson,Spring Hill Twp 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,661
+Johnson,Spring Hill Twp 0-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,2
+Johnson,Spring Hill Twp 0-03,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,66
+Johnson,Spring Hill Twp 0-04,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,15
+Johnson,Spring Hill Twp 0-05,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,9
+Johnson,Westwood 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,221
+Johnson,Westwood 0-02,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,250
+Johnson,Westwood Hills 0-01,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,134
+Johnson,Total,U.S. House,3,"Yoder, Kevin",Kevin,,Yoder,,Republican,177044
+Johnson,Merriam 1-01,State Senate,6,"Pettey, Pat",Pat,,Pettey,,Democratic,246
+Johnson,Merriam 1-02,State Senate,6,"Pettey, Pat",Pat,,Pettey,,Democratic,379
+Johnson,Merriam 2-01,State Senate,6,"Pettey, Pat",Pat,,Pettey,,Democratic,383
+Johnson,Merriam 2-02,State Senate,6,"Pettey, Pat",Pat,,Pettey,,Democratic,2
+Johnson,Merriam 4-03,State Senate,6,"Pettey, Pat",Pat,,Pettey,,Democratic,227
+Johnson,Overland Park 1-01,State Senate,6,"Pettey, Pat",Pat,,Pettey,,Democratic,417
+Johnson,Merriam 1-01,State Senate,6,"Steineger, Chris",Chris,,Steineger,,Republican,218
+Johnson,Merriam 1-02,State Senate,6,"Steineger, Chris",Chris,,Steineger,,Republican,257
+Johnson,Merriam 2-01,State Senate,6,"Steineger, Chris",Chris,,Steineger,,Republican,339
+Johnson,Merriam 2-02,State Senate,6,"Steineger, Chris",Chris,,Steineger,,Republican,1
+Johnson,Merriam 4-03,State Senate,6,"Steineger, Chris",Chris,,Steineger,,Republican,187
+Johnson,Overland Park 1-01,State Senate,6,"Steineger, Chris",Chris,,Steineger,,Republican,286
+Johnson,Fairway 1-00,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,271
+Johnson,Fairway 2-00,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,244
+Johnson,Fairway 3-00,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,292
+Johnson,Fairway 4-00,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,320
+Johnson,Leawood 1-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,290
+Johnson,Leawood 1-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,319
+Johnson,Leawood 1-03,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,287
+Johnson,Leawood 1-04,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,258
+Johnson,Leawood 1-06,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,80
+Johnson,Mission 1-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,367
+Johnson,Mission 1-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,238
+Johnson,Mission 2-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,260
+Johnson,Mission 2-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,306
+Johnson,Mission 3-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,404
+Johnson,Mission 3-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,193
+Johnson,Mission 4-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,247
+Johnson,Mission 4-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,241
+Johnson,Mission 4-03,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,192
+Johnson,Mission Hills 0-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,125
+Johnson,Mission Hills 0-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,192
+Johnson,Mission Hills 0-03,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,93
+Johnson,Mission Hills 0-04,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,187
+Johnson,Mission Woods 0-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,55
+Johnson,Overland Park 1-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,424
+Johnson,Overland Park 1-03,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,317
+Johnson,Overland Park 1-06,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,442
+Johnson,Overland Park 1-07,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,423
+Johnson,Overland Park 1-16,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,422
+Johnson,Overland Park 1-17,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,207
+Johnson,Overland Park 1-18,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,297
+Johnson,Overland Park 2-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,303
+Johnson,Overland Park 2-03,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,257
+Johnson,Overland Park 2-08,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,262
+Johnson,Overland Park 2-14,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,207
+Johnson,Overland Park 2-16,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,243
+Johnson,Overland Park 2-19,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,219
+Johnson,Overland Park 2-21,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,222
+Johnson,Overland Park 2-22,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,308
+Johnson,Overland Park 2-23,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,189
+Johnson,Prairie Village 1-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,360
+Johnson,Prairie Village 1-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,282
+Johnson,Prairie Village 1-03,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,422
+Johnson,Prairie Village 2-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,344
+Johnson,Prairie Village 2-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,189
+Johnson,Prairie Village 2-03,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,342
+Johnson,Prairie Village 3-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,225
+Johnson,Prairie Village 3-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,345
+Johnson,Prairie Village 3-03,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,355
+Johnson,Prairie Village 4-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,221
+Johnson,Prairie Village 4-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,218
+Johnson,Prairie Village 4-03,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,360
+Johnson,Prairie Village 5-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,282
+Johnson,Prairie Village 5-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,261
+Johnson,Prairie Village 5-03,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,231
+Johnson,Prairie Village 6-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,348
+Johnson,Prairie Village 6-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,330
+Johnson,Prairie Village 6-03,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,230
+Johnson,Roeland Park 1-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,256
+Johnson,Roeland Park 1-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,159
+Johnson,Roeland Park 1-03,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,0
+Johnson,Roeland Park 2-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,234
+Johnson,Roeland Park 2-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,306
+Johnson,Roeland Park 3-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,212
+Johnson,Roeland Park 3-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,352
+Johnson,Roeland Park 4-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,154
+Johnson,Roeland Park 4-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,458
+Johnson,Westwood 0-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,272
+Johnson,Westwood 0-02,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,240
+Johnson,Westwood Hills 0-01,State Senate,7,"Russell, Kyle",Kyle,,Russell,,Democratic,143
+Johnson,Fairway 1-00,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,342
+Johnson,Fairway 2-00,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,285
+Johnson,Fairway 3-00,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,409
+Johnson,Fairway 4-00,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,268
+Johnson,Leawood 1-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,308
+Johnson,Leawood 1-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,616
+Johnson,Leawood 1-03,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,531
+Johnson,Leawood 1-04,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,397
+Johnson,Leawood 1-06,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,82
+Johnson,Mission 1-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,299
+Johnson,Mission 1-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,145
+Johnson,Mission 2-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,149
+Johnson,Mission 2-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,239
+Johnson,Mission 3-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,302
+Johnson,Mission 3-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,159
+Johnson,Mission 4-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,170
+Johnson,Mission 4-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,338
+Johnson,Mission 4-03,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,163
+Johnson,Mission Hills 0-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,403
+Johnson,Mission Hills 0-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,475
+Johnson,Mission Hills 0-03,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,337
+Johnson,Mission Hills 0-04,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,480
+Johnson,Mission Woods 0-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,53
+Johnson,Overland Park 1-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,293
+Johnson,Overland Park 1-03,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,352
+Johnson,Overland Park 1-06,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,365
+Johnson,Overland Park 1-07,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,435
+Johnson,Overland Park 1-16,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,391
+Johnson,Overland Park 1-17,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,166
+Johnson,Overland Park 1-18,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,325
+Johnson,Overland Park 2-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,309
+Johnson,Overland Park 2-03,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,288
+Johnson,Overland Park 2-08,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,169
+Johnson,Overland Park 2-14,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,233
+Johnson,Overland Park 2-16,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,246
+Johnson,Overland Park 2-19,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,284
+Johnson,Overland Park 2-21,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,277
+Johnson,Overland Park 2-22,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,305
+Johnson,Overland Park 2-23,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,372
+Johnson,Prairie Village 1-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,510
+Johnson,Prairie Village 1-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,349
+Johnson,Prairie Village 1-03,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,480
+Johnson,Prairie Village 2-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,377
+Johnson,Prairie Village 2-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,221
+Johnson,Prairie Village 2-03,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,352
+Johnson,Prairie Village 3-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,299
+Johnson,Prairie Village 3-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,435
+Johnson,Prairie Village 3-03,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,349
+Johnson,Prairie Village 4-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,546
+Johnson,Prairie Village 4-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,320
+Johnson,Prairie Village 4-03,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,482
+Johnson,Prairie Village 5-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,553
+Johnson,Prairie Village 5-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,539
+Johnson,Prairie Village 5-03,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,366
+Johnson,Prairie Village 6-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,468
+Johnson,Prairie Village 6-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,315
+Johnson,Prairie Village 6-03,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,256
+Johnson,Roeland Park 1-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,118
+Johnson,Roeland Park 1-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,89
+Johnson,Roeland Park 1-03,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,0
+Johnson,Roeland Park 2-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,152
+Johnson,Roeland Park 2-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,184
+Johnson,Roeland Park 3-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,114
+Johnson,Roeland Park 3-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,219
+Johnson,Roeland Park 4-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,107
+Johnson,Roeland Park 4-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,302
+Johnson,Westwood 0-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,185
+Johnson,Westwood 0-02,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,190
+Johnson,Westwood Hills 0-01,State Senate,7,"Wolf, Kay",Kay,,Wolf,,Republican,101
+Johnson,Overland Park 2-04,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,320
+Johnson,Overland Park 2-09,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,265
+Johnson,Overland Park 2-10,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,257
+Johnson,Overland Park 2-11,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,300
+Johnson,Overland Park 2-12,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,234
+Johnson,Overland Park 2-13,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,161
+Johnson,Overland Park 2-15,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,374
+Johnson,Overland Park 2-17,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,435
+Johnson,Overland Park 2-20,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,254
+Johnson,Overland Park 2-26,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,121
+Johnson,Overland Park 3-01,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,608
+Johnson,Overland Park 3-02,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,325
+Johnson,Overland Park 3-03,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,328
+Johnson,Overland Park 3-04,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,389
+Johnson,Overland Park 3-05,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,405
+Johnson,Overland Park 3-06,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,444
+Johnson,Overland Park 3-07,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,286
+Johnson,Overland Park 3-08,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,334
+Johnson,Overland Park 3-09,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,516
+Johnson,Overland Park 3-10,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,283
+Johnson,Overland Park 3-11,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,388
+Johnson,Overland Park 3-12,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,215
+Johnson,Overland Park 3-13,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,637
+Johnson,Overland Park 3-14,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,384
+Johnson,Overland Park 3-15,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,318
+Johnson,Overland Park 3-17,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,291
+Johnson,Overland Park 3-18,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,320
+Johnson,Overland Park 3-19,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,403
+Johnson,Overland Park 4-04,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,700
+Johnson,Overland Park 4-05,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,541
+Johnson,Overland Park 4-06,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,379
+Johnson,Overland Park 4-07,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,265
+Johnson,Overland Park 4-08,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,449
+Johnson,Overland Park 4-09,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,518
+Johnson,Overland Park 4-10,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,371
+Johnson,Overland Park 4-11,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,487
+Johnson,Overland Park 4-12,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,726
+Johnson,Overland Park 4-13,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,428
+Johnson,Overland Park 4-14,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,317
+Johnson,Overland Park 4-15,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,676
+Johnson,Overland Park 4-16,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,563
+Johnson,Overland Park 4-17,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,550
+Johnson,Overland Park 4-18,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,98
+Johnson,Overland Park 5-01,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,475
+Johnson,Overland Park 5-02,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,243
+Johnson,Overland Park 5-03,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,364
+Johnson,Overland Park 5-04,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,394
+Johnson,Overland Park 5-05,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,280
+Johnson,Overland Park 5-11,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,502
+Johnson,Overland Park 5-12,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,115
+Johnson,Overland Park 5-15,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,400
+Johnson,Overland Park 5-19,State Senate,8,"Denning, Jim",Jim,,Denning,,Republican,48
+Johnson,Overland Park 2-04,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,378
+Johnson,Overland Park 2-09,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,315
+Johnson,Overland Park 2-10,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,203
+Johnson,Overland Park 2-11,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,322
+Johnson,Overland Park 2-12,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,245
+Johnson,Overland Park 2-13,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,228
+Johnson,Overland Park 2-15,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,435
+Johnson,Overland Park 2-17,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,325
+Johnson,Overland Park 2-20,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,220
+Johnson,Overland Park 2-26,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,167
+Johnson,Overland Park 3-01,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,444
+Johnson,Overland Park 3-02,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,325
+Johnson,Overland Park 3-03,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,260
+Johnson,Overland Park 3-04,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,423
+Johnson,Overland Park 3-05,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,380
+Johnson,Overland Park 3-06,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,452
+Johnson,Overland Park 3-07,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,335
+Johnson,Overland Park 3-08,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,324
+Johnson,Overland Park 3-09,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,473
+Johnson,Overland Park 3-10,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,230
+Johnson,Overland Park 3-11,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,321
+Johnson,Overland Park 3-12,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,326
+Johnson,Overland Park 3-13,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,585
+Johnson,Overland Park 3-14,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,451
+Johnson,Overland Park 3-15,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,232
+Johnson,Overland Park 3-17,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,231
+Johnson,Overland Park 3-18,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,358
+Johnson,Overland Park 3-19,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,334
+Johnson,Overland Park 4-04,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,419
+Johnson,Overland Park 4-05,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,311
+Johnson,Overland Park 4-06,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,277
+Johnson,Overland Park 4-07,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,302
+Johnson,Overland Park 4-08,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,339
+Johnson,Overland Park 4-09,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,232
+Johnson,Overland Park 4-10,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,205
+Johnson,Overland Park 4-11,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,429
+Johnson,Overland Park 4-12,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,511
+Johnson,Overland Park 4-13,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,169
+Johnson,Overland Park 4-14,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,170
+Johnson,Overland Park 4-15,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,410
+Johnson,Overland Park 4-16,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,277
+Johnson,Overland Park 4-17,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,382
+Johnson,Overland Park 4-18,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,103
+Johnson,Overland Park 5-01,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,352
+Johnson,Overland Park 5-02,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,200
+Johnson,Overland Park 5-03,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,268
+Johnson,Overland Park 5-04,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,356
+Johnson,Overland Park 5-05,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,357
+Johnson,Overland Park 5-11,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,516
+Johnson,Overland Park 5-12,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,125
+Johnson,Overland Park 5-15,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,334
+Johnson,Overland Park 5-19,State Senate,8,"Johnston, Lisa",Lisa,,Johnston,,Democratic,32
+Johnson,De Soto 0-01,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,603
+Johnson,De Soto 0-02,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,322
+Johnson,De Soto 0-03,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,562
+Johnson,De Soto 0-04,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,De Soto 0-05,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,De Soto 0-06,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,41
+Johnson,De Soto 0-07,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,2
+Johnson,De Soto 0-08,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,Gardner 0-01,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,814
+Johnson,Gardner 0-06,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,628
+Johnson,Gardner 0-07,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,15
+Johnson,Gardner 0-08,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,52
+Johnson,Gardner 0-12,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,8
+Johnson,Gardner 0-14,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,386
+Johnson,Gardner 0-15,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,Gardner Twp 0-01,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,259
+Johnson,Gardner Twp 0-04,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,1
+Johnson,Gardner Twp 0-05,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,5
+Johnson,Gardner Twp 0-07,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,2
+Johnson,Gardner Twp 0-08,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,1
+Johnson,Gardner Twp 0-11,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,65
+Johnson,Lenexa 2-08,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,Lexington Twp 0-01,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,567
+Johnson,Lexington Twp 0-02,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,2
+Johnson,Lexington Twp 0-03,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,2
+Johnson,Lexington Twp 0-04,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,1
+Johnson,Lexington Twp 0-05,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,McCamish Twp 0-02,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,268
+Johnson,Olathe 1-01,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,452
+Johnson,Olathe 1-07,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,Olathe 1-11,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,71
+Johnson,Olathe 1-12,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,21
+Johnson,Olathe 1-13,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,Olathe 1-19,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,217
+Johnson,Olathe 1-20,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,333
+Johnson,Olathe 1-21,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,590
+Johnson,Olathe 1-22,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,789
+Johnson,Olathe 1-23,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,Olathe 1-24,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,Olathe 1-26,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,Olathe 1-27,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,299
+Johnson,Olathe 2-02,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,262
+Johnson,Olathe 2-05,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,1054
+Johnson,Olathe 2-06,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,600
+Johnson,Olathe 2-07,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,667
+Johnson,Olathe 2-09,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,210
+Johnson,Olathe 2-10,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,925
+Johnson,Olathe 2-11,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,667
+Johnson,Olathe 2-12,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,370
+Johnson,Olathe 2-13,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,423
+Johnson,Olathe 2-15,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,321
+Johnson,Olathe 2-16,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,Olathe 2-17,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,Olathe 2-19,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,5
+Johnson,Olathe 2-20,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,Olathe 2-21,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,Olathe 2-22,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,704
+Johnson,Olathe 2-23,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,531
+Johnson,Olathe 2-24,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,11
+Johnson,Olathe 2-25,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,2
+Johnson,Olathe 2-26,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,Olathe 2-27,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,9
+Johnson,Olathe 2-28,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,134
+Johnson,Olathe 4-01,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,423
+Johnson,Olathe 4-02,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,669
+Johnson,Olathe 4-03,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,264
+Johnson,Olathe 4-04,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,254
+Johnson,Olathe 4-05,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,475
+Johnson,Olathe 4-08,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,463
+Johnson,Olathe 4-09,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,654
+Johnson,Olathe 4-10,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,382
+Johnson,Olathe 4-11,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,211
+Johnson,Olathe 4-13,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,258
+Johnson,Olathe 4-14,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,544
+Johnson,Olathe 4-17,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,4
+Johnson,Olathe 4-18,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,160
+Johnson,Olathe Twp 0-01,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,218
+Johnson,Olathe Twp 0-02,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,50
+Johnson,Olathe Twp 0-03,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,25
+Johnson,Olathe Twp 0-04,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,1
+Johnson,Olathe Twp 0-05,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,3
+Johnson,Olathe Twp 0-08,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,12
+Johnson,Olathe Twp 0-09,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,Olathe Twp 0-11,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,3
+Johnson,Olathe Twp 0-17,State Senate,9,"Lynn, Julia",Julia,,Lynn,,Republican,0
+Johnson,De Soto 0-01,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,289
+Johnson,De Soto 0-02,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,181
+Johnson,De Soto 0-03,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,229
+Johnson,De Soto 0-04,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,De Soto 0-05,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,De Soto 0-06,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,31
+Johnson,De Soto 0-07,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,De Soto 0-08,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Gardner 0-01,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,361
+Johnson,Gardner 0-06,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,277
+Johnson,Gardner 0-07,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,11
+Johnson,Gardner 0-08,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,13
+Johnson,Gardner 0-12,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,11
+Johnson,Gardner 0-14,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,230
+Johnson,Gardner 0-15,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Gardner Twp 0-01,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,111
+Johnson,Gardner Twp 0-04,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Gardner Twp 0-05,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,3
+Johnson,Gardner Twp 0-07,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,2
+Johnson,Gardner Twp 0-08,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,5
+Johnson,Gardner Twp 0-11,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,42
+Johnson,Lenexa 2-08,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Lexington Twp 0-01,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,196
+Johnson,Lexington Twp 0-02,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,1
+Johnson,Lexington Twp 0-03,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,1
+Johnson,Lexington Twp 0-04,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Lexington Twp 0-05,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,McCamish Twp 0-02,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,89
+Johnson,Olathe 1-01,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,333
+Johnson,Olathe 1-07,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Olathe 1-11,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,65
+Johnson,Olathe 1-12,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,13
+Johnson,Olathe 1-13,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Olathe 1-19,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,145
+Johnson,Olathe 1-20,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,255
+Johnson,Olathe 1-21,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,394
+Johnson,Olathe 1-22,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,316
+Johnson,Olathe 1-23,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Olathe 1-24,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Olathe 1-26,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,4
+Johnson,Olathe 1-27,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,242
+Johnson,Olathe 2-02,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,167
+Johnson,Olathe 2-05,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,384
+Johnson,Olathe 2-06,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,192
+Johnson,Olathe 2-07,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,321
+Johnson,Olathe 2-09,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,127
+Johnson,Olathe 2-10,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,599
+Johnson,Olathe 2-11,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,427
+Johnson,Olathe 2-12,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,212
+Johnson,Olathe 2-13,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,248
+Johnson,Olathe 2-15,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,125
+Johnson,Olathe 2-16,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Olathe 2-17,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Olathe 2-19,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,2
+Johnson,Olathe 2-20,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Olathe 2-21,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Olathe 2-22,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,367
+Johnson,Olathe 2-23,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,285
+Johnson,Olathe 2-24,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,3
+Johnson,Olathe 2-25,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,6
+Johnson,Olathe 2-26,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Olathe 2-27,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,2
+Johnson,Olathe 2-28,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,111
+Johnson,Olathe 4-01,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,346
+Johnson,Olathe 4-02,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,406
+Johnson,Olathe 4-03,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,233
+Johnson,Olathe 4-04,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,247
+Johnson,Olathe 4-05,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,304
+Johnson,Olathe 4-08,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,241
+Johnson,Olathe 4-09,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,370
+Johnson,Olathe 4-10,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,205
+Johnson,Olathe 4-11,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,218
+Johnson,Olathe 4-13,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,223
+Johnson,Olathe 4-14,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,386
+Johnson,Olathe 4-17,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,1
+Johnson,Olathe 4-18,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,171
+Johnson,Olathe Twp 0-01,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,134
+Johnson,Olathe Twp 0-02,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,15
+Johnson,Olathe Twp 0-03,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,23
+Johnson,Olathe Twp 0-04,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,1
+Johnson,Olathe Twp 0-05,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Olathe Twp 0-08,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,4
+Johnson,Olathe Twp 0-09,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Olathe Twp 0-11,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,1
+Johnson,Olathe Twp 0-17,State Senate,9,"Ring, Merlin D.",Merlin,D.,Ring,,Democratic,0
+Johnson,Bonner Springs 4-01,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,0
+Johnson,Lake Quivira 0-01,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,257
+Johnson,Merriam 2-03,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,217
+Johnson,Merriam 3-01,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,376
+Johnson,Merriam 3-02,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,276
+Johnson,Merriam 4-01,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,357
+Johnson,Merriam 4-02,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,168
+Johnson,Overland Park 1-04,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,113
+Johnson,Overland Park 1-21,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,108
+Johnson,Shawnee 1-01,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,398
+Johnson,Shawnee 1-02,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,249
+Johnson,Shawnee 1-03,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,279
+Johnson,Shawnee 1-04,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,419
+Johnson,Shawnee 1-05,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,458
+Johnson,Shawnee 1-06,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,294
+Johnson,Shawnee 1-07,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,375
+Johnson,Shawnee 1-08,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,360
+Johnson,Shawnee 1-09,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,105
+Johnson,Shawnee 1-10,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,85
+Johnson,Shawnee 1-11,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,268
+Johnson,Shawnee 1-12,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,5
+Johnson,Shawnee 2-01,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,186
+Johnson,Shawnee 2-02,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,315
+Johnson,Shawnee 2-03,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,359
+Johnson,Shawnee 2-04,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,423
+Johnson,Shawnee 2-05,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,215
+Johnson,Shawnee 2-06,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,230
+Johnson,Shawnee 2-07,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,259
+Johnson,Shawnee 2-08,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,225
+Johnson,Shawnee 2-09,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,224
+Johnson,Shawnee 2-10,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,192
+Johnson,Shawnee 2-11,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,264
+Johnson,Shawnee 2-12,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,128
+Johnson,Shawnee 2-13,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,141
+Johnson,Shawnee 3-01,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,179
+Johnson,Shawnee 3-02,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,353
+Johnson,Shawnee 3-03,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,301
+Johnson,Shawnee 3-04,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,238
+Johnson,Shawnee 3-05,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,278
+Johnson,Shawnee 3-06,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,374
+Johnson,Shawnee 3-07,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,364
+Johnson,Shawnee 3-08,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,345
+Johnson,Shawnee 3-09,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,156
+Johnson,Shawnee 4-01,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,420
+Johnson,Shawnee 4-02,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,234
+Johnson,Shawnee 4-03,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,104
+Johnson,Shawnee 4-04,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,223
+Johnson,Shawnee 4-05,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,361
+Johnson,Shawnee 4-06,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,277
+Johnson,Shawnee 4-07,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,375
+Johnson,Shawnee 4-08,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,151
+Johnson,Shawnee 4-09,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,477
+Johnson,Shawnee 4-11,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,304
+Johnson,Shawnee 4-12,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,0
+Johnson,Shawnee 4-13,State Senate,10,"Greene, Mark J.",Mark,J.,Greene,,Democratic,44
+Johnson,Bonner Springs 4-01,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,0
+Johnson,Lake Quivira 0-01,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,386
+Johnson,Merriam 2-03,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,178
+Johnson,Merriam 3-01,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,298
+Johnson,Merriam 3-02,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,261
+Johnson,Merriam 4-01,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,378
+Johnson,Merriam 4-02,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,170
+Johnson,Overland Park 1-04,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,149
+Johnson,Overland Park 1-21,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,118
+Johnson,Shawnee 1-01,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,471
+Johnson,Shawnee 1-02,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,352
+Johnson,Shawnee 1-03,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,336
+Johnson,Shawnee 1-04,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,596
+Johnson,Shawnee 1-05,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,593
+Johnson,Shawnee 1-06,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,507
+Johnson,Shawnee 1-07,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,500
+Johnson,Shawnee 1-08,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,622
+Johnson,Shawnee 1-09,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,74
+Johnson,Shawnee 1-10,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,211
+Johnson,Shawnee 1-11,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,407
+Johnson,Shawnee 1-12,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,4
+Johnson,Shawnee 2-01,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,220
+Johnson,Shawnee 2-02,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,390
+Johnson,Shawnee 2-03,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,303
+Johnson,Shawnee 2-04,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,461
+Johnson,Shawnee 2-05,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,243
+Johnson,Shawnee 2-06,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,352
+Johnson,Shawnee 2-07,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,273
+Johnson,Shawnee 2-08,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,260
+Johnson,Shawnee 2-09,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,241
+Johnson,Shawnee 2-10,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,224
+Johnson,Shawnee 2-11,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,338
+Johnson,Shawnee 2-12,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,86
+Johnson,Shawnee 2-13,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,184
+Johnson,Shawnee 3-01,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,412
+Johnson,Shawnee 3-02,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,717
+Johnson,Shawnee 3-03,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,544
+Johnson,Shawnee 3-04,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,516
+Johnson,Shawnee 3-05,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,673
+Johnson,Shawnee 3-06,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,517
+Johnson,Shawnee 3-07,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,653
+Johnson,Shawnee 3-08,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,638
+Johnson,Shawnee 3-09,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,400
+Johnson,Shawnee 4-01,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,606
+Johnson,Shawnee 4-02,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,349
+Johnson,Shawnee 4-03,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,155
+Johnson,Shawnee 4-04,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,146
+Johnson,Shawnee 4-05,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,456
+Johnson,Shawnee 4-06,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,412
+Johnson,Shawnee 4-07,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,644
+Johnson,Shawnee 4-08,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,215
+Johnson,Shawnee 4-09,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,718
+Johnson,Shawnee 4-11,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,358
+Johnson,Shawnee 4-12,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,0
+Johnson,Shawnee 4-13,State Senate,10,"Pilcher-Cook, Mary",Mary,,Pilcher-Cook,,Republican,56
+Johnson,Leawood 1-05,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,232
+Johnson,Leawood 2-01,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,318
+Johnson,Leawood 2-02,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,375
+Johnson,Leawood 2-03,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,330
+Johnson,Leawood 2-04,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,256
+Johnson,Leawood 2-05,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,203
+Johnson,Leawood 2-06,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,129
+Johnson,Leawood 3-01,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,217
+Johnson,Leawood 3-02,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,342
+Johnson,Leawood 3-03,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,193
+Johnson,Leawood 3-04,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,96
+Johnson,Leawood 3-05,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,374
+Johnson,Leawood 3-06,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,305
+Johnson,Leawood 3-07,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,287
+Johnson,Leawood 4-01,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,75
+Johnson,Leawood 4-02,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,272
+Johnson,Leawood 4-03,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,264
+Johnson,Leawood 4-04,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,326
+Johnson,Leawood 4-05,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,324
+Johnson,Leawood 4-06,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,148
+Johnson,Leawood 4-07,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,315
+Johnson,Leawood 4-08,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,112
+Johnson,Overland Park 2-01,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,263
+Johnson,Overland Park 2-24,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,464
+Johnson,Overland Park 2-25,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,337
+Johnson,Overland Park 3-16,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,327
+Johnson,Overland Park 3-20,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,413
+Johnson,Overland Park 4-03,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,350
+Johnson,Overland Park 5-06,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,332
+Johnson,Overland Park 5-07,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,262
+Johnson,Overland Park 5-08,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,465
+Johnson,Overland Park 5-09,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,430
+Johnson,Overland Park 5-10,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,363
+Johnson,Overland Park 5-13,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,468
+Johnson,Overland Park 5-14,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,330
+Johnson,Overland Park 5-16,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,235
+Johnson,Overland Park 5-17,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,165
+Johnson,Overland Park 5-18,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,322
+Johnson,Overland Park 6-01,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,323
+Johnson,Overland Park 6-02,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,254
+Johnson,Overland Park 6-05,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,391
+Johnson,Overland Park 6-11,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,313
+Johnson,Overland Park 6-12,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,148
+Johnson,Overland Park 6-13,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,336
+Johnson,Overland Park 6-14,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,1
+Johnson,Overland Park 6-15,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,317
+Johnson,Overland Park 6-17,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,335
+Johnson,Overland Park 6-19,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,376
+Johnson,Oxford Twp 0-04,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,158
+Johnson,Oxford Twp 0-05,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,1
+Johnson,Oxford Twp 0-08,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,0
+Johnson,Oxford Twp 0-09,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,13
+Johnson,Oxford Twp 0-10,State Senate,11,"Delaney, Michael F.",Michael,F.,Delaney,,Democratic,0
+Johnson,Leawood 1-05,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,380
+Johnson,Leawood 2-01,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,442
+Johnson,Leawood 2-02,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,564
+Johnson,Leawood 2-03,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,564
+Johnson,Leawood 2-04,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,700
+Johnson,Leawood 2-05,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,355
+Johnson,Leawood 2-06,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,259
+Johnson,Leawood 3-01,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,301
+Johnson,Leawood 3-02,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,551
+Johnson,Leawood 3-03,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,371
+Johnson,Leawood 3-04,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,179
+Johnson,Leawood 3-05,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,743
+Johnson,Leawood 3-06,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,755
+Johnson,Leawood 3-07,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,545
+Johnson,Leawood 4-01,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,186
+Johnson,Leawood 4-02,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,457
+Johnson,Leawood 4-03,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,453
+Johnson,Leawood 4-04,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,603
+Johnson,Leawood 4-05,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,557
+Johnson,Leawood 4-06,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,530
+Johnson,Leawood 4-07,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,883
+Johnson,Leawood 4-08,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,358
+Johnson,Overland Park 2-01,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,285
+Johnson,Overland Park 2-24,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,499
+Johnson,Overland Park 2-25,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,339
+Johnson,Overland Park 3-16,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,329
+Johnson,Overland Park 3-20,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,454
+Johnson,Overland Park 4-03,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,740
+Johnson,Overland Park 5-06,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,443
+Johnson,Overland Park 5-07,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,738
+Johnson,Overland Park 5-08,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,752
+Johnson,Overland Park 5-09,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,602
+Johnson,Overland Park 5-10,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,480
+Johnson,Overland Park 5-13,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,518
+Johnson,Overland Park 5-14,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,477
+Johnson,Overland Park 5-16,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,286
+Johnson,Overland Park 5-17,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,188
+Johnson,Overland Park 5-18,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,339
+Johnson,Overland Park 6-01,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,625
+Johnson,Overland Park 6-02,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,509
+Johnson,Overland Park 6-05,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,622
+Johnson,Overland Park 6-11,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,489
+Johnson,Overland Park 6-12,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,220
+Johnson,Overland Park 6-13,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,673
+Johnson,Overland Park 6-14,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,2
+Johnson,Overland Park 6-15,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,743
+Johnson,Overland Park 6-17,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,513
+Johnson,Overland Park 6-19,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,596
+Johnson,Oxford Twp 0-04,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,332
+Johnson,Oxford Twp 0-05,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,13
+Johnson,Oxford Twp 0-08,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,0
+Johnson,Oxford Twp 0-09,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,21
+Johnson,Oxford Twp 0-10,State Senate,11,"Melcher, Jeff",Jeff,,Melcher,,Republican,2
+Johnson,Lenexa 1-01,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,230
+Johnson,Lenexa 1-02,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,455
+Johnson,Lenexa 1-03,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,532
+Johnson,Lenexa 1-04,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,387
+Johnson,Lenexa 1-05,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,379
+Johnson,Lenexa 1-06,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,370
+Johnson,Lenexa 1-07,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,273
+Johnson,Lenexa 1-08,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,132
+Johnson,Lenexa 1-09,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,9
+Johnson,Lenexa 2-01,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,346
+Johnson,Lenexa 2-02,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,71
+Johnson,Lenexa 2-03,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,343
+Johnson,Lenexa 2-04,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,275
+Johnson,Lenexa 2-05,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,482
+Johnson,Lenexa 2-06,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,220
+Johnson,Lenexa 2-07,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,406
+Johnson,Lenexa 3-01,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,418
+Johnson,Lenexa 3-02,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,541
+Johnson,Lenexa 3-03,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,497
+Johnson,Lenexa 3-04,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,285
+Johnson,Lenexa 3-05,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,338
+Johnson,Lenexa 3-06,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,354
+Johnson,Lenexa 3-07,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,378
+Johnson,Lenexa 3-08,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,407
+Johnson,Lenexa 4-01,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,210
+Johnson,Lenexa 4-02,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,362
+Johnson,Lenexa 4-03,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,272
+Johnson,Lenexa 4-04,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,229
+Johnson,Lenexa 4-05,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,182
+Johnson,Lenexa 4-06,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,301
+Johnson,Lenexa 4-07,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,297
+Johnson,Lenexa 4-08,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,333
+Johnson,Lenexa 4-09,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,289
+Johnson,Lenexa 4-10,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,225
+Johnson,Lenexa 4-11,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,56
+Johnson,Olathe 2-18,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,0
+Johnson,Overland Park 1-05,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,259
+Johnson,Overland Park 1-08,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,369
+Johnson,Overland Park 1-09,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,198
+Johnson,Overland Park 1-10,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,401
+Johnson,Overland Park 1-11,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,192
+Johnson,Overland Park 1-12,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,440
+Johnson,Overland Park 1-13,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,249
+Johnson,Overland Park 1-14,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,361
+Johnson,Overland Park 1-15,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,187
+Johnson,Overland Park 1-19,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,321
+Johnson,Overland Park 1-20,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,224
+Johnson,Overland Park 1-22,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,100
+Johnson,Overland Park 2-05,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,333
+Johnson,Overland Park 2-06,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,311
+Johnson,Overland Park 2-07,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,227
+Johnson,Overland Park 2-18,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,385
+Johnson,Shawnee 4-10,State Senate,21,"Roy, Juanita",Juanita,,Roy,,Democratic,0
+Johnson,Lenexa 1-01,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,263
+Johnson,Lenexa 1-02,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,556
+Johnson,Lenexa 1-03,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,623
+Johnson,Lenexa 1-04,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,421
+Johnson,Lenexa 1-05,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,434
+Johnson,Lenexa 1-06,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,594
+Johnson,Lenexa 1-07,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,264
+Johnson,Lenexa 1-08,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,120
+Johnson,Lenexa 1-09,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,8
+Johnson,Lenexa 2-01,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,666
+Johnson,Lenexa 2-02,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,219
+Johnson,Lenexa 2-03,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,715
+Johnson,Lenexa 2-04,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,800
+Johnson,Lenexa 2-05,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,410
+Johnson,Lenexa 2-06,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,457
+Johnson,Lenexa 2-07,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,687
+Johnson,Lenexa 3-01,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,297
+Johnson,Lenexa 3-02,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,416
+Johnson,Lenexa 3-03,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,547
+Johnson,Lenexa 3-04,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,420
+Johnson,Lenexa 3-05,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,242
+Johnson,Lenexa 3-06,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,308
+Johnson,Lenexa 3-07,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,444
+Johnson,Lenexa 3-08,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,469
+Johnson,Lenexa 4-01,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,209
+Johnson,Lenexa 4-02,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,436
+Johnson,Lenexa 4-03,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,189
+Johnson,Lenexa 4-04,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,212
+Johnson,Lenexa 4-05,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,175
+Johnson,Lenexa 4-06,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,365
+Johnson,Lenexa 4-07,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,373
+Johnson,Lenexa 4-08,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,280
+Johnson,Lenexa 4-09,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,373
+Johnson,Lenexa 4-10,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,170
+Johnson,Lenexa 4-11,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,64
+Johnson,Olathe 2-18,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,0
+Johnson,Overland Park 1-05,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,223
+Johnson,Overland Park 1-08,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,315
+Johnson,Overland Park 1-09,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,208
+Johnson,Overland Park 1-10,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,383
+Johnson,Overland Park 1-11,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,138
+Johnson,Overland Park 1-12,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,343
+Johnson,Overland Park 1-13,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,281
+Johnson,Overland Park 1-14,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,346
+Johnson,Overland Park 1-15,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,151
+Johnson,Overland Park 1-19,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,275
+Johnson,Overland Park 1-20,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,178
+Johnson,Overland Park 1-22,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,73
+Johnson,Overland Park 2-05,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,347
+Johnson,Overland Park 2-06,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,331
+Johnson,Overland Park 2-07,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,272
+Johnson,Overland Park 2-18,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,437
+Johnson,Shawnee 4-10,State Senate,21,"Smith, Greg A.",Greg,A.,Smith,,Republican,0
+Johnson,Olathe 1-02,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,291
+Johnson,Olathe 1-03,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,262
+Johnson,Olathe 1-04,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,473
+Johnson,Olathe 1-05,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,502
+Johnson,Olathe 1-06,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,350
+Johnson,Olathe 1-08,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,626
+Johnson,Olathe 1-09,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,596
+Johnson,Olathe 1-10,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,4
+Johnson,Olathe 1-14,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,445
+Johnson,Olathe 1-15,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,487
+Johnson,Olathe 1-16,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,688
+Johnson,Olathe 1-18,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,131
+Johnson,Olathe 1-25,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,0
+Johnson,Olathe 1-28,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,123
+Johnson,Olathe 1-29,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,83
+Johnson,Olathe 2-01,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,241
+Johnson,Olathe 2-03,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,333
+Johnson,Olathe 2-04,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,379
+Johnson,Olathe 2-08,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,505
+Johnson,Olathe 2-14,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,376
+Johnson,Olathe 3-01,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,210
+Johnson,Olathe 3-02,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,605
+Johnson,Olathe 3-03,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,369
+Johnson,Olathe 3-04,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,551
+Johnson,Olathe 3-06,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,422
+Johnson,Olathe 3-07,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,400
+Johnson,Olathe 3-08,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,596
+Johnson,Olathe 3-09,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,323
+Johnson,Olathe 3-10,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,645
+Johnson,Olathe 3-11,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,400
+Johnson,Olathe 3-12,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,528
+Johnson,Olathe 3-13,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,574
+Johnson,Olathe 3-15,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,467
+Johnson,Olathe 3-16,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,487
+Johnson,Olathe 3-17,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,640
+Johnson,Olathe 3-18,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,546
+Johnson,Olathe 3-19,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,382
+Johnson,Olathe 3-20,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,432
+Johnson,Olathe 3-21,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,301
+Johnson,Olathe 3-22,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,485
+Johnson,Olathe 3-23,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,458
+Johnson,Olathe 3-24,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,0
+Johnson,Olathe 3-26,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,45
+Johnson,Olathe 3-27,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,266
+Johnson,Olathe 4-06,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,622
+Johnson,Olathe 4-07,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,496
+Johnson,Olathe 4-12,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,631
+Johnson,Olathe 4-15,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,34
+Johnson,Olathe 4-16,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,1
+Johnson,Olathe Twp 0-07,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,1
+Johnson,Olathe Twp 0-10,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,12
+Johnson,Olathe Twp 0-12,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,0
+Johnson,Olathe Twp 0-13,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,0
+Johnson,Olathe Twp 0-14,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,1
+Johnson,Olathe Twp 0-24,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,3
+Johnson,Olathe Twp 0-25,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,7
+Johnson,Olathe Twp 0-26,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,3
+Johnson,Olathe Twp 0-32,State Senate,23,"Olson, Rob",Rob,,Olson,,Republican,21
+Johnson,Olathe 1-02,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,225
+Johnson,Olathe 1-03,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,184
+Johnson,Olathe 1-04,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,319
+Johnson,Olathe 1-05,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,305
+Johnson,Olathe 1-06,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,179
+Johnson,Olathe 1-08,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,415
+Johnson,Olathe 1-09,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,296
+Johnson,Olathe 1-10,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,2
+Johnson,Olathe 1-14,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,254
+Johnson,Olathe 1-15,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,244
+Johnson,Olathe 1-16,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,296
+Johnson,Olathe 1-18,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,78
+Johnson,Olathe 1-25,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,0
+Johnson,Olathe 1-28,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,79
+Johnson,Olathe 1-29,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,39
+Johnson,Olathe 2-01,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,127
+Johnson,Olathe 2-03,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,272
+Johnson,Olathe 2-04,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,362
+Johnson,Olathe 2-08,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,408
+Johnson,Olathe 2-14,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,253
+Johnson,Olathe 3-01,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,177
+Johnson,Olathe 3-02,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,418
+Johnson,Olathe 3-03,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,151
+Johnson,Olathe 3-04,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,328
+Johnson,Olathe 3-06,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,186
+Johnson,Olathe 3-07,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,215
+Johnson,Olathe 3-08,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,294
+Johnson,Olathe 3-09,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,167
+Johnson,Olathe 3-10,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,325
+Johnson,Olathe 3-11,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,246
+Johnson,Olathe 3-12,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,340
+Johnson,Olathe 3-13,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,308
+Johnson,Olathe 3-15,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,217
+Johnson,Olathe 3-16,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,252
+Johnson,Olathe 3-17,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,299
+Johnson,Olathe 3-18,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,295
+Johnson,Olathe 3-19,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,141
+Johnson,Olathe 3-20,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,181
+Johnson,Olathe 3-21,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,96
+Johnson,Olathe 3-22,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,304
+Johnson,Olathe 3-23,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,327
+Johnson,Olathe 3-24,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,0
+Johnson,Olathe 3-26,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,41
+Johnson,Olathe 3-27,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,129
+Johnson,Olathe 4-06,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,428
+Johnson,Olathe 4-07,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,435
+Johnson,Olathe 4-12,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,391
+Johnson,Olathe 4-15,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,52
+Johnson,Olathe 4-16,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,1
+Johnson,Olathe Twp 0-07,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,1
+Johnson,Olathe Twp 0-10,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,7
+Johnson,Olathe Twp 0-12,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,0
+Johnson,Olathe Twp 0-13,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,0
+Johnson,Olathe Twp 0-14,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,0
+Johnson,Olathe Twp 0-24,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,0
+Johnson,Olathe Twp 0-25,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,1
+Johnson,Olathe Twp 0-26,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,1
+Johnson,Olathe Twp 0-32,State Senate,23,"Wright, Steve",Steve,,Wright,,Democratic,7
+Johnson,Aubry Twp 0-01,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,98
+Johnson,Aubry Twp 0-02,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,652
+Johnson,Aubry Twp 0-03,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,358
+Johnson,Aubry Twp 0-04,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,839
+Johnson,Aubry Twp 0-05,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,13
+Johnson,Aubry Twp 0-06,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,91
+Johnson,Edgerton 0-01,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,547
+Johnson,Edgerton 0-02,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Edgerton 0-03,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Edgerton 0-04,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Edgerton 0-05,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Edgerton 0-06,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Edgerton 0-07,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Edgerton 0-08,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Gardner 0-02,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,151
+Johnson,Gardner 0-03,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,717
+Johnson,Gardner 0-04,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,525
+Johnson,Gardner 0-05,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Gardner 0-09,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,855
+Johnson,Gardner 0-10,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,562
+Johnson,Gardner 0-11,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Gardner 0-13,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,656
+Johnson,Gardner Twp 0-02,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,395
+Johnson,Gardner Twp 0-03,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Gardner Twp 0-06,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Gardner Twp 0-09,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,2
+Johnson,Gardner Twp 0-10,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Gardner Twp 0-12,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,McCamish Twp 0-01,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,140
+Johnson,McCamish Twp 0-03,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Olathe 1-17,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,171
+Johnson,Olathe 3-05,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,647
+Johnson,Olathe 3-14,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,3
+Johnson,Olathe 3-25,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Olathe Twp 0-06,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,1
+Johnson,Olathe Twp 0-27,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Overland Park 4-01,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,470
+Johnson,Overland Park 4-02,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,831
+Johnson,Overland Park 6-03,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,782
+Johnson,Overland Park 6-04,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,785
+Johnson,Overland Park 6-06,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,1
+Johnson,Overland Park 6-07,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,216
+Johnson,Overland Park 6-08,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,939
+Johnson,Overland Park 6-09,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,884
+Johnson,Overland Park 6-10,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,674
+Johnson,Overland Park 6-16,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,494
+Johnson,Overland Park 6-18,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Overland Park 6-20,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,351
+Johnson,Overland Park 6-21,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,984
+Johnson,Overland Park 6-22,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,288
+Johnson,Overland Park 6-23,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,130
+Johnson,Oxford Twp 0-01,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Oxford Twp 0-02,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,473
+Johnson,Oxford Twp 0-03,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Oxford Twp 0-11,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,102
+Johnson,Spring Hill 0-01,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,1059
+Johnson,Spring Hill 0-02,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Spring Hill 0-03,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,37
+Johnson,Spring Hill 0-04,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,0
+Johnson,Spring Hill Twp 0-01,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,751
+Johnson,Spring Hill Twp 0-02,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,2
+Johnson,Spring Hill Twp 0-03,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,74
+Johnson,Spring Hill Twp 0-04,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,14
+Johnson,Spring Hill Twp 0-05,State Senate,37,"Apple, Pat",Pat,,Apple,,Republican,10
+Johnson,Lenexa 1-01,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,223
+Johnson,Lenexa 1-07,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,280
+Johnson,Lenexa 2-05,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,507
+Johnson,Lenexa 4-05,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,194
+Johnson,Lenexa 4-06,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,307
+Johnson,Lenexa 4-07,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,313
+Johnson,Lenexa 4-08,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,307
+Johnson,Lenexa 4-09,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,299
+Johnson,Lenexa 4-10,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,209
+Johnson,Olathe 4-01,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,330
+Johnson,Olathe 4-04,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,226
+Johnson,Olathe 4-08,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,259
+Johnson,Olathe 4-09,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,364
+Johnson,Olathe 4-10,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,192
+Johnson,Olathe 4-13,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,209
+Johnson,Olathe 4-14,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,391
+Johnson,Olathe 4-17,State House,30,"Dickinson, Liz",Liz,,Dickinson,,Democratic,1
+Johnson,Lenexa 1-01,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,266
+Johnson,Lenexa 1-07,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,254
+Johnson,Lenexa 2-05,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,376
+Johnson,Lenexa 4-05,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,161
+Johnson,Lenexa 4-06,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,350
+Johnson,Lenexa 4-07,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,339
+Johnson,Lenexa 4-08,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,301
+Johnson,Lenexa 4-09,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,357
+Johnson,Lenexa 4-10,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,182
+Johnson,Olathe 4-01,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,431
+Johnson,Olathe 4-04,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,282
+Johnson,Olathe 4-08,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,443
+Johnson,Olathe 4-09,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,661
+Johnson,Olathe 4-10,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,398
+Johnson,Olathe 4-13,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,271
+Johnson,Olathe 4-14,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,547
+Johnson,Olathe 4-17,State House,30,"Kinzer, Lance",Lance,,Kinzer,,Republican,4
+Johnson,De Soto 0-01,State House,38,"Dove, Willie",Willie,,Dove,,Republican,545
+Johnson,De Soto 0-02,State House,38,"Dove, Willie",Willie,,Dove,,Republican,295
+Johnson,De Soto 0-03,State House,38,"Dove, Willie",Willie,,Dove,,Republican,490
+Johnson,De Soto 0-04,State House,38,"Dove, Willie",Willie,,Dove,,Republican,0
+Johnson,De Soto 0-05,State House,38,"Dove, Willie",Willie,,Dove,,Republican,0
+Johnson,De Soto 0-06,State House,38,"Dove, Willie",Willie,,Dove,,Republican,38
+Johnson,De Soto 0-07,State House,38,"Dove, Willie",Willie,,Dove,,Republican,2
+Johnson,De Soto 0-08,State House,38,"Dove, Willie",Willie,,Dove,,Republican,0
+Johnson,Gardner 0-07,State House,38,"Dove, Willie",Willie,,Dove,,Republican,10
+Johnson,Gardner Twp 0-01,State House,38,"Dove, Willie",Willie,,Dove,,Republican,237
+Johnson,Lenexa 2-08,State House,38,"Dove, Willie",Willie,,Dove,,Republican,0
+Johnson,Lexington Twp 0-01,State House,38,"Dove, Willie",Willie,,Dove,,Republican,522
+Johnson,Lexington Twp 0-02,State House,38,"Dove, Willie",Willie,,Dove,,Republican,3
+Johnson,Lexington Twp 0-03,State House,38,"Dove, Willie",Willie,,Dove,,Republican,2
+Johnson,Lexington Twp 0-04,State House,38,"Dove, Willie",Willie,,Dove,,Republican,0
+Johnson,Lexington Twp 0-05,State House,38,"Dove, Willie",Willie,,Dove,,Republican,0
+Johnson,Olathe 2-17,State House,38,"Dove, Willie",Willie,,Dove,,Republican,0
+Johnson,Olathe 2-20,State House,38,"Dove, Willie",Willie,,Dove,,Republican,0
+Johnson,De Soto 0-01,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,336
+Johnson,De Soto 0-02,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,209
+Johnson,De Soto 0-03,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,299
+Johnson,De Soto 0-04,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,0
+Johnson,De Soto 0-05,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,0
+Johnson,De Soto 0-06,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,33
+Johnson,De Soto 0-07,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,0
+Johnson,De Soto 0-08,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,0
+Johnson,Gardner 0-07,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,15
+Johnson,Gardner Twp 0-01,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,133
+Johnson,Lenexa 2-08,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,0
+Johnson,Lexington Twp 0-01,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,224
+Johnson,Lexington Twp 0-02,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,0
+Johnson,Lexington Twp 0-03,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,1
+Johnson,Lexington Twp 0-04,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,0
+Johnson,Lexington Twp 0-05,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,0
+Johnson,Olathe 2-17,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,0
+Johnson,Olathe 2-20,State House,38,"Henderson, Pete",Pete,,Henderson,,Democratic,0
+Johnson,Bonner Springs 4-01,State House,39,"Macheers, Charles",Charles,,Macheers,,Republican,0
+Johnson,Shawnee 1-08,State House,39,"Macheers, Charles",Charles,,Macheers,,Republican,586
+Johnson,Shawnee 1-10,State House,39,"Macheers, Charles",Charles,,Macheers,,Republican,205
+Johnson,Shawnee 1-11,State House,39,"Macheers, Charles",Charles,,Macheers,,Republican,413
+Johnson,Shawnee 3-01,State House,39,"Macheers, Charles",Charles,,Macheers,,Republican,385
+Johnson,Shawnee 3-02,State House,39,"Macheers, Charles",Charles,,Macheers,,Republican,711
+Johnson,Shawnee 3-03,State House,39,"Macheers, Charles",Charles,,Macheers,,Republican,539
+Johnson,Shawnee 3-04,State House,39,"Macheers, Charles",Charles,,Macheers,,Republican,508
+Johnson,Shawnee 3-05,State House,39,"Macheers, Charles",Charles,,Macheers,,Republican,649
+Johnson,Shawnee 3-06,State House,39,"Macheers, Charles",Charles,,Macheers,,Republican,499
+Johnson,Shawnee 3-07,State House,39,"Macheers, Charles",Charles,,Macheers,,Republican,619
+Johnson,Shawnee 3-08,State House,39,"Macheers, Charles",Charles,,Macheers,,Republican,610
+Johnson,Shawnee 3-09,State House,39,"Macheers, Charles",Charles,,Macheers,,Republican,396
+Johnson,Shawnee 4-09,State House,39,"Macheers, Charles",Charles,,Macheers,,Republican,699
+Johnson,Bonner Springs 4-01,State House,39,"Shulda, Marlys",Marlys,,Shulda,,Democratic,0
+Johnson,Shawnee 1-08,State House,39,"Shulda, Marlys",Marlys,,Shulda,,Democratic,393
+Johnson,Shawnee 1-10,State House,39,"Shulda, Marlys",Marlys,,Shulda,,Democratic,91
+Johnson,Shawnee 1-11,State House,39,"Shulda, Marlys",Marlys,,Shulda,,Democratic,259
+Johnson,Shawnee 3-01,State House,39,"Shulda, Marlys",Marlys,,Shulda,,Democratic,201
+Johnson,Shawnee 3-02,State House,39,"Shulda, Marlys",Marlys,,Shulda,,Democratic,348
+Johnson,Shawnee 3-03,State House,39,"Shulda, Marlys",Marlys,,Shulda,,Democratic,306
+Johnson,Shawnee 3-04,State House,39,"Shulda, Marlys",Marlys,,Shulda,,Democratic,244
+Johnson,Shawnee 3-05,State House,39,"Shulda, Marlys",Marlys,,Shulda,,Democratic,291
+Johnson,Shawnee 3-06,State House,39,"Shulda, Marlys",Marlys,,Shulda,,Democratic,389
+Johnson,Shawnee 3-07,State House,39,"Shulda, Marlys",Marlys,,Shulda,,Democratic,384
+Johnson,Shawnee 3-08,State House,39,"Shulda, Marlys",Marlys,,Shulda,,Democratic,365
+Johnson,Shawnee 3-09,State House,39,"Shulda, Marlys",Marlys,,Shulda,,Democratic,160
+Johnson,Shawnee 4-09,State House,39,"Shulda, Marlys",Marlys,,Shulda,,Democratic,499
+Johnson,Edgerton 0-01,State House,43,"King, Kevin",Kevin,,King,,Democratic,191
+Johnson,Edgerton 0-02,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Edgerton 0-03,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Edgerton 0-04,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Edgerton 0-05,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Edgerton 0-06,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Edgerton 0-07,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Edgerton 0-08,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Gardner 0-01,State House,43,"King, Kevin",Kevin,,King,,Democratic,370
+Johnson,Gardner 0-02,State House,43,"King, Kevin",Kevin,,King,,Democratic,86
+Johnson,Gardner 0-03,State House,43,"King, Kevin",Kevin,,King,,Democratic,337
+Johnson,Gardner 0-04,State House,43,"King, Kevin",Kevin,,King,,Democratic,213
+Johnson,Gardner 0-05,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Gardner 0-06,State House,43,"King, Kevin",Kevin,,King,,Democratic,285
+Johnson,Gardner 0-08,State House,43,"King, Kevin",Kevin,,King,,Democratic,16
+Johnson,Gardner 0-09,State House,43,"King, Kevin",Kevin,,King,,Democratic,350
+Johnson,Gardner 0-10,State House,43,"King, Kevin",Kevin,,King,,Democratic,228
+Johnson,Gardner 0-11,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Gardner 0-12,State House,43,"King, Kevin",Kevin,,King,,Democratic,12
+Johnson,Gardner 0-13,State House,43,"King, Kevin",Kevin,,King,,Democratic,265
+Johnson,Gardner 0-14,State House,43,"King, Kevin",Kevin,,King,,Democratic,252
+Johnson,Gardner 0-15,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Gardner Twp 0-02,State House,43,"King, Kevin",Kevin,,King,,Democratic,127
+Johnson,Gardner Twp 0-03,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Gardner Twp 0-04,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Gardner Twp 0-05,State House,43,"King, Kevin",Kevin,,King,,Democratic,4
+Johnson,Gardner Twp 0-06,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Gardner Twp 0-07,State House,43,"King, Kevin",Kevin,,King,,Democratic,2
+Johnson,Gardner Twp 0-08,State House,43,"King, Kevin",Kevin,,King,,Democratic,3
+Johnson,Gardner Twp 0-09,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Gardner Twp 0-12,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,McCamish Twp 0-01,State House,43,"King, Kevin",Kevin,,King,,Democratic,47
+Johnson,McCamish Twp 0-02,State House,43,"King, Kevin",Kevin,,King,,Democratic,92
+Johnson,McCamish Twp 0-03,State House,43,"King, Kevin",Kevin,,King,,Democratic,0
+Johnson,Edgerton 0-01,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,441
+Johnson,Edgerton 0-02,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,0
+Johnson,Edgerton 0-03,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,0
+Johnson,Edgerton 0-04,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,0
+Johnson,Edgerton 0-05,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,0
+Johnson,Edgerton 0-06,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,0
+Johnson,Edgerton 0-07,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,0
+Johnson,Edgerton 0-08,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,0
+Johnson,Gardner 0-01,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,819
+Johnson,Gardner 0-02,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,104
+Johnson,Gardner 0-03,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,552
+Johnson,Gardner 0-04,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,449
+Johnson,Gardner 0-05,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,0
+Johnson,Gardner 0-06,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,634
+Johnson,Gardner 0-08,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,51
+Johnson,Gardner 0-09,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,704
+Johnson,Gardner 0-10,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,473
+Johnson,Gardner 0-11,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,0
+Johnson,Gardner 0-12,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,7
+Johnson,Gardner 0-13,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,559
+Johnson,Gardner 0-14,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,389
+Johnson,Gardner 0-15,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,0
+Johnson,Gardner Twp 0-02,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,347
+Johnson,Gardner Twp 0-03,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,0
+Johnson,Gardner Twp 0-04,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,1
+Johnson,Gardner Twp 0-05,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,4
+Johnson,Gardner Twp 0-06,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,0
+Johnson,Gardner Twp 0-07,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,2
+Johnson,Gardner Twp 0-08,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,2
+Johnson,Gardner Twp 0-09,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,2
+Johnson,Gardner Twp 0-12,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,0
+Johnson,McCamish Twp 0-01,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,132
+Johnson,McCamish Twp 0-02,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,264
+Johnson,McCamish Twp 0-03,State House,43,"Sutton, Bill",Bill,,Sutton,,Republican,0
+Johnson,Overland Park 4-04,State House,48,"Kleeb, Marvin",Marvin,,Kleeb,,Republican,892
+Johnson,Overland Park 4-05,State House,48,"Kleeb, Marvin",Marvin,,Kleeb,,Republican,705
+Johnson,Overland Park 4-11,State House,48,"Kleeb, Marvin",Marvin,,Kleeb,,Republican,701
+Johnson,Overland Park 4-12,State House,48,"Kleeb, Marvin",Marvin,,Kleeb,,Republican,961
+Johnson,Overland Park 5-05,State House,48,"Kleeb, Marvin",Marvin,,Kleeb,,Republican,419
+Johnson,Overland Park 5-15,State House,48,"Kleeb, Marvin",Marvin,,Kleeb,,Republican,581
+Johnson,Overland Park 5-18,State House,48,"Kleeb, Marvin",Marvin,,Kleeb,,Republican,493
+Johnson,Overland Park 5-19,State House,48,"Kleeb, Marvin",Marvin,,Kleeb,,Republican,51
+Johnson,Overland Park 6-01,State House,48,"Kleeb, Marvin",Marvin,,Kleeb,,Republican,823
+Johnson,Overland Park 6-02,State House,48,"Kleeb, Marvin",Marvin,,Kleeb,,Republican,653
+Johnson,Overland Park 6-04,State House,48,"Kleeb, Marvin",Marvin,,Kleeb,,Republican,779
+Johnson,Overland Park 6-05,State House,48,"Kleeb, Marvin",Marvin,,Kleeb,,Republican,839
+Johnson,Overland Park 6-17,State House,48,"Kleeb, Marvin",Marvin,,Kleeb,,Republican,679
+Johnson,Overland Park 6-23,State House,48,"Kleeb, Marvin",Marvin,,Kleeb,,Republican,136
+Johnson,Olathe 3-01,State House,49,"Mace, Keith",Keith,,Mace,,Democratic,144
+Johnson,Olathe 3-02,State House,49,"Mace, Keith",Keith,,Mace,,Democratic,366
+Johnson,Olathe 3-08,State House,49,"Mace, Keith",Keith,,Mace,,Democratic,252
+Johnson,Olathe 3-09,State House,49,"Mace, Keith",Keith,,Mace,,Democratic,153
+Johnson,Olathe 3-12,State House,49,"Mace, Keith",Keith,,Mace,,Democratic,292
+Johnson,Olathe 3-16,State House,49,"Mace, Keith",Keith,,Mace,,Democratic,236
+Johnson,Olathe 3-18,State House,49,"Mace, Keith",Keith,,Mace,,Democratic,271
+Johnson,Olathe 3-27,State House,49,"Mace, Keith",Keith,,Mace,,Democratic,108
+Johnson,Olathe 4-06,State House,49,"Mace, Keith",Keith,,Mace,,Democratic,390
+Johnson,Olathe 4-07,State House,49,"Mace, Keith",Keith,,Mace,,Democratic,377
+Johnson,Olathe 4-12,State House,49,"Mace, Keith",Keith,,Mace,,Democratic,349
+Johnson,Olathe 4-18,State House,49,"Mace, Keith",Keith,,Mace,,Democratic,159
+Johnson,Olathe 3-01,State House,49,"Schwab, Scott",Scott,,Schwab,,Republican,199
+Johnson,Olathe 3-02,State House,49,"Schwab, Scott",Scott,,Schwab,,Republican,569
+Johnson,Olathe 3-08,State House,49,"Schwab, Scott",Scott,,Schwab,,Republican,574
+Johnson,Olathe 3-09,State House,49,"Schwab, Scott",Scott,,Schwab,,Republican,285
+Johnson,Olathe 3-12,State House,49,"Schwab, Scott",Scott,,Schwab,,Republican,493
+Johnson,Olathe 3-16,State House,49,"Schwab, Scott",Scott,,Schwab,,Republican,457
+Johnson,Olathe 3-18,State House,49,"Schwab, Scott",Scott,,Schwab,,Republican,526
+Johnson,Olathe 3-27,State House,49,"Schwab, Scott",Scott,,Schwab,,Republican,240
+Johnson,Olathe 4-06,State House,49,"Schwab, Scott",Scott,,Schwab,,Republican,569
+Johnson,Olathe 4-07,State House,49,"Schwab, Scott",Scott,,Schwab,,Republican,447
+Johnson,Olathe 4-12,State House,49,"Schwab, Scott",Scott,,Schwab,,Republican,609
+Johnson,Olathe 4-18,State House,49,"Schwab, Scott",Scott,,Schwab,,Republican,143
+Johnson,Olathe 3-01,State House,49,"Wilson, John",John,,Wilson,,Libertarian,43
+Johnson,Olathe 3-02,State House,49,"Wilson, John",John,,Wilson,,Libertarian,87
+Johnson,Olathe 3-08,State House,49,"Wilson, John",John,,Wilson,,Libertarian,65
+Johnson,Olathe 3-09,State House,49,"Wilson, John",John,,Wilson,,Libertarian,47
+Johnson,Olathe 3-12,State House,49,"Wilson, John",John,,Wilson,,Libertarian,78
+Johnson,Olathe 3-16,State House,49,"Wilson, John",John,,Wilson,,Libertarian,44
+Johnson,Olathe 3-18,State House,49,"Wilson, John",John,,Wilson,,Libertarian,44
+Johnson,Olathe 3-27,State House,49,"Wilson, John",John,,Wilson,,Libertarian,39
+Johnson,Olathe 4-06,State House,49,"Wilson, John",John,,Wilson,,Libertarian,89
+Johnson,Olathe 4-07,State House,49,"Wilson, John",John,,Wilson,,Libertarian,109
+Johnson,Olathe 4-12,State House,49,"Wilson, John",John,,Wilson,,Libertarian,66
+Johnson,Olathe 4-18,State House,49,"Wilson, John",John,,Wilson,,Libertarian,31
+Johnson,Olathe 1-05,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,635
+Johnson,Olathe 1-09,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,743
+Johnson,Olathe 1-28,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,161
+Johnson,Olathe 1-29,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,103
+Johnson,Olathe 3-03,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,446
+Johnson,Olathe 3-04,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,725
+Johnson,Olathe 3-06,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,520
+Johnson,Olathe 3-07,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,497
+Johnson,Olathe 3-10,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,808
+Johnson,Olathe 3-11,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,531
+Johnson,Olathe 3-13,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,717
+Johnson,Olathe 3-15,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,579
+Johnson,Olathe 3-17,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,797
+Johnson,Olathe 3-19,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,471
+Johnson,Olathe 3-22,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,636
+Johnson,Olathe 3-23,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,638
+Johnson,Olathe 3-24,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,0
+Johnson,Olathe 3-25,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,0
+Johnson,Olathe 3-26,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,61
+Johnson,Olathe Twp 0-14,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,1
+Johnson,Oxford Twp 0-11,State House,78,"Ryckman, Ron",Ron,,Ryckman,,Republican,103
+Johnson,Gardner Twp 0-10,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,0
+Johnson,Gardner Twp 0-11,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,46
+Johnson,Lenexa 2-02,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,72
+Johnson,Lenexa 2-07,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,393
+Johnson,Olathe 1-12,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,12
+Johnson,Olathe 1-13,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,0
+Johnson,Olathe 1-19,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,156
+Johnson,Olathe 1-20,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,273
+Johnson,Olathe 1-21,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,414
+Johnson,Olathe 1-22,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,348
+Johnson,Olathe 1-24,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,0
+Johnson,Olathe 1-27,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,236
+Johnson,Olathe 2-05,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,404
+Johnson,Olathe 2-06,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,193
+Johnson,Olathe 2-07,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,327
+Johnson,Olathe 2-10,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,620
+Johnson,Olathe 2-16,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,0
+Johnson,Olathe 2-18,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,0
+Johnson,Olathe 2-19,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,4
+Johnson,Olathe 2-21,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,0
+Johnson,Olathe 2-24,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,3
+Johnson,Olathe 2-25,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,6
+Johnson,Olathe Twp 0-01,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,136
+Johnson,Olathe Twp 0-03,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,25
+Johnson,Olathe Twp 0-04,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,0
+Johnson,Olathe Twp 0-08,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,4
+Johnson,Olathe Twp 0-09,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,0
+Johnson,Olathe Twp 0-11,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,2
+Johnson,Olathe Twp 0-17,State House,121,"Dixon, Tyler G.",Tyler,G.,Dixon,,Democratic,0
+Johnson,Gardner Twp 0-10,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,0
+Johnson,Gardner Twp 0-11,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,66
+Johnson,Lenexa 2-02,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,211
+Johnson,Lenexa 2-07,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,676
+Johnson,Olathe 1-12,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,21
+Johnson,Olathe 1-13,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,0
+Johnson,Olathe 1-19,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,208
+Johnson,Olathe 1-20,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,311
+Johnson,Olathe 1-21,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,563
+Johnson,Olathe 1-22,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,740
+Johnson,Olathe 1-24,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,0
+Johnson,Olathe 1-27,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,304
+Johnson,Olathe 2-05,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,1018
+Johnson,Olathe 2-06,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,582
+Johnson,Olathe 2-07,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,651
+Johnson,Olathe 2-10,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,890
+Johnson,Olathe 2-16,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,0
+Johnson,Olathe 2-18,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,0
+Johnson,Olathe 2-19,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,3
+Johnson,Olathe 2-21,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,0
+Johnson,Olathe 2-24,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,11
+Johnson,Olathe 2-25,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,2
+Johnson,Olathe Twp 0-01,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,217
+Johnson,Olathe Twp 0-03,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,23
+Johnson,Olathe Twp 0-04,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,2
+Johnson,Olathe Twp 0-08,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,12
+Johnson,Olathe Twp 0-09,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,0
+Johnson,Olathe Twp 0-11,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,2
+Johnson,Olathe Twp 0-17,State House,121,"Siegfreid, Arlen H.",Arlen,H.,Siegfreid,,Republican,0
+Johnson,Overland Park 1-08,State House,22,"Brems, Marla",Marla,,Brems,,Republican,251
+Johnson,Overland Park 1-09,State House,22,"Brems, Marla",Marla,,Brems,,Republican,173
+Johnson,Overland Park 1-10,State House,22,"Brems, Marla",Marla,,Brems,,Republican,287
+Johnson,Overland Park 1-11,State House,22,"Brems, Marla",Marla,,Brems,,Republican,116
+Johnson,Overland Park 1-12,State House,22,"Brems, Marla",Marla,,Brems,,Republican,271
+Johnson,Overland Park 1-13,State House,22,"Brems, Marla",Marla,,Brems,,Republican,198
+Johnson,Overland Park 1-14,State House,22,"Brems, Marla",Marla,,Brems,,Republican,265
+Johnson,Overland Park 1-15,State House,22,"Brems, Marla",Marla,,Brems,,Republican,123
+Johnson,Overland Park 1-19,State House,22,"Brems, Marla",Marla,,Brems,,Republican,213
+Johnson,Overland Park 2-06,State House,22,"Brems, Marla",Marla,,Brems,,Republican,279
+Johnson,Overland Park 2-07,State House,22,"Brems, Marla",Marla,,Brems,,Republican,217
+Johnson,Overland Park 2-10,State House,22,"Brems, Marla",Marla,,Brems,,Republican,231
+Johnson,Overland Park 2-11,State House,22,"Brems, Marla",Marla,,Brems,,Republican,261
+Johnson,Overland Park 2-12,State House,22,"Brems, Marla",Marla,,Brems,,Republican,208
+Johnson,Overland Park 2-13,State House,22,"Brems, Marla",Marla,,Brems,,Republican,142
+Johnson,Overland Park 2-18,State House,22,"Brems, Marla",Marla,,Brems,,Republican,316
+Johnson,Overland Park 1-08,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,429
+Johnson,Overland Park 1-09,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,227
+Johnson,Overland Park 1-10,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,484
+Johnson,Overland Park 1-11,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,207
+Johnson,Overland Park 1-12,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,509
+Johnson,Overland Park 1-13,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,328
+Johnson,Overland Park 1-14,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,437
+Johnson,Overland Park 1-15,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,216
+Johnson,Overland Park 1-19,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,378
+Johnson,Overland Park 2-06,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,362
+Johnson,Overland Park 2-07,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,284
+Johnson,Overland Park 2-10,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,227
+Johnson,Overland Park 2-11,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,369
+Johnson,Overland Park 2-12,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,274
+Johnson,Overland Park 2-13,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,247
+Johnson,Overland Park 2-18,State House,22,"Lusk, Nancy",Nancy,,Lusk,,Democratic,498
+Johnson,Lenexa 3-01,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,335
+Johnson,Lenexa 3-02,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,452
+Johnson,Lenexa 3-03,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,582
+Johnson,Lenexa 3-04,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,443
+Johnson,Lenexa 3-05,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,252
+Johnson,Lenexa 4-03,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,207
+Johnson,Lenexa 4-04,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,233
+Johnson,Overland Park 2-05,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,322
+Johnson,Overland Park 2-09,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,283
+Johnson,Overland Park 2-26,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,124
+Johnson,Shawnee 2-12,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,79
+Johnson,Shawnee 2-13,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,171
+Johnson,Shawnee 4-01,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,609
+Johnson,Shawnee 4-03,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,155
+Johnson,Shawnee 4-04,State House,23,"Meigs, Kelly R.",Kelly,R.,Meigs,,Republican,143
+Johnson,Lenexa 3-01,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,383
+Johnson,Lenexa 3-02,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,505
+Johnson,Lenexa 3-03,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,470
+Johnson,Lenexa 3-04,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,264
+Johnson,Lenexa 3-05,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,321
+Johnson,Lenexa 4-03,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,252
+Johnson,Lenexa 4-04,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,207
+Johnson,Overland Park 2-05,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,354
+Johnson,Overland Park 2-09,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,294
+Johnson,Overland Park 2-26,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,161
+Johnson,Shawnee 2-12,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,133
+Johnson,Shawnee 2-13,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,149
+Johnson,Shawnee 4-01,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,411
+Johnson,Shawnee 4-03,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,102
+Johnson,Shawnee 4-04,State House,23,"Pack, Dave",Dave,,Pack,,Democratic,222
+Johnson,Merriam 1-01,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,268
+Johnson,Merriam 1-02,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,408
+Johnson,Merriam 2-01,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,415
+Johnson,Merriam 2-02,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,1
+Johnson,Merriam 2-03,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,250
+Johnson,Merriam 3-01,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,410
+Johnson,Merriam 3-02,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,309
+Johnson,Merriam 4-01,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,391
+Johnson,Merriam 4-02,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,180
+Johnson,Merriam 4-03,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,242
+Johnson,Mission 1-02,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,260
+Johnson,Mission 3-01,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,441
+Johnson,Overland Park 1-01,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,445
+Johnson,Overland Park 1-02,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,466
+Johnson,Overland Park 1-03,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,365
+Johnson,Overland Park 1-04,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,128
+Johnson,Overland Park 1-05,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,279
+Johnson,Overland Park 1-20,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,238
+Johnson,Overland Park 1-21,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,110
+Johnson,Overland Park 1-22,State House,24,"Perry, Emily",Emily,,Perry,,Democratic,110
+Johnson,Merriam 1-01,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,200
+Johnson,Merriam 1-02,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,227
+Johnson,Merriam 2-01,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,319
+Johnson,Merriam 2-02,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,1
+Johnson,Merriam 2-03,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,146
+Johnson,Merriam 3-01,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,270
+Johnson,Merriam 3-02,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,224
+Johnson,Merriam 4-01,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,352
+Johnson,Merriam 4-02,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,160
+Johnson,Merriam 4-03,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,180
+Johnson,Mission 1-02,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,122
+Johnson,Mission 3-01,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,269
+Johnson,Overland Park 1-01,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,259
+Johnson,Overland Park 1-02,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,264
+Johnson,Overland Park 1-03,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,316
+Johnson,Overland Park 1-04,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,135
+Johnson,Overland Park 1-05,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,206
+Johnson,Overland Park 1-20,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,157
+Johnson,Overland Park 1-21,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,118
+Johnson,Overland Park 1-22,State House,24,"Waldschmidt, Christopher Kenneth",Christopher,Kenneth,Waldschmidt,,Republican,64
+Johnson,Fairway 1-00,State House,25,"England, Megan",Megan,,England,,Democratic,240
+Johnson,Fairway 2-00,State House,25,"England, Megan",Megan,,England,,Democratic,193
+Johnson,Fairway 3-00,State House,25,"England, Megan",Megan,,England,,Democratic,230
+Johnson,Fairway 4-00,State House,25,"England, Megan",Megan,,England,,Democratic,327
+Johnson,Mission 1-01,State House,25,"England, Megan",Megan,,England,,Democratic,386
+Johnson,Mission 2-01,State House,25,"England, Megan",Megan,,England,,Democratic,263
+Johnson,Mission 2-02,State House,25,"England, Megan",Megan,,England,,Democratic,329
+Johnson,Mission 3-02,State House,25,"England, Megan",Megan,,England,,Democratic,206
+Johnson,Mission 4-01,State House,25,"England, Megan",Megan,,England,,Democratic,253
+Johnson,Mission 4-02,State House,25,"England, Megan",Megan,,England,,Democratic,259
+Johnson,Mission 4-03,State House,25,"England, Megan",Megan,,England,,Democratic,198
+Johnson,Mission Hills 0-01,State House,25,"England, Megan",Megan,,England,,Democratic,127
+Johnson,Mission Hills 0-02,State House,25,"England, Megan",Megan,,England,,Democratic,172
+Johnson,Mission Hills 0-03,State House,25,"England, Megan",Megan,,England,,Democratic,65
+Johnson,Mission Woods 0-01,State House,25,"England, Megan",Megan,,England,,Democratic,44
+Johnson,Prairie Village 1-01,State House,25,"England, Megan",Megan,,England,,Democratic,370
+Johnson,Roeland Park 1-01,State House,25,"England, Megan",Megan,,England,,Democratic,264
+Johnson,Roeland Park 1-02,State House,25,"England, Megan",Megan,,England,,Democratic,164
+Johnson,Roeland Park 1-03,State House,25,"England, Megan",Megan,,England,,Democratic,0
+Johnson,Roeland Park 2-01,State House,25,"England, Megan",Megan,,England,,Democratic,232
+Johnson,Roeland Park 2-02,State House,25,"England, Megan",Megan,,England,,Democratic,300
+Johnson,Roeland Park 3-01,State House,25,"England, Megan",Megan,,England,,Democratic,190
+Johnson,Roeland Park 3-02,State House,25,"England, Megan",Megan,,England,,Democratic,318
+Johnson,Roeland Park 4-01,State House,25,"England, Megan",Megan,,England,,Democratic,149
+Johnson,Roeland Park 4-02,State House,25,"England, Megan",Megan,,England,,Democratic,466
+Johnson,Westwood 0-01,State House,25,"England, Megan",Megan,,England,,Democratic,277
+Johnson,Westwood 0-02,State House,25,"England, Megan",Megan,,England,,Democratic,231
+Johnson,Westwood Hills 0-01,State House,25,"England, Megan",Megan,,England,,Democratic,123
+Johnson,Fairway 1-00,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,376
+Johnson,Fairway 2-00,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,345
+Johnson,Fairway 3-00,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,472
+Johnson,Fairway 4-00,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,266
+Johnson,Mission 1-01,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,283
+Johnson,Mission 2-01,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,142
+Johnson,Mission 2-02,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,219
+Johnson,Mission 3-02,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,147
+Johnson,Mission 4-01,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,165
+Johnson,Mission 4-02,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,325
+Johnson,Mission 4-03,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,159
+Johnson,Mission Hills 0-01,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,403
+Johnson,Mission Hills 0-02,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,488
+Johnson,Mission Hills 0-03,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,363
+Johnson,Mission Woods 0-01,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,64
+Johnson,Prairie Village 1-01,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,493
+Johnson,Roeland Park 1-01,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,116
+Johnson,Roeland Park 1-02,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,86
+Johnson,Roeland Park 1-03,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,0
+Johnson,Roeland Park 2-01,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,147
+Johnson,Roeland Park 2-02,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,194
+Johnson,Roeland Park 3-01,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,139
+Johnson,Roeland Park 3-02,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,269
+Johnson,Roeland Park 4-01,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,113
+Johnson,Roeland Park 4-02,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,298
+Johnson,Westwood 0-01,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,181
+Johnson,Westwood 0-02,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,202
+Johnson,Westwood Hills 0-01,State House,25,"Rooker, Melissa A.",Melissa,A.,Rooker,,Republican,118
+Johnson,Aubry Twp 0-05,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,14
+Johnson,Olathe 1-04,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,650
+Johnson,Olathe 1-06,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,454
+Johnson,Olathe 1-07,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,0
+Johnson,Olathe 1-08,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,880
+Johnson,Olathe 1-10,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,6
+Johnson,Olathe 1-14,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,584
+Johnson,Olathe 1-15,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,624
+Johnson,Olathe 1-16,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,858
+Johnson,Olathe 1-17,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,175
+Johnson,Olathe 1-18,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,184
+Johnson,Olathe 1-23,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,0
+Johnson,Olathe 1-26,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,3
+Johnson,Olathe 3-20,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,553
+Johnson,Olathe 3-21,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,362
+Johnson,Olathe Twp 0-02,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,53
+Johnson,Olathe Twp 0-05,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,2
+Johnson,Olathe Twp 0-06,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,1
+Johnson,Olathe Twp 0-07,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,1
+Johnson,Olathe Twp 0-10,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,15
+Johnson,Olathe Twp 0-12,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,0
+Johnson,Olathe Twp 0-13,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,0
+Johnson,Olathe Twp 0-24,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,3
+Johnson,Olathe Twp 0-25,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,8
+Johnson,Olathe Twp 0-26,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,3
+Johnson,Olathe Twp 0-27,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,0
+Johnson,Olathe Twp 0-32,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,24
+Johnson,Oxford Twp 0-01,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,1
+Johnson,Spring Hill 0-01,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,1047
+Johnson,Spring Hill 0-02,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,0
+Johnson,Spring Hill 0-03,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,38
+Johnson,Spring Hill 0-04,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,0
+Johnson,Spring Hill Twp 0-01,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,740
+Johnson,Spring Hill Twp 0-02,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,2
+Johnson,Spring Hill Twp 0-03,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,75
+Johnson,Spring Hill Twp 0-04,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,15
+Johnson,Spring Hill Twp 0-05,State House,26,"Campbell, Larry L.",Larry,L.,Campbell,,Republican,10
+Johnson,Aubry Twp 0-01,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,102
+Johnson,Aubry Twp 0-02,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,663
+Johnson,Aubry Twp 0-03,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,360
+Johnson,Aubry Twp 0-04,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,853
+Johnson,Aubry Twp 0-06,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,94
+Johnson,Leawood 4-08,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,400
+Johnson,Overland Park 6-06,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,1
+Johnson,Overland Park 6-08,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,946
+Johnson,Overland Park 6-09,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,898
+Johnson,Overland Park 6-10,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,677
+Johnson,Overland Park 6-11,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,656
+Johnson,Overland Park 6-12,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,293
+Johnson,Overland Park 6-13,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,853
+Johnson,Overland Park 6-14,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,3
+Johnson,Overland Park 6-15,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,926
+Johnson,Overland Park 6-18,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,0
+Johnson,Overland Park 6-19,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,797
+Johnson,Overland Park 6-20,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,368
+Johnson,Overland Park 6-22,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,289
+Johnson,Oxford Twp 0-02,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,490
+Johnson,Oxford Twp 0-04,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,402
+Johnson,Oxford Twp 0-08,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,0
+Johnson,Oxford Twp 0-09,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,28
+Johnson,Oxford Twp 0-10,State House,27,"Merrick, Ray",Ray,,Merrick,,Republican,2
+Johnson,Leawood 3-04,State House,28,"Jackson, Kelly L.",Kelly,L.,Jackson,,Democratic,138
+Johnson,Leawood 3-05,State House,28,"Jackson, Kelly L.",Kelly,L.,Jackson,,Democratic,476
+Johnson,Leawood 3-06,State House,28,"Jackson, Kelly L.",Kelly,L.,Jackson,,Democratic,416
+Johnson,Leawood 4-04,State House,28,"Jackson, Kelly L.",Kelly,L.,Jackson,,Democratic,459
+Johnson,Leawood 4-05,State House,28,"Jackson, Kelly L.",Kelly,L.,Jackson,,Democratic,436
+Johnson,Leawood 4-06,State House,28,"Jackson, Kelly L.",Kelly,L.,Jackson,,Democratic,243
+Johnson,Leawood 4-07,State House,28,"Jackson, Kelly L.",Kelly,L.,Jackson,,Democratic,472
+Johnson,Overland Park 5-06,State House,28,"Jackson, Kelly L.",Kelly,L.,Jackson,,Democratic,381
+Johnson,Overland Park 5-07,State House,28,"Jackson, Kelly L.",Kelly,L.,Jackson,,Democratic,296
+Johnson,Overland Park 5-08,State House,28,"Jackson, Kelly L.",Kelly,L.,Jackson,,Democratic,524
+Johnson,Overland Park 5-09,State House,28,"Jackson, Kelly L.",Kelly,L.,Jackson,,Democratic,459
+Johnson,Overland Park 5-16,State House,28,"Jackson, Kelly L.",Kelly,L.,Jackson,,Democratic,250
+Johnson,Overland Park 5-17,State House,28,"Jackson, Kelly L.",Kelly,L.,Jackson,,Democratic,190
+Johnson,Oxford Twp 0-05,State House,28,"Jackson, Kelly L.",Kelly,L.,Jackson,,Democratic,2
+Johnson,Leawood 3-04,State House,28,"Lunn, Jerry",Jerry,,Lunn,,Republican,140
+Johnson,Leawood 3-05,State House,28,"Lunn, Jerry",Jerry,,Lunn,,Republican,646
+Johnson,Leawood 3-06,State House,28,"Lunn, Jerry",Jerry,,Lunn,,Republican,647
+Johnson,Leawood 4-04,State House,28,"Lunn, Jerry",Jerry,,Lunn,,Republican,470
+Johnson,Leawood 4-05,State House,28,"Lunn, Jerry",Jerry,,Lunn,,Republican,448
+Johnson,Leawood 4-06,State House,28,"Lunn, Jerry",Jerry,,Lunn,,Republican,435
+Johnson,Leawood 4-07,State House,28,"Lunn, Jerry",Jerry,,Lunn,,Republican,727
+Johnson,Overland Park 5-06,State House,28,"Lunn, Jerry",Jerry,,Lunn,,Republican,408
+Johnson,Overland Park 5-07,State House,28,"Lunn, Jerry",Jerry,,Lunn,,Republican,711
+Johnson,Overland Park 5-08,State House,28,"Lunn, Jerry",Jerry,,Lunn,,Republican,691
+Johnson,Overland Park 5-09,State House,28,"Lunn, Jerry",Jerry,,Lunn,,Republican,566
+Johnson,Overland Park 5-16,State House,28,"Lunn, Jerry",Jerry,,Lunn,,Republican,261
+Johnson,Overland Park 5-17,State House,28,"Lunn, Jerry",Jerry,,Lunn,,Republican,166
+Johnson,Oxford Twp 0-05,State House,28,"Lunn, Jerry",Jerry,,Lunn,,Republican,12
+Johnson,Overland Park 2-04,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,354
+Johnson,Overland Park 3-02,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,317
+Johnson,Overland Park 3-03,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,255
+Johnson,Overland Park 3-04,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,403
+Johnson,Overland Park 3-05,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,368
+Johnson,Overland Park 3-06,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,430
+Johnson,Overland Park 3-07,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,323
+Johnson,Overland Park 3-08,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,278
+Johnson,Overland Park 3-12,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,311
+Johnson,Overland Park 3-17,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,228
+Johnson,Overland Park 3-19,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,301
+Johnson,Overland Park 5-01,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,338
+Johnson,Overland Park 5-02,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,192
+Johnson,Overland Park 5-03,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,230
+Johnson,Overland Park 5-04,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,337
+Johnson,Overland Park 5-11,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,441
+Johnson,Overland Park 5-12,State House,29,"Leiker, Nancy",Nancy,,Leiker,,Democratic,108
+Johnson,Overland Park 2-04,State House,29,"Todd, James",James,,Todd,,Republican,335
+Johnson,Overland Park 3-02,State House,29,"Todd, James",James,,Todd,,Republican,332
+Johnson,Overland Park 3-03,State House,29,"Todd, James",James,,Todd,,Republican,328
+Johnson,Overland Park 3-04,State House,29,"Todd, James",James,,Todd,,Republican,404
+Johnson,Overland Park 3-05,State House,29,"Todd, James",James,,Todd,,Republican,406
+Johnson,Overland Park 3-06,State House,29,"Todd, James",James,,Todd,,Republican,459
+Johnson,Overland Park 3-07,State House,29,"Todd, James",James,,Todd,,Republican,291
+Johnson,Overland Park 3-08,State House,29,"Todd, James",James,,Todd,,Republican,372
+Johnson,Overland Park 3-12,State House,29,"Todd, James",James,,Todd,,Republican,216
+Johnson,Overland Park 3-17,State House,29,"Todd, James",James,,Todd,,Republican,292
+Johnson,Overland Park 3-19,State House,29,"Todd, James",James,,Todd,,Republican,429
+Johnson,Overland Park 5-01,State House,29,"Todd, James",James,,Todd,,Republican,482
+Johnson,Overland Park 5-02,State House,29,"Todd, James",James,,Todd,,Republican,252
+Johnson,Overland Park 5-03,State House,29,"Todd, James",James,,Todd,,Republican,390
+Johnson,Overland Park 5-04,State House,29,"Todd, James",James,,Todd,,Republican,403
+Johnson,Overland Park 5-11,State House,29,"Todd, James",James,,Todd,,Republican,559
+Johnson,Overland Park 5-12,State House,29,"Todd, James",James,,Todd,,Republican,125
+Johnson,Olathe 3-05,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,636
+Johnson,Olathe 3-14,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,3
+Johnson,Overland Park 4-01,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,471
+Johnson,Overland Park 4-02,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,837
+Johnson,Overland Park 4-03,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,930
+Johnson,Overland Park 4-09,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,630
+Johnson,Overland Park 4-10,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,468
+Johnson,Overland Park 4-13,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,507
+Johnson,Overland Park 4-14,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,392
+Johnson,Overland Park 4-15,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,887
+Johnson,Overland Park 4-16,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,695
+Johnson,Overland Park 4-17,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,746
+Johnson,Overland Park 4-18,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,154
+Johnson,Overland Park 6-03,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,784
+Johnson,Overland Park 6-07,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,217
+Johnson,Overland Park 6-16,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,499
+Johnson,Overland Park 6-21,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,992
+Johnson,Oxford Twp 0-03,State House,8,"McPherson, Craig",Craig,,McPherson,,Republican,0
+Johnson,Lenexa 1-06,State House,14,"Esau, Keith",Keith,,Esau,,Republican,589
+Johnson,Lenexa 1-08,State House,14,"Esau, Keith",Keith,,Esau,,Republican,114
+Johnson,Lenexa 2-01,State House,14,"Esau, Keith",Keith,,Esau,,Republican,665
+Johnson,Lenexa 2-03,State House,14,"Esau, Keith",Keith,,Esau,,Republican,677
+Johnson,Lenexa 2-04,State House,14,"Esau, Keith",Keith,,Esau,,Republican,774
+Johnson,Lenexa 2-06,State House,14,"Esau, Keith",Keith,,Esau,,Republican,452
+Johnson,Olathe 2-09,State House,14,"Esau, Keith",Keith,,Esau,,Republican,195
+Johnson,Olathe 2-12,State House,14,"Esau, Keith",Keith,,Esau,,Republican,377
+Johnson,Olathe 2-15,State House,14,"Esau, Keith",Keith,,Esau,,Republican,311
+Johnson,Olathe 2-22,State House,14,"Esau, Keith",Keith,,Esau,,Republican,718
+Johnson,Olathe 2-26,State House,14,"Esau, Keith",Keith,,Esau,,Republican,0
+Johnson,Olathe 2-27,State House,14,"Esau, Keith",Keith,,Esau,,Republican,10
+Johnson,Olathe 2-28,State House,14,"Esau, Keith",Keith,,Esau,,Republican,138
+Johnson,Olathe 4-02,State House,14,"Esau, Keith",Keith,,Esau,,Republican,626
+Johnson,Olathe 4-03,State House,14,"Esau, Keith",Keith,,Esau,,Republican,254
+Johnson,Olathe 4-05,State House,14,"Esau, Keith",Keith,,Esau,,Republican,471
+Johnson,Olathe 4-11,State House,14,"Esau, Keith",Keith,,Esau,,Republican,218
+Johnson,Olathe 4-15,State House,14,"Esau, Keith",Keith,,Esau,,Republican,41
+Johnson,Olathe 4-16,State House,14,"Esau, Keith",Keith,,Esau,,Republican,1
+Johnson,Shawnee 4-10,State House,14,"Esau, Keith",Keith,,Esau,,Republican,0
+Johnson,Lenexa 1-06,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,365
+Johnson,Lenexa 1-08,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,130
+Johnson,Lenexa 2-01,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,347
+Johnson,Lenexa 2-03,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,367
+Johnson,Lenexa 2-04,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,294
+Johnson,Lenexa 2-06,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,223
+Johnson,Olathe 2-09,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,141
+Johnson,Olathe 2-12,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,199
+Johnson,Olathe 2-15,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,135
+Johnson,Olathe 2-22,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,354
+Johnson,Olathe 2-26,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,0
+Johnson,Olathe 2-27,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,1
+Johnson,Olathe 2-28,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,107
+Johnson,Olathe 4-02,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,431
+Johnson,Olathe 4-03,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,246
+Johnson,Olathe 4-05,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,308
+Johnson,Olathe 4-11,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,205
+Johnson,Olathe 4-15,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,47
+Johnson,Olathe 4-16,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,2
+Johnson,Shawnee 4-10,State House,14,"Eveslage, Roberta A.",Roberta,A.,Eveslage,,Democratic,0
+Johnson,Olathe 1-01,State House,15,"Montgomery, Robert",Robert,,Montgomery,,Republican,623
+Johnson,Olathe 1-02,State House,15,"Montgomery, Robert",Robert,,Montgomery,,Republican,418
+Johnson,Olathe 1-03,State House,15,"Montgomery, Robert",Robert,,Montgomery,,Republican,376
+Johnson,Olathe 1-11,State House,15,"Montgomery, Robert",Robert,,Montgomery,,Republican,102
+Johnson,Olathe 1-25,State House,15,"Montgomery, Robert",Robert,,Montgomery,,Republican,0
+Johnson,Olathe 2-01,State House,15,"Montgomery, Robert",Robert,,Montgomery,,Republican,305
+Johnson,Olathe 2-02,State House,15,"Montgomery, Robert",Robert,,Montgomery,,Republican,347
+Johnson,Olathe 2-03,State House,15,"Montgomery, Robert",Robert,,Montgomery,,Republican,484
+Johnson,Olathe 2-04,State House,15,"Montgomery, Robert",Robert,,Montgomery,,Republican,579
+Johnson,Olathe 2-08,State House,15,"Montgomery, Robert",Robert,,Montgomery,,Republican,715
+Johnson,Olathe 2-11,State House,15,"Montgomery, Robert",Robert,,Montgomery,,Republican,904
+Johnson,Olathe 2-13,State House,15,"Montgomery, Robert",Robert,,Montgomery,,Republican,540
+Johnson,Olathe 2-14,State House,15,"Montgomery, Robert",Robert,,Montgomery,,Republican,527
+Johnson,Olathe 2-23,State House,15,"Montgomery, Robert",Robert,,Montgomery,,Republican,678
+Johnson,Lenexa 4-01,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,322
+Johnson,Lenexa 4-02,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,630
+Johnson,Lenexa 4-11,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,92
+Johnson,Overland Park 2-15,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,585
+Johnson,Overland Park 2-17,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,583
+Johnson,Overland Park 2-20,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,356
+Johnson,Overland Park 3-01,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,819
+Johnson,Overland Park 3-09,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,747
+Johnson,Overland Park 3-10,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,384
+Johnson,Overland Park 3-11,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,546
+Johnson,Overland Park 3-13,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,921
+Johnson,Overland Park 3-14,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,594
+Johnson,Overland Park 3-15,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,431
+Johnson,Overland Park 3-18,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,501
+Johnson,Overland Park 4-06,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,518
+Johnson,Overland Park 4-07,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,421
+Johnson,Overland Park 4-08,State House,16,"Grosserode, Amanda",Amanda,,Grosserode,,Republican,616
+Johnson,Lake Quivira 0-01,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,309
+Johnson,Lenexa 1-02,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,488
+Johnson,Lenexa 1-03,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,557
+Johnson,Lenexa 1-04,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,349
+Johnson,Lenexa 1-05,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,360
+Johnson,Lenexa 1-09,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,6
+Johnson,Lenexa 3-06,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,266
+Johnson,Lenexa 3-07,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,409
+Johnson,Lenexa 3-08,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,429
+Johnson,Shawnee 1-07,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,445
+Johnson,Shawnee 1-09,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,72
+Johnson,Shawnee 1-12,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,4
+Johnson,Shawnee 4-02,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,321
+Johnson,Shawnee 4-05,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,405
+Johnson,Shawnee 4-06,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,368
+Johnson,Shawnee 4-07,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,552
+Johnson,Shawnee 4-08,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,169
+Johnson,Shawnee 4-11,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,328
+Johnson,Shawnee 4-12,State House,17,"Hildabrand, Brett M.",Brett,M.,Hildabrand,,Republican,0
+Johnson,Lake Quivira 0-01,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,18
+Johnson,Lenexa 1-02,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,152
+Johnson,Lenexa 1-03,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,205
+Johnson,Lenexa 1-04,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,140
+Johnson,Lenexa 1-05,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,105
+Johnson,Lenexa 1-09,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,2
+Johnson,Lenexa 3-06,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,102
+Johnson,Lenexa 3-07,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,96
+Johnson,Lenexa 3-08,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,101
+Johnson,Shawnee 1-07,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,57
+Johnson,Shawnee 1-09,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,28
+Johnson,Shawnee 1-12,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,0
+Johnson,Shawnee 4-02,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,34
+Johnson,Shawnee 4-05,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,81
+Johnson,Shawnee 4-06,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,56
+Johnson,Shawnee 4-07,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,48
+Johnson,Shawnee 4-08,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,23
+Johnson,Shawnee 4-11,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,63
+Johnson,Shawnee 4-12,State House,17,"Kerner, Michael",Michael,,Kerner,,Libertarian,0
+Johnson,Lake Quivira 0-01,State House,17,"Meeker, Larry",Larry,,Meeker,,,334
+Johnson,Lenexa 1-02,State House,17,"Meeker, Larry",Larry,,Meeker,,,352
+Johnson,Lenexa 1-03,State House,17,"Meeker, Larry",Larry,,Meeker,,,371
+Johnson,Lenexa 1-04,State House,17,"Meeker, Larry",Larry,,Meeker,,,305
+Johnson,Lenexa 1-05,State House,17,"Meeker, Larry",Larry,,Meeker,,,330
+Johnson,Lenexa 1-09,State House,17,"Meeker, Larry",Larry,,Meeker,,,10
+Johnson,Lenexa 3-06,State House,17,"Meeker, Larry",Larry,,Meeker,,,273
+Johnson,Lenexa 3-07,State House,17,"Meeker, Larry",Larry,,Meeker,,,315
+Johnson,Lenexa 3-08,State House,17,"Meeker, Larry",Larry,,Meeker,,,341
+Johnson,Shawnee 1-07,State House,17,"Meeker, Larry",Larry,,Meeker,,,368
+Johnson,Shawnee 1-09,State House,17,"Meeker, Larry",Larry,,Meeker,,,60
+Johnson,Shawnee 1-12,State House,17,"Meeker, Larry",Larry,,Meeker,,,5
+Johnson,Shawnee 4-02,State House,17,"Meeker, Larry",Larry,,Meeker,,,223
+Johnson,Shawnee 4-05,State House,17,"Meeker, Larry",Larry,,Meeker,,,304
+Johnson,Shawnee 4-06,State House,17,"Meeker, Larry",Larry,,Meeker,,,263
+Johnson,Shawnee 4-07,State House,17,"Meeker, Larry",Larry,,Meeker,,,416
+Johnson,Shawnee 4-08,State House,17,"Meeker, Larry",Larry,,Meeker,,,178
+Johnson,Shawnee 4-11,State House,17,"Meeker, Larry",Larry,,Meeker,,,246
+Johnson,Shawnee 4-12,State House,17,"Meeker, Larry",Larry,,Meeker,,,0
+Johnson,Shawnee 1-01,State House,18,"Rubin, John",John,,Rubin,,Republican,470
+Johnson,Shawnee 1-02,State House,18,"Rubin, John",John,,Rubin,,Republican,337
+Johnson,Shawnee 1-03,State House,18,"Rubin, John",John,,Rubin,,Republican,298
+Johnson,Shawnee 1-04,State House,18,"Rubin, John",John,,Rubin,,Republican,609
+Johnson,Shawnee 1-05,State House,18,"Rubin, John",John,,Rubin,,Republican,574
+Johnson,Shawnee 1-06,State House,18,"Rubin, John",John,,Rubin,,Republican,490
+Johnson,Shawnee 2-01,State House,18,"Rubin, John",John,,Rubin,,Republican,219
+Johnson,Shawnee 2-02,State House,18,"Rubin, John",John,,Rubin,,Republican,403
+Johnson,Shawnee 2-03,State House,18,"Rubin, John",John,,Rubin,,Republican,289
+Johnson,Shawnee 2-04,State House,18,"Rubin, John",John,,Rubin,,Republican,448
+Johnson,Shawnee 2-05,State House,18,"Rubin, John",John,,Rubin,,Republican,241
+Johnson,Shawnee 2-06,State House,18,"Rubin, John",John,,Rubin,,Republican,347
+Johnson,Shawnee 2-07,State House,18,"Rubin, John",John,,Rubin,,Republican,283
+Johnson,Shawnee 2-08,State House,18,"Rubin, John",John,,Rubin,,Republican,242
+Johnson,Shawnee 2-09,State House,18,"Rubin, John",John,,Rubin,,Republican,218
+Johnson,Shawnee 2-10,State House,18,"Rubin, John",John,,Rubin,,Republican,200
+Johnson,Shawnee 2-11,State House,18,"Rubin, John",John,,Rubin,,Republican,333
+Johnson,Shawnee 4-13,State House,18,"Rubin, John",John,,Rubin,,Republican,56
+Johnson,Shawnee 1-01,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,393
+Johnson,Shawnee 1-02,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,261
+Johnson,Shawnee 1-03,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,319
+Johnson,Shawnee 1-04,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,411
+Johnson,Shawnee 1-05,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,482
+Johnson,Shawnee 1-06,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,302
+Johnson,Shawnee 2-01,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,188
+Johnson,Shawnee 2-02,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,313
+Johnson,Shawnee 2-03,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,371
+Johnson,Shawnee 2-04,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,437
+Johnson,Shawnee 2-05,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,218
+Johnson,Shawnee 2-06,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,239
+Johnson,Shawnee 2-07,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,256
+Johnson,Shawnee 2-08,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,246
+Johnson,Shawnee 2-09,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,248
+Johnson,Shawnee 2-10,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,217
+Johnson,Shawnee 2-11,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,272
+Johnson,Shawnee 4-13,State House,18,"Talia, Milack",Milack,,Talia,,Democratic,42
+Johnson,Leawood 1-02,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,600
+Johnson,Leawood 1-03,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,518
+Johnson,Leawood 1-04,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,392
+Johnson,Leawood 1-05,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,416
+Johnson,Leawood 1-06,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,92
+Johnson,Leawood 2-01,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,504
+Johnson,Leawood 2-02,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,578
+Johnson,Overland Park 1-16,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,383
+Johnson,Overland Park 1-18,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,304
+Johnson,Overland Park 2-02,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,328
+Johnson,Overland Park 2-03,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,294
+Johnson,Overland Park 2-08,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,163
+Johnson,Overland Park 2-14,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,232
+Johnson,Overland Park 2-16,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,282
+Johnson,Overland Park 2-19,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,278
+Johnson,Overland Park 2-21,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,286
+Johnson,Overland Park 2-22,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,319
+Johnson,Overland Park 2-23,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,383
+Johnson,Prairie Village 5-01,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,473
+Johnson,Prairie Village 5-02,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,518
+Johnson,Prairie Village 5-03,State House,19,"Clayton, Stephanie",Stephanie,,Clayton,,Republican,353
+Johnson,Leawood 1-02,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,331
+Johnson,Leawood 1-03,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,290
+Johnson,Leawood 1-04,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,260
+Johnson,Leawood 1-05,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,183
+Johnson,Leawood 1-06,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,68
+Johnson,Leawood 2-01,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,240
+Johnson,Leawood 2-02,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,322
+Johnson,Overland Park 1-16,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,412
+Johnson,Overland Park 1-18,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,309
+Johnson,Overland Park 2-02,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,287
+Johnson,Overland Park 2-03,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,255
+Johnson,Overland Park 2-08,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,265
+Johnson,Overland Park 2-14,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,202
+Johnson,Overland Park 2-16,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,215
+Johnson,Overland Park 2-19,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,228
+Johnson,Overland Park 2-21,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,202
+Johnson,Overland Park 2-22,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,292
+Johnson,Overland Park 2-23,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,185
+Johnson,Prairie Village 5-01,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,351
+Johnson,Prairie Village 5-02,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,270
+Johnson,Prairie Village 5-03,State House,19,"Luea, Zachary",Zachary,,Luea,,Democratic,228
+Johnson,Leawood 2-03,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,684
+Johnson,Leawood 2-04,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,798
+Johnson,Leawood 2-05,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,415
+Johnson,Leawood 2-06,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,319
+Johnson,Leawood 3-01,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,377
+Johnson,Leawood 3-02,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,693
+Johnson,Leawood 3-03,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,451
+Johnson,Leawood 3-07,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,661
+Johnson,Leawood 4-01,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,214
+Johnson,Leawood 4-02,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,563
+Johnson,Leawood 4-03,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,554
+Johnson,Overland Park 2-01,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,418
+Johnson,Overland Park 2-24,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,713
+Johnson,Overland Park 2-25,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,507
+Johnson,Overland Park 3-16,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,493
+Johnson,Overland Park 3-20,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,638
+Johnson,Overland Park 5-10,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,648
+Johnson,Overland Park 5-13,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,705
+Johnson,Overland Park 5-14,State House,20,"Bruchman, Rob",Rob,,Bruchman,,Republican,602
+Johnson,Leawood 1-01,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,248
+Johnson,Mission Hills 0-04,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,129
+Johnson,Overland Park 1-06,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,415
+Johnson,Overland Park 1-07,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,443
+Johnson,Overland Park 1-17,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,213
+Johnson,Prairie Village 1-02,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,306
+Johnson,Prairie Village 1-03,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,424
+Johnson,Prairie Village 2-01,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,386
+Johnson,Prairie Village 2-02,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,228
+Johnson,Prairie Village 2-03,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,404
+Johnson,Prairie Village 3-01,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,230
+Johnson,Prairie Village 3-02,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,381
+Johnson,Prairie Village 3-03,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,343
+Johnson,Prairie Village 4-01,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,240
+Johnson,Prairie Village 4-02,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,237
+Johnson,Prairie Village 4-03,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,338
+Johnson,Prairie Village 6-01,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,364
+Johnson,Prairie Village 6-02,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,339
+Johnson,Prairie Village 6-03,State House,21,"Bell, Amy A.",Amy,A.,Bell,,Democratic,269
+Johnson,Leawood 1-01,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,351
+Johnson,Mission Hills 0-04,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,543
+Johnson,Overland Park 1-06,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,383
+Johnson,Overland Park 1-07,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,403
+Johnson,Overland Park 1-17,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,150
+Johnson,Prairie Village 1-02,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,323
+Johnson,Prairie Village 1-03,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,476
+Johnson,Prairie Village 2-01,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,330
+Johnson,Prairie Village 2-02,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,177
+Johnson,Prairie Village 2-03,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,282
+Johnson,Prairie Village 3-01,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,288
+Johnson,Prairie Village 3-02,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,395
+Johnson,Prairie Village 3-03,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,354
+Johnson,Prairie Village 4-01,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,529
+Johnson,Prairie Village 4-02,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,296
+Johnson,Prairie Village 4-03,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,502
+Johnson,Prairie Village 6-01,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,445
+Johnson,Prairie Village 6-02,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,307
+Johnson,Prairie Village 6-03,State House,21,"Bollier, Barbara",Barbara,,Bollier,,Republican,212

--- a/2012/20121106__ks__general__kearny__precinct.csv
+++ b/2012/20121106__ks__general__kearny__precinct.csv
@@ -1,0 +1,208 @@
+county,precinct,office,district,party,candidate,votes,vtd
+KEARNY,Deerfield Precinct,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",203,000010
+KEARNY,East Hibbard Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",47,000020
+KEARNY,Hartland Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",45,000030
+KEARNY,Kendall Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",26,000040
+KEARNY,Lakin Precinct 1,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",320,000050
+KEARNY,Lakin Precinct 2,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",271,000060
+KEARNY,Lakin Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",84,000070
+KEARNY,Southside Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",60,000080
+KEARNY,West Hibbard Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",13,000090
+KEARNY,Deerfield Precinct,Kansas Senate,39,Republican,"Powell, Larry R.",209,000010
+KEARNY,East Hibbard Township,Kansas Senate,39,Republican,"Powell, Larry R.",51,000020
+KEARNY,Hartland Township,Kansas Senate,39,Republican,"Powell, Larry R.",51,000030
+KEARNY,Kendall Township,Kansas Senate,39,Republican,"Powell, Larry R.",28,000040
+KEARNY,Lakin Precinct 1,Kansas Senate,39,Republican,"Powell, Larry R.",349,000050
+KEARNY,Lakin Precinct 2,Kansas Senate,39,Republican,"Powell, Larry R.",294,000060
+KEARNY,Lakin Township,Kansas Senate,39,Republican,"Powell, Larry R.",84,000070
+KEARNY,Southside Township,Kansas Senate,39,Republican,"Powell, Larry R.",73,000080
+KEARNY,West Hibbard Township,Kansas Senate,39,Republican,"Powell, Larry R.",20,000090
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Barnett, Andre",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Bush, Kent W",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Christensen, Will",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Goode, Virgil",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Stein, Jill E",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,Democratic,"Obama, Barack",62,000010
+KEARNY,Deerfield Precinct,President / Vice President,,Libertarian,"Johnson, Gary",5,000010
+KEARNY,Deerfield Precinct,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+KEARNY,Deerfield Precinct,President / Vice President,,Republican,"Romney, Mitt",183,000010
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,Democratic,"Obama, Barack",10,000020
+KEARNY,East Hibbard Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,Republican,"Romney, Mitt",50,000020
+KEARNY,Hartland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+KEARNY,Hartland Township,President / Vice President,,Democratic,"Obama, Barack",3,000030
+KEARNY,Hartland Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+KEARNY,Hartland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+KEARNY,Hartland Township,President / Vice President,,Republican,"Romney, Mitt",53,000030
+KEARNY,Kendall Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+KEARNY,Kendall Township,President / Vice President,,Democratic,"Obama, Barack",3,000040
+KEARNY,Kendall Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+KEARNY,Kendall Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+KEARNY,Kendall Township,President / Vice President,,Republican,"Romney, Mitt",27,000040
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,Democratic,"Obama, Barack",82,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",3,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,Republican,"Romney, Mitt",338,000050
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,Democratic,"Obama, Barack",82,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,Republican,"Romney, Mitt",264,000060
+KEARNY,Lakin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+KEARNY,Lakin Township,President / Vice President,,Democratic,"Obama, Barack",14,000070
+KEARNY,Lakin Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+KEARNY,Lakin Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+KEARNY,Lakin Township,President / Vice President,,Republican,"Romney, Mitt",85,000070
+KEARNY,Southside Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+KEARNY,Southside Township,President / Vice President,,Democratic,"Obama, Barack",10,000080
+KEARNY,Southside Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+KEARNY,Southside Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+KEARNY,Southside Township,President / Vice President,,Republican,"Romney, Mitt",75,000080
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,Democratic,"Obama, Barack",2,000090
+KEARNY,West Hibbard Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+KEARNY,West Hibbard Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,Republican,"Romney, Mitt",22,000090
+KEARNY,Deerfield Precinct,United States House of Representatives,1,Republican,"Huelskamp, Tim",208,000010
+KEARNY,East Hibbard Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000020
+KEARNY,Hartland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",50,000030
+KEARNY,Kendall Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000040
+KEARNY,Lakin Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",368,000050
+KEARNY,Lakin Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",303,000060
+KEARNY,Lakin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",86,000070
+KEARNY,Southside Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",76,000080
+KEARNY,West Hibbard Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000090

--- a/2012/20121106__ks__general__kingman__precinct.csv
+++ b/2012/20121106__ks__general__kingman__precinct.csv
@@ -1,0 +1,799 @@
+county,precinct,office,district,party,candidate,votes,vtd
+KINGMAN,Allen Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",6,000010
+KINGMAN,Allen Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",42,000010
+KINGMAN,Belmont Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",5,000020
+KINGMAN,Belmont Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",24,000020
+KINGMAN,Bennett Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",72,000030
+KINGMAN,Bennett Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",186,000030
+KINGMAN,Canton Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",3,000040
+KINGMAN,Canton Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",40,000040
+KINGMAN,Chikaskia Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",13,000050
+KINGMAN,Chikaskia Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",41,000050
+KINGMAN,Dale Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",18,000060
+KINGMAN,Dale Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",58,000060
+KINGMAN,Dresden Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",51,000070
+KINGMAN,Dresden Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",101,000070
+KINGMAN,Eagle Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",6,000080
+KINGMAN,Eagle Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",42,000080
+KINGMAN,Eureka Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",4,000090
+KINGMAN,Eureka Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",48,000090
+KINGMAN,Evan Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",41,000100
+KINGMAN,Evan Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",197,000100
+KINGMAN,Galesburg Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",18,000110
+KINGMAN,Galesburg Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",84,000110
+KINGMAN,Hoosier Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",14,000120
+KINGMAN,Hoosier Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",53,000120
+KINGMAN,Kingman Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",8,000130
+KINGMAN,Kingman Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",46,000130
+KINGMAN,Kingman Ward 1,Kansas House of Representatives,114,Democratic,"Moore, Carol",95,00014A
+KINGMAN,Kingman Ward 1,Kansas House of Representatives,114,Republican,"Thimesch, Jack",197,00014A
+KINGMAN,Kingman Ward 1 Exclave,Kansas House of Representatives,114,Democratic,"Moore, Carol",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,Kansas House of Representatives,114,Republican,"Thimesch, Jack",0,00014B
+KINGMAN,Kingman Ward 2,Kansas House of Representatives,114,Democratic,"Moore, Carol",117,000150
+KINGMAN,Kingman Ward 2,Kansas House of Representatives,114,Republican,"Thimesch, Jack",333,000150
+KINGMAN,Kingman Ward 3,Kansas House of Representatives,114,Democratic,"Moore, Carol",46,000160
+KINGMAN,Kingman Ward 3,Kansas House of Representatives,114,Republican,"Thimesch, Jack",124,000160
+KINGMAN,Kingman Ward 4,Kansas House of Representatives,114,Democratic,"Moore, Carol",55,000170
+KINGMAN,Kingman Ward 4,Kansas House of Representatives,114,Republican,"Thimesch, Jack",155,000170
+KINGMAN,Liberty Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",10,000180
+KINGMAN,Liberty Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",44,000180
+KINGMAN,Ninnescah Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",23,000190
+KINGMAN,Ninnescah Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",107,000190
+KINGMAN,Peters Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",17,000200
+KINGMAN,Peters Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",38,000200
+KINGMAN,Richland Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",9,000210
+KINGMAN,Richland Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",35,000210
+KINGMAN,Rochester Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",21,000220
+KINGMAN,Rochester Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",58,000220
+KINGMAN,Rural Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",53,000230
+KINGMAN,Rural Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",87,000230
+KINGMAN,Union Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",8,000240
+KINGMAN,Union Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",35,000240
+KINGMAN,Valley Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",7,000250
+KINGMAN,Valley Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",35,000250
+KINGMAN,Vinita Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",21,000260
+KINGMAN,Vinita Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",97,000260
+KINGMAN,White Township Part A,Kansas House of Representatives,114,Democratic,"Moore, Carol",15,00027A
+KINGMAN,White Township Part A,Kansas House of Representatives,114,Republican,"Thimesch, Jack",57,00027A
+KINGMAN,White Township Part A Enclave,Kansas House of Representatives,114,Democratic,"Moore, Carol",0,00027B
+KINGMAN,White Township Part A Enclave,Kansas House of Representatives,114,Republican,"Thimesch, Jack",0,00027B
+KINGMAN,White Township Part B,Kansas House of Representatives,114,Democratic,"Moore, Carol",14,00027C
+KINGMAN,White Township Part B,Kansas House of Representatives,114,Republican,"Thimesch, Jack",61,00027C
+KINGMAN,Allen Township,Kansas Senate,32,Republican,"Abrams, Steve E",44,000010
+KINGMAN,Belmont Township,Kansas Senate,32,Republican,"Abrams, Steve E",22,000020
+KINGMAN,Bennett Township,Kansas Senate,32,Republican,"Abrams, Steve E",223,000030
+KINGMAN,Canton Township,Kansas Senate,32,Republican,"Abrams, Steve E",41,000040
+KINGMAN,Chikaskia Township,Kansas Senate,32,Republican,"Abrams, Steve E",40,000050
+KINGMAN,Dale Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",29,000060
+KINGMAN,Dale Township,Kansas Senate,34,Republican,"Bruce, Terry",46,000060
+KINGMAN,Dresden Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",62,000070
+KINGMAN,Dresden Township,Kansas Senate,34,Republican,"Bruce, Terry",89,000070
+KINGMAN,Eagle Township,Kansas Senate,32,Republican,"Abrams, Steve E",39,000080
+KINGMAN,Eureka Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",18,000090
+KINGMAN,Eureka Township,Kansas Senate,34,Republican,"Bruce, Terry",33,000090
+KINGMAN,Evan Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",58,000100
+KINGMAN,Evan Township,Kansas Senate,34,Republican,"Bruce, Terry",176,000100
+KINGMAN,Galesburg Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",31,000110
+KINGMAN,Galesburg Township,Kansas Senate,34,Republican,"Bruce, Terry",71,000110
+KINGMAN,Hoosier Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",20,000120
+KINGMAN,Hoosier Township,Kansas Senate,34,Republican,"Bruce, Terry",48,000120
+KINGMAN,Kingman Township,Kansas Senate,32,Republican,"Abrams, Steve E",43,000130
+KINGMAN,Kingman Ward 1,Kansas Senate,34,Democratic,"Treaster, Mark R.",130,00014A
+KINGMAN,Kingman Ward 1,Kansas Senate,34,Republican,"Bruce, Terry",161,00014A
+KINGMAN,Kingman Ward 1 Exclave,Kansas Senate,34,Democratic,"Treaster, Mark R.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,Kansas Senate,34,Republican,"Bruce, Terry",0,00014B
+KINGMAN,Kingman Ward 2,Kansas Senate,34,Democratic,"Treaster, Mark R.",195,000150
+KINGMAN,Kingman Ward 2,Kansas Senate,34,Republican,"Bruce, Terry",262,000150
+KINGMAN,Kingman Ward 3,Kansas Senate,34,Democratic,"Treaster, Mark R.",74,000160
+KINGMAN,Kingman Ward 3,Kansas Senate,34,Republican,"Bruce, Terry",92,000160
+KINGMAN,Kingman Ward 4,Kansas Senate,34,Democratic,"Treaster, Mark R.",99,000170
+KINGMAN,Kingman Ward 4,Kansas Senate,34,Republican,"Bruce, Terry",110,000170
+KINGMAN,Liberty Township,Kansas Senate,32,Republican,"Abrams, Steve E",49,000180
+KINGMAN,Ninnescah Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",34,000190
+KINGMAN,Ninnescah Township,Kansas Senate,34,Republican,"Bruce, Terry",92,000190
+KINGMAN,Peters Township,Kansas Senate,32,Republican,"Abrams, Steve E",37,000200
+KINGMAN,Richland Township,Kansas Senate,32,Republican,"Abrams, Steve E",35,000210
+KINGMAN,Rochester Township,Kansas Senate,32,Republican,"Abrams, Steve E",58,000220
+KINGMAN,Rural Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",54,000230
+KINGMAN,Rural Township,Kansas Senate,34,Republican,"Bruce, Terry",79,000230
+KINGMAN,Union Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",13,000240
+KINGMAN,Union Township,Kansas Senate,34,Republican,"Bruce, Terry",30,000240
+KINGMAN,Valley Township,Kansas Senate,32,Republican,"Abrams, Steve E",34,000250
+KINGMAN,Vinita Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",28,000260
+KINGMAN,Vinita Township,Kansas Senate,34,Republican,"Bruce, Terry",88,000260
+KINGMAN,White Township Part A,Kansas Senate,34,Democratic,"Treaster, Mark R.",21,00027A
+KINGMAN,White Township Part A,Kansas Senate,34,Republican,"Bruce, Terry",50,00027A
+KINGMAN,White Township Part A Enclave,Kansas Senate,34,Democratic,"Treaster, Mark R.",0,00027B
+KINGMAN,White Township Part A Enclave,Kansas Senate,34,Republican,"Bruce, Terry",0,00027B
+KINGMAN,White Township Part B,Kansas Senate,34,Democratic,"Treaster, Mark R.",27,00027C
+KINGMAN,White Township Part B,Kansas Senate,34,Republican,"Bruce, Terry",46,00027C
+KINGMAN,Allen Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+KINGMAN,Allen Township,President / Vice President,,Democratic,"Obama, Barack",4,000010
+KINGMAN,Allen Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+KINGMAN,Allen Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+KINGMAN,Allen Township,President / Vice President,,Republican,"Romney, Mitt",44,000010
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+KINGMAN,Belmont Township,President / Vice President,,Democratic,"Obama, Barack",12,000020
+KINGMAN,Belmont Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+KINGMAN,Belmont Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+KINGMAN,Belmont Township,President / Vice President,,Republican,"Romney, Mitt",18,000020
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Stein, Jill E",1,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+KINGMAN,Bennett Township,President / Vice President,,Democratic,"Obama, Barack",60,000030
+KINGMAN,Bennett Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000030
+KINGMAN,Bennett Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+KINGMAN,Bennett Township,President / Vice President,,Republican,"Romney, Mitt",196,000030
+KINGMAN,Canton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+KINGMAN,Canton Township,President / Vice President,,Democratic,"Obama, Barack",3,000040
+KINGMAN,Canton Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+KINGMAN,Canton Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+KINGMAN,Canton Township,President / Vice President,,Republican,"Romney, Mitt",40,000040
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,Democratic,"Obama, Barack",17,000050
+KINGMAN,Chikaskia Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+KINGMAN,Chikaskia Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,Republican,"Romney, Mitt",37,000050
+KINGMAN,Dale Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+KINGMAN,Dale Township,President / Vice President,,Democratic,"Obama, Barack",16,000060
+KINGMAN,Dale Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+KINGMAN,Dale Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000060
+KINGMAN,Dale Township,President / Vice President,,Republican,"Romney, Mitt",57,000060
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+KINGMAN,Dresden Township,President / Vice President,,Democratic,"Obama, Barack",37,000070
+KINGMAN,Dresden Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000070
+KINGMAN,Dresden Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+KINGMAN,Dresden Township,President / Vice President,,Republican,"Romney, Mitt",107,000070
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+KINGMAN,Eagle Township,President / Vice President,,Democratic,"Obama, Barack",7,000080
+KINGMAN,Eagle Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+KINGMAN,Eagle Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+KINGMAN,Eagle Township,President / Vice President,,Republican,"Romney, Mitt",40,000080
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+KINGMAN,Eureka Township,President / Vice President,,Democratic,"Obama, Barack",8,000090
+KINGMAN,Eureka Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000090
+KINGMAN,Eureka Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+KINGMAN,Eureka Township,President / Vice President,,Republican,"Romney, Mitt",40,000090
+KINGMAN,Evan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Goode, Virgil",1,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+KINGMAN,Evan Township,President / Vice President,,Democratic,"Obama, Barack",38,000100
+KINGMAN,Evan Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000100
+KINGMAN,Evan Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000100
+KINGMAN,Evan Township,President / Vice President,,Republican,"Romney, Mitt",194,000100
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,Democratic,"Obama, Barack",25,000110
+KINGMAN,Galesburg Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000110
+KINGMAN,Galesburg Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000110
+KINGMAN,Galesburg Township,President / Vice President,,Republican,"Romney, Mitt",72,000110
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,Democratic,"Obama, Barack",10,000120
+KINGMAN,Hoosier Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+KINGMAN,Hoosier Township,President / Vice President,,Republican,"Romney, Mitt",55,000120
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+KINGMAN,Kingman Township,President / Vice President,,Democratic,"Obama, Barack",15,000130
+KINGMAN,Kingman Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+KINGMAN,Kingman Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+KINGMAN,Kingman Township,President / Vice President,,Republican,"Romney, Mitt",35,000130
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Christensen, Will",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,Democratic,"Obama, Barack",90,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",4,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,Republican,"Romney, Mitt",204,00014A
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00014B
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Stein, Jill E",1,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,Democratic,"Obama, Barack",117,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",9,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",4,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,Republican,"Romney, Mitt",335,000150
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,Democratic,"Obama, Barack",46,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",5,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",2,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,Republican,"Romney, Mitt",119,000160
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Stein, Jill E",1,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,Democratic,"Obama, Barack",61,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",11,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",2,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,Republican,"Romney, Mitt",136,000170
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+KINGMAN,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",11,000180
+KINGMAN,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+KINGMAN,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+KINGMAN,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",43,000180
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,Democratic,"Obama, Barack",7,000190
+KINGMAN,Ninnescah Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000190
+KINGMAN,Ninnescah Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,Republican,"Romney, Mitt",120,000190
+KINGMAN,Peters Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+KINGMAN,Peters Township,President / Vice President,,Democratic,"Obama, Barack",13,000200
+KINGMAN,Peters Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+KINGMAN,Peters Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+KINGMAN,Peters Township,President / Vice President,,Republican,"Romney, Mitt",41,000200
+KINGMAN,Richland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+KINGMAN,Richland Township,President / Vice President,,Democratic,"Obama, Barack",6,000210
+KINGMAN,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+KINGMAN,Richland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+KINGMAN,Richland Township,President / Vice President,,Republican,"Romney, Mitt",35,000210
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+KINGMAN,Rochester Township,President / Vice President,,Democratic,"Obama, Barack",23,000220
+KINGMAN,Rochester Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000220
+KINGMAN,Rochester Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000220
+KINGMAN,Rochester Township,President / Vice President,,Republican,"Romney, Mitt",52,000220
+KINGMAN,Rural Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+KINGMAN,Rural Township,President / Vice President,,Democratic,"Obama, Barack",40,000230
+KINGMAN,Rural Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000230
+KINGMAN,Rural Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+KINGMAN,Rural Township,President / Vice President,,Republican,"Romney, Mitt",100,000230
+KINGMAN,Union Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+KINGMAN,Union Township,President / Vice President,,Democratic,"Obama, Barack",6,000240
+KINGMAN,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+KINGMAN,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000240
+KINGMAN,Union Township,President / Vice President,,Republican,"Romney, Mitt",36,000240
+KINGMAN,Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+KINGMAN,Valley Township,President / Vice President,,Democratic,"Obama, Barack",6,000250
+KINGMAN,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000250
+KINGMAN,Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+KINGMAN,Valley Township,President / Vice President,,Republican,"Romney, Mitt",36,000250
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Barnett, Andre",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Bush, Kent W",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Christensen, Will",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Goode, Virgil",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Stein, Jill E",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+KINGMAN,Vinita Township,President / Vice President,,Democratic,"Obama, Barack",22,000260
+KINGMAN,Vinita Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000260
+KINGMAN,Vinita Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000260
+KINGMAN,Vinita Township,President / Vice President,,Republican,"Romney, Mitt",93,000260
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Barnett, Andre",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Bush, Kent W",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Christensen, Will",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Goode, Virgil",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Stein, Jill E",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,Democratic,"Obama, Barack",16,00027A
+KINGMAN,White Township Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,Reform,"Baldwin, Chuck",1,00027A
+KINGMAN,White Township Part A,President / Vice President,,Republican,"Romney, Mitt",56,00027A
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Christensen, Will",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00027B
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Ayers, Avery L",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Barnett, Andre",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Bush, Kent W",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Christensen, Will",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Duncan, Richard A",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Goode, Virgil",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Knill, Dennis J",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Reed, Jill A.",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Rogers, Rick L",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Stein, Jill E",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,Democratic,"Obama, Barack",17,00027C
+KINGMAN,White Township Part B,President / Vice President,,Libertarian,"Johnson, Gary",1,00027C
+KINGMAN,White Township Part B,President / Vice President,,Reform,"Baldwin, Chuck",1,00027C
+KINGMAN,White Township Part B,President / Vice President,,Republican,"Romney, Mitt",56,00027C
+KINGMAN,Allen Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",8,000010
+KINGMAN,Allen Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,000010
+KINGMAN,Allen Township,United States House of Representatives,4,Republican,"Pompeo, Mike",37,000010
+KINGMAN,Belmont Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",9,000020
+KINGMAN,Belmont Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000020
+KINGMAN,Belmont Township,United States House of Representatives,4,Republican,"Pompeo, Mike",18,000020
+KINGMAN,Bennett Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",50,000030
+KINGMAN,Bennett Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",24,000030
+KINGMAN,Bennett Township,United States House of Representatives,4,Republican,"Pompeo, Mike",184,000030
+KINGMAN,Canton Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",4,000040
+KINGMAN,Canton Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000040
+KINGMAN,Canton Township,United States House of Representatives,4,Republican,"Pompeo, Mike",38,000040
+KINGMAN,Chikaskia Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",17,000050
+KINGMAN,Chikaskia Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,000050
+KINGMAN,Chikaskia Township,United States House of Representatives,4,Republican,"Pompeo, Mike",34,000050
+KINGMAN,Dale Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",16,000060
+KINGMAN,Dale Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",9,000060
+KINGMAN,Dale Township,United States House of Representatives,4,Republican,"Pompeo, Mike",51,000060
+KINGMAN,Dresden Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",34,000070
+KINGMAN,Dresden Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",10,000070
+KINGMAN,Dresden Township,United States House of Representatives,4,Republican,"Pompeo, Mike",105,000070
+KINGMAN,Eagle Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",6,000080
+KINGMAN,Eagle Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,000080
+KINGMAN,Eagle Township,United States House of Representatives,4,Republican,"Pompeo, Mike",38,000080
+KINGMAN,Eureka Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",6,000090
+KINGMAN,Eureka Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000090
+KINGMAN,Eureka Township,United States House of Representatives,4,Republican,"Pompeo, Mike",42,000090
+KINGMAN,Evan Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",41,000100
+KINGMAN,Evan Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",12,000100
+KINGMAN,Evan Township,United States House of Representatives,4,Republican,"Pompeo, Mike",185,000100
+KINGMAN,Galesburg Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",21,000110
+KINGMAN,Galesburg Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000110
+KINGMAN,Galesburg Township,United States House of Representatives,4,Republican,"Pompeo, Mike",76,000110
+KINGMAN,Hoosier Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",10,000120
+KINGMAN,Hoosier Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000120
+KINGMAN,Hoosier Township,United States House of Representatives,4,Republican,"Pompeo, Mike",57,000120
+KINGMAN,Kingman Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",13,000130
+KINGMAN,Kingman Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000130
+KINGMAN,Kingman Township,United States House of Representatives,4,Republican,"Pompeo, Mike",37,000130
+KINGMAN,Kingman Ward 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",75,00014A
+KINGMAN,Kingman Ward 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",17,00014A
+KINGMAN,Kingman Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",197,00014A
+KINGMAN,Kingman Ward 1 Exclave,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00014B
+KINGMAN,Kingman Ward 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",91,000150
+KINGMAN,Kingman Ward 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",34,000150
+KINGMAN,Kingman Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",327,000150
+KINGMAN,Kingman Ward 3,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",33,000160
+KINGMAN,Kingman Ward 3,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",16,000160
+KINGMAN,Kingman Ward 3,United States House of Representatives,4,Republican,"Pompeo, Mike",117,000160
+KINGMAN,Kingman Ward 4,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",56,000170
+KINGMAN,Kingman Ward 4,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",17,000170
+KINGMAN,Kingman Ward 4,United States House of Representatives,4,Republican,"Pompeo, Mike",136,000170
+KINGMAN,Liberty Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",10,000180
+KINGMAN,Liberty Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,000180
+KINGMAN,Liberty Township,United States House of Representatives,4,Republican,"Pompeo, Mike",42,000180
+KINGMAN,Ninnescah Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",6,000190
+KINGMAN,Ninnescah Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",7,000190
+KINGMAN,Ninnescah Township,United States House of Representatives,4,Republican,"Pompeo, Mike",117,000190
+KINGMAN,Peters Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",7,000200
+KINGMAN,Peters Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000200
+KINGMAN,Peters Township,United States House of Representatives,4,Republican,"Pompeo, Mike",43,000200
+KINGMAN,Richland Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",5,000210
+KINGMAN,Richland Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000210
+KINGMAN,Richland Township,United States House of Representatives,4,Republican,"Pompeo, Mike",38,000210
+KINGMAN,Rochester Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",21,000220
+KINGMAN,Rochester Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000220
+KINGMAN,Rochester Township,United States House of Representatives,4,Republican,"Pompeo, Mike",52,000220
+KINGMAN,Rural Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",33,000230
+KINGMAN,Rural Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",7,000230
+KINGMAN,Rural Township,United States House of Representatives,4,Republican,"Pompeo, Mike",97,000230
+KINGMAN,Union Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",6,000240
+KINGMAN,Union Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,000240
+KINGMAN,Union Township,United States House of Representatives,4,Republican,"Pompeo, Mike",32,000240
+KINGMAN,Valley Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",7,000250
+KINGMAN,Valley Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000250
+KINGMAN,Valley Township,United States House of Representatives,4,Republican,"Pompeo, Mike",34,000250
+KINGMAN,Vinita Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",18,000260
+KINGMAN,Vinita Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000260
+KINGMAN,Vinita Township,United States House of Representatives,4,Republican,"Pompeo, Mike",93,000260
+KINGMAN,White Township Part A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",12,00027A
+KINGMAN,White Township Part A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,00027A
+KINGMAN,White Township Part A,United States House of Representatives,4,Republican,"Pompeo, Mike",58,00027A
+KINGMAN,White Township Part A Enclave,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,00027B
+KINGMAN,White Township Part A Enclave,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,00027B
+KINGMAN,White Township Part A Enclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,00027B
+KINGMAN,White Township Part B,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",10,00027C
+KINGMAN,White Township Part B,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,00027C
+KINGMAN,White Township Part B,United States House of Representatives,4,Republican,"Pompeo, Mike",60,00027C

--- a/2012/20121106__ks__general__kiowa__precinct.csv
+++ b/2012/20121106__ks__general__kiowa__precinct.csv
@@ -1,0 +1,100 @@
+county,precinct,office,district,party,candidate,votes,vtd
+KIOWA,Belvidere,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",16,000010
+KIOWA,Belvidere,Kansas House of Representatives,117,Republican,"Ewy, John L.",4,000010
+KIOWA,Center I,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",277,000020
+KIOWA,Center I,Kansas House of Representatives,117,Republican,"Ewy, John L.",48,000020
+KIOWA,Center I I,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",172,000030
+KIOWA,Center I I,Kansas House of Representatives,117,Republican,"Ewy, John L.",27,000030
+KIOWA,Haviland,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",257,000040
+KIOWA,Haviland,Kansas House of Representatives,117,Republican,"Ewy, John L.",139,000040
+KIOWA,Mullinville,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",176,000050
+KIOWA,Mullinville,Kansas House of Representatives,117,Republican,"Ewy, John L.",49,000050
+KIOWA,Belvidere,Kansas Senate,33,Republican,"Holmes, Mitch",12,000010
+KIOWA,Center I,Kansas Senate,33,Republican,"Holmes, Mitch",247,000020
+KIOWA,Center I I,Kansas Senate,33,Republican,"Holmes, Mitch",144,000030
+KIOWA,Haviland,Kansas Senate,33,Republican,"Holmes, Mitch",333,000040
+KIOWA,Mullinville,Kansas Senate,33,Republican,"Holmes, Mitch",181,000050
+KIOWA,Belvidere,President / Vice President,,Democratic,"Obama, Barack",4,000010
+KIOWA,Belvidere,President / Vice President,,Republican,"Romney, Mitt",17,000010
+KIOWA,Center I,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Barnett, Andre",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Bush, Kent W",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Christensen, Will",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Goode, Virgil",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Stein, Jill E",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+KIOWA,Center I,President / Vice President,,Democratic,"Obama, Barack",55,000020
+KIOWA,Center I,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+KIOWA,Center I,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+KIOWA,Center I,President / Vice President,,Republican,"Romney, Mitt",264,000020
+KIOWA,Center I I,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Barnett, Andre",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Bush, Kent W",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Christensen, Will",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Goode, Virgil",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Stein, Jill E",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+KIOWA,Center I I,President / Vice President,,Democratic,"Obama, Barack",32,000030
+KIOWA,Center I I,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+KIOWA,Center I I,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+KIOWA,Center I I,President / Vice President,,Republican,"Romney, Mitt",162,000030
+KIOWA,Haviland,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Barnett, Andre",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Bush, Kent W",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Christensen, Will",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Goode, Virgil",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Stein, Jill E",2,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+KIOWA,Haviland,President / Vice President,,Democratic,"Obama, Barack",49,000040
+KIOWA,Haviland,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+KIOWA,Haviland,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+KIOWA,Haviland,President / Vice President,,Republican,"Romney, Mitt",338,000040
+KIOWA,Mullinville,President / Vice President,,Democratic,"Obama, Barack",23,000050
+KIOWA,Mullinville,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+KIOWA,Mullinville,President / Vice President,,Reform,"Baldwin, Chuck",1,000050
+KIOWA,Mullinville,President / Vice President,,Republican,"Romney, Mitt",195,000050
+KIOWA,ADVANCED,President / Vice President,,write - in,"Stein, Jill E",0,999998
+KIOWA,PROVISIONAL,President / Vice President,,Democratic,"Obama, Barack",0,999999
+KIOWA,PROVISIONAL,President / Vice President,,Republican,"Romney, Mitt",0,999999
+KIOWA,Belvidere,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000010
+KIOWA,Belvidere,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000010
+KIOWA,Belvidere,United States House of Representatives,4,Republican,"Pompeo, Mike",16,000010
+KIOWA,Center I,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",56,000020
+KIOWA,Center I,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",18,000020
+KIOWA,Center I,United States House of Representatives,4,Republican,"Pompeo, Mike",224,000020
+KIOWA,Center I I,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",34,000030
+KIOWA,Center I I,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",11,000030
+KIOWA,Center I I,United States House of Representatives,4,Republican,"Pompeo, Mike",141,000030
+KIOWA,Haviland,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",38,000040
+KIOWA,Haviland,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",24,000040
+KIOWA,Haviland,United States House of Representatives,4,Republican,"Pompeo, Mike",324,000040
+KIOWA,Mullinville,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",29,000050
+KIOWA,Mullinville,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",11,000050
+KIOWA,Mullinville,United States House of Representatives,4,Republican,"Pompeo, Mike",179,000050

--- a/2012/20121106__ks__general__labette__precinct.csv
+++ b/2012/20121106__ks__general__labette__precinct.csv
@@ -1,0 +1,1205 @@
+county,precinct,office,district,party,candidate,votes,vtd
+LABETTE,Altamont City Part A,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",0,00001A
+LABETTE,Altamont City Part A,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00001A
+LABETTE,Canada Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",41,000020
+LABETTE,Canada Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",74,000020
+LABETTE,Chetopa Ward 1,Kansas House of Representatives,1,Democratic,"Randall, Grant",46,000030
+LABETTE,Chetopa Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",60,000030
+LABETTE,Chetopa Ward 2,Kansas House of Representatives,1,Democratic,"Randall, Grant",56,000040
+LABETTE,Chetopa Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",55,000040
+LABETTE,Chetopa Ward 3,Kansas House of Representatives,1,Democratic,"Randall, Grant",62,000050
+LABETTE,Chetopa Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",91,000050
+LABETTE,Elm Grove Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",152,000060
+LABETTE,Elm Grove Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",229,000060
+LABETTE,Fairview Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",30,000070
+LABETTE,Fairview Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",73,000070
+LABETTE,Hackberry Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",62,000080
+LABETTE,Hackberry Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",90,000080
+LABETTE,Howard Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",69,000090
+LABETTE,Howard Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",94,000090
+LABETTE,Labette Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",40,000100
+LABETTE,Labette Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",138,000100
+LABETTE,Liberty Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",40,000110
+LABETTE,Liberty Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",142,000110
+LABETTE,Montana Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",26,000120
+LABETTE,Montana Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",56,000120
+LABETTE,Mound Valley Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",113,000130
+LABETTE,Mound Valley Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",214,000130
+LABETTE,Mount Pleasant Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",184,000140
+LABETTE,Mount Pleasant Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",355,000140
+LABETTE,Neosho Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",17,000150
+LABETTE,Neosho Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",71,000150
+LABETTE,North Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",58,00016A
+LABETTE,North Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",238,00016A
+LABETTE,North Township Enclave,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",0,00016B
+LABETTE,North Township Enclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00016B
+LABETTE,Oswego City Ward 1,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",63,000180
+LABETTE,Oswego City Ward 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",165,000180
+LABETTE,Oswego City Ward 2,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",71,00019A
+LABETTE,Oswego City Ward 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",166,00019A
+LABETTE,Oswego City Ward 3,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",51,000200
+LABETTE,Oswego City Ward 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",119,000200
+LABETTE,Oswego Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",32,000210
+LABETTE,Oswego Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",102,000210
+LABETTE,Parsons Ward 1 Precinct 1,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",95,000220
+LABETTE,Parsons Ward 1 Precinct 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",209,000220
+LABETTE,Parsons Ward 1 Precinct 2,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",49,000230
+LABETTE,Parsons Ward 1 Precinct 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",122,000230
+LABETTE,Parsons Ward 1 Precinct 3,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",58,00024A
+LABETTE,Parsons Ward 1 Precinct 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",85,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",22,000250
+LABETTE,Parsons Ward 2 Precinct 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",91,000250
+LABETTE,Parsons Ward 2 Precinct 2,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",72,000260
+LABETTE,Parsons Ward 2 Precinct 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",200,000260
+LABETTE,Parsons Ward 2 Precinct 3,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",93,00027A
+LABETTE,Parsons Ward 2 Precinct 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",181,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",32,000280
+LABETTE,Parsons Ward 3 Precinct 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",101,000280
+LABETTE,Parsons Ward 3 Precinct 2,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",132,00029A
+LABETTE,Parsons Ward 3 Precinct 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",201,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",70,000300
+LABETTE,Parsons Ward 3 Precinct 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",193,000300
+LABETTE,Parsons Ward 3 Precinct 4,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",121,000310
+LABETTE,Parsons Ward 3 Precinct 4,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",287,000310
+LABETTE,Parsons Ward 4 Precinct 1,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",44,000320
+LABETTE,Parsons Ward 4 Precinct 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",108,000320
+LABETTE,Parsons Ward 4 Precinct 2,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",78,000330
+LABETTE,Parsons Ward 4 Precinct 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",159,000330
+LABETTE,Parsons Ward 4 Precinct 3,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",70,000340
+LABETTE,Parsons Ward 4 Precinct 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",132,000340
+LABETTE,Parsons Ward 4 Precinct 4,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",62,000350
+LABETTE,Parsons Ward 4 Precinct 4,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",234,000350
+LABETTE,Walton Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",86,000370
+LABETTE,Walton Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",290,000370
+LABETTE,Osage Township S14,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",0,120020
+LABETTE,Osage Township S14,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,120020
+LABETTE,Osage Township S15,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",85,120030
+LABETTE,Osage Township S15,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",229,120030
+LABETTE,Richland Township H1 A,Kansas House of Representatives,1,Democratic,"Randall, Grant",10,12004A
+LABETTE,Richland Township H1 A,Kansas House of Representatives,1,Republican,"Houser, Michael",20,12004A
+LABETTE,Richland Township H1 B,Kansas House of Representatives,1,Democratic,"Randall, Grant",0,12004B
+LABETTE,Richland Township H1 B,Kansas House of Representatives,1,Republican,"Houser, Michael",0,12004B
+LABETTE,Richland Township H1,Kansas House of Representatives,1,Democratic,"Randall, Grant",3,120040
+LABETTE,Richland Township H1,Kansas House of Representatives,1,Republican,"Houser, Michael",13,120040
+LABETTE,Richland Township H7,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",21,120050
+LABETTE,Richland Township H7,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",46,120050
+LABETTE,Oswego City Ward 1 Exclave,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",0,900010
+LABETTE,Oswego City Ward 1 Exclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,900010
+LABETTE,Altamont City Part A,Kansas Senate,15,Republican,"King, Jeff",0,00001A
+LABETTE,Canada Township,Kansas Senate,15,Republican,"King, Jeff",102,000020
+LABETTE,Chetopa Ward 1,Kansas Senate,13,Democratic,"Garman, Gene",46,000030
+LABETTE,Chetopa Ward 1,Kansas Senate,13,Republican,"LaTurner, Jacob",58,000030
+LABETTE,Chetopa Ward 2,Kansas Senate,13,Democratic,"Garman, Gene",53,000040
+LABETTE,Chetopa Ward 2,Kansas Senate,13,Republican,"LaTurner, Jacob",58,000040
+LABETTE,Chetopa Ward 3,Kansas Senate,13,Democratic,"Garman, Gene",68,000050
+LABETTE,Chetopa Ward 3,Kansas Senate,13,Republican,"LaTurner, Jacob",86,000050
+LABETTE,Elm Grove Township,Kansas Senate,15,Republican,"King, Jeff",349,000060
+LABETTE,Fairview Township,Kansas Senate,15,Republican,"King, Jeff",83,000070
+LABETTE,Hackberry Township,Kansas Senate,15,Republican,"King, Jeff",126,000080
+LABETTE,Howard Township,Kansas Senate,15,Republican,"King, Jeff",133,000090
+LABETTE,Labette Township,Kansas Senate,15,Republican,"King, Jeff",166,000100
+LABETTE,Liberty Township,Kansas Senate,15,Republican,"King, Jeff",139,000110
+LABETTE,Montana Township,Kansas Senate,15,Republican,"King, Jeff",61,000120
+LABETTE,Mound Valley Township,Kansas Senate,15,Republican,"King, Jeff",286,000130
+LABETTE,Mount Pleasant Township,Kansas Senate,15,Republican,"King, Jeff",437,000140
+LABETTE,Neosho Township,Kansas Senate,15,Republican,"King, Jeff",61,000150
+LABETTE,North Township,Kansas Senate,15,Republican,"King, Jeff",242,00016A
+LABETTE,North Township Enclave,Kansas Senate,15,Republican,"King, Jeff",0,00016B
+LABETTE,Oswego City Ward 1,Kansas Senate,15,Republican,"King, Jeff",181,000180
+LABETTE,Oswego City Ward 2,Kansas Senate,15,Republican,"King, Jeff",194,00019A
+LABETTE,Oswego City Ward 3,Kansas Senate,15,Republican,"King, Jeff",131,000200
+LABETTE,Oswego Township,Kansas Senate,15,Republican,"King, Jeff",115,000210
+LABETTE,Parsons Ward 1 Precinct 1,Kansas Senate,15,Republican,"King, Jeff",222,000220
+LABETTE,Parsons Ward 1 Precinct 2,Kansas Senate,15,Republican,"King, Jeff",139,000230
+LABETTE,Parsons Ward 1 Precinct 3,Kansas Senate,15,Republican,"King, Jeff",102,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Kansas Senate,15,Republican,"King, Jeff",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,Kansas Senate,15,Republican,"King, Jeff",81,000250
+LABETTE,Parsons Ward 2 Precinct 2,Kansas Senate,15,Republican,"King, Jeff",196,000260
+LABETTE,Parsons Ward 2 Precinct 3,Kansas Senate,15,Republican,"King, Jeff",214,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Kansas Senate,15,Republican,"King, Jeff",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,Kansas Senate,15,Republican,"King, Jeff",101,000280
+LABETTE,Parsons Ward 3 Precinct 2,Kansas Senate,15,Republican,"King, Jeff",235,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Kansas Senate,15,Republican,"King, Jeff",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,Kansas Senate,15,Republican,"King, Jeff",193,000300
+LABETTE,Parsons Ward 3 Precinct 4,Kansas Senate,15,Republican,"King, Jeff",305,000310
+LABETTE,Parsons Ward 4 Precinct 1,Kansas Senate,15,Republican,"King, Jeff",122,000320
+LABETTE,Parsons Ward 4 Precinct 2,Kansas Senate,15,Republican,"King, Jeff",180,000330
+LABETTE,Parsons Ward 4 Precinct 3,Kansas Senate,15,Republican,"King, Jeff",143,000340
+LABETTE,Parsons Ward 4 Precinct 4,Kansas Senate,15,Republican,"King, Jeff",228,000350
+LABETTE,Walton Township,Kansas Senate,15,Republican,"King, Jeff",294,000370
+LABETTE,Osage Township S14,Kansas Senate,14,Democratic,"Fuson, Eden",0,120020
+LABETTE,Osage Township S14,Kansas Senate,14,Republican,"Knox, Forrest J.",0,120020
+LABETTE,Osage Township S15,Kansas Senate,15,Republican,"King, Jeff",258,120030
+LABETTE,Richland Township H1 A,Kansas Senate,13,Democratic,"Garman, Gene",11,12004A
+LABETTE,Richland Township H1 A,Kansas Senate,13,Republican,"LaTurner, Jacob",21,12004A
+LABETTE,Richland Township H1 B,Kansas Senate,13,Democratic,"Garman, Gene",0,12004B
+LABETTE,Richland Township H1 B,Kansas Senate,13,Republican,"LaTurner, Jacob",0,12004B
+LABETTE,Richland Township H1,Kansas Senate,13,Democratic,"Garman, Gene",4,120040
+LABETTE,Richland Township H1,Kansas Senate,13,Republican,"LaTurner, Jacob",12,120040
+LABETTE,Richland Township H7,Kansas Senate,13,Democratic,"Garman, Gene",24,120050
+LABETTE,Richland Township H7,Kansas Senate,13,Republican,"LaTurner, Jacob",47,120050
+LABETTE,Oswego City Ward 1 Exclave,Kansas Senate,15,Republican,"King, Jeff",0,900010
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Barnett, Andre",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Bush, Kent W",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Christensen, Will",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Goode, Virgil",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Stein, Jill E",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,Democratic,"Obama, Barack",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,Reform,"Baldwin, Chuck",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,Republican,"Romney, Mitt",0,00001A
+LABETTE,Canada Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+LABETTE,Canada Township,President / Vice President,,Democratic,"Obama, Barack",21,000020
+LABETTE,Canada Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+LABETTE,Canada Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+LABETTE,Canada Township,President / Vice President,,Republican,"Romney, Mitt",94,000020
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,Democratic,"Obama, Barack",47,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,Republican,"Romney, Mitt",61,000030
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,Democratic,"Obama, Barack",46,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,Republican,"Romney, Mitt",62,000040
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,Democratic,"Obama, Barack",68,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",4,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,Republican,"Romney, Mitt",87,000050
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Stein, Jill E",1,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,Democratic,"Obama, Barack",92,000060
+LABETTE,Elm Grove Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000060
+LABETTE,Elm Grove Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000060
+LABETTE,Elm Grove Township,President / Vice President,,Republican,"Romney, Mitt",299,000060
+LABETTE,Fairview Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+LABETTE,Fairview Township,President / Vice President,,Democratic,"Obama, Barack",21,000070
+LABETTE,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+LABETTE,Fairview Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+LABETTE,Fairview Township,President / Vice President,,Republican,"Romney, Mitt",85,000070
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+LABETTE,Hackberry Township,President / Vice President,,Democratic,"Obama, Barack",33,000080
+LABETTE,Hackberry Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000080
+LABETTE,Hackberry Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+LABETTE,Hackberry Township,President / Vice President,,Republican,"Romney, Mitt",118,000080
+LABETTE,Howard Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+LABETTE,Howard Township,President / Vice President,,Democratic,"Obama, Barack",43,000090
+LABETTE,Howard Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+LABETTE,Howard Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+LABETTE,Howard Township,President / Vice President,,Republican,"Romney, Mitt",122,000090
+LABETTE,Labette Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+LABETTE,Labette Township,President / Vice President,,Democratic,"Obama, Barack",33,000100
+LABETTE,Labette Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000100
+LABETTE,Labette Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+LABETTE,Labette Township,President / Vice President,,Republican,"Romney, Mitt",146,000100
+LABETTE,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+LABETTE,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",58,000110
+LABETTE,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+LABETTE,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000110
+LABETTE,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",126,000110
+LABETTE,Montana Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+LABETTE,Montana Township,President / Vice President,,Democratic,"Obama, Barack",29,000120
+LABETTE,Montana Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+LABETTE,Montana Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+LABETTE,Montana Township,President / Vice President,,Republican,"Romney, Mitt",55,000120
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,Democratic,"Obama, Barack",96,000130
+LABETTE,Mound Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000130
+LABETTE,Mound Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000130
+LABETTE,Mound Valley Township,President / Vice President,,Republican,"Romney, Mitt",232,000130
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,Democratic,"Obama, Barack",147,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,Republican,"Romney, Mitt",395,000140
+LABETTE,Neosho Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+LABETTE,Neosho Township,President / Vice President,,Democratic,"Obama, Barack",32,000150
+LABETTE,Neosho Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+LABETTE,Neosho Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+LABETTE,Neosho Township,President / Vice President,,Republican,"Romney, Mitt",54,000150
+LABETTE,North Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Ayers, Avery L",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Barnett, Andre",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Barr, Roseanne C",1,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Bush, Kent W",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Christensen, Will",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Duncan, Richard A",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Goode, Virgil",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Knill, Dennis J",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Reed, Jill A.",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Rogers, Rick L",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Stein, Jill E",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00016A
+LABETTE,North Township,President / Vice President,,Democratic,"Obama, Barack",105,00016A
+LABETTE,North Township,President / Vice President,,Libertarian,"Johnson, Gary",8,00016A
+LABETTE,North Township,President / Vice President,,Reform,"Baldwin, Chuck",4,00016A
+LABETTE,North Township,President / Vice President,,Republican,"Romney, Mitt",183,00016A
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Christensen, Will",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00016B
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Stein, Jill E",1,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,Democratic,"Obama, Barack",74,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",6,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,Republican,"Romney, Mitt",149,000180
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,Democratic,"Obama, Barack",101,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",2,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,Republican,"Romney, Mitt",141,00019A
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,Democratic,"Obama, Barack",62,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",5,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,Republican,"Romney, Mitt",104,000200
+LABETTE,Oswego Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+LABETTE,Oswego Township,President / Vice President,,Democratic,"Obama, Barack",50,000210
+LABETTE,Oswego Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000210
+LABETTE,Oswego Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+LABETTE,Oswego Township,President / Vice President,,Republican,"Romney, Mitt",88,000210
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",1,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",132,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",171,000220
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",76,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",7,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",86,000230
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",88,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",2,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",1,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",59,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",1,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",53,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",56,000250
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",147,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",2,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",130,000260
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",152,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",4,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",3,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",119,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",1,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",59,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",75,000280
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",1,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",197,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",5,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",140,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",1,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",131,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",5,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",129,000300
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Goode, Virgil",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Stein, Jill E",1,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,Democratic,"Obama, Barack",198,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",4,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",1,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,Republican,"Romney, Mitt",205,000310
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",68,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",1,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",87,000320
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",129,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",2,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",110,000330
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",123,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",2,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",2,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",75,000340
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Goode, Virgil",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Stein, Jill E",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,Democratic,"Obama, Barack",122,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",1,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",1,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,Republican,"Romney, Mitt",178,000350
+LABETTE,Walton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Barnett, Andre",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Bush, Kent W",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Christensen, Will",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Goode, Virgil",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Stein, Jill E",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000370
+LABETTE,Walton Township,President / Vice President,,Democratic,"Obama, Barack",136,000370
+LABETTE,Walton Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000370
+LABETTE,Walton Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000370
+LABETTE,Walton Township,President / Vice President,,Republican,"Romney, Mitt",240,000370
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Barnett, Andre",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Bush, Kent W",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Christensen, Will",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Goode, Virgil",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Stein, Jill E",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+LABETTE,Osage Township S14,President / Vice President,,Democratic,"Obama, Barack",0,120020
+LABETTE,Osage Township S14,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+LABETTE,Osage Township S14,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+LABETTE,Osage Township S14,President / Vice President,,Republican,"Romney, Mitt",0,120020
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Barnett, Andre",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Bush, Kent W",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Christensen, Will",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Goode, Virgil",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Stein, Jill E",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+LABETTE,Osage Township S15,President / Vice President,,Democratic,"Obama, Barack",113,120030
+LABETTE,Osage Township S15,President / Vice President,,Libertarian,"Johnson, Gary",3,120030
+LABETTE,Osage Township S15,President / Vice President,,Reform,"Baldwin, Chuck",3,120030
+LABETTE,Osage Township S15,President / Vice President,,Republican,"Romney, Mitt",200,120030
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Ayers, Avery L",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Barnett, Andre",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Bush, Kent W",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Christensen, Will",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Duncan, Richard A",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Goode, Virgil",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Hoefling, Tom",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Knill, Dennis J",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Reed, Jill A.",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Rogers, Rick L",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Stein, Jill E",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,Democratic,"Obama, Barack",9,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,Republican,"Romney, Mitt",22,12004A
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Ayers, Avery L",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Barnett, Andre",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Barr, Roseanne C",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Bush, Kent W",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Christensen, Will",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Duncan, Richard A",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Goode, Virgil",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Hoefling, Tom",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Knill, Dennis J",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Reed, Jill A.",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Rogers, Rick L",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Stein, Jill E",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Thorne, Kevin M",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Warner, Gerald L.",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,Democratic,"Obama, Barack",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,Libertarian,"Johnson, Gary",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,Reform,"Baldwin, Chuck",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,Republican,"Romney, Mitt",0,12004B
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Barnett, Andre",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Bush, Kent W",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Christensen, Will",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Goode, Virgil",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Stein, Jill E",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+LABETTE,Richland Township H1,President / Vice President,,Democratic,"Obama, Barack",5,120040
+LABETTE,Richland Township H1,President / Vice President,,Libertarian,"Johnson, Gary",0,120040
+LABETTE,Richland Township H1,President / Vice President,,Reform,"Baldwin, Chuck",0,120040
+LABETTE,Richland Township H1,President / Vice President,,Republican,"Romney, Mitt",11,120040
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Barnett, Andre",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Bush, Kent W",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Christensen, Will",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Goode, Virgil",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Stein, Jill E",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+LABETTE,Richland Township H7,President / Vice President,,Democratic,"Obama, Barack",21,120050
+LABETTE,Richland Township H7,President / Vice President,,Libertarian,"Johnson, Gary",0,120050
+LABETTE,Richland Township H7,President / Vice President,,Reform,"Baldwin, Chuck",3,120050
+LABETTE,Richland Township H7,President / Vice President,,Republican,"Romney, Mitt",48,120050
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900010
+LABETTE,Altamont City Part A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00001A
+LABETTE,Altamont City Part A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00001A
+LABETTE,Altamont City Part A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00001A
+LABETTE,Canada Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",16,000020
+LABETTE,Canada Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000020
+LABETTE,Canada Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",97,000020
+LABETTE,Chetopa Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",32,000030
+LABETTE,Chetopa Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000030
+LABETTE,Chetopa Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000030
+LABETTE,Chetopa Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",40,000040
+LABETTE,Chetopa Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000040
+LABETTE,Chetopa Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",64,000040
+LABETTE,Chetopa Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",50,000050
+LABETTE,Chetopa Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,000050
+LABETTE,Chetopa Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",93,000050
+LABETTE,Elm Grove Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",80,000060
+LABETTE,Elm Grove Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,000060
+LABETTE,Elm Grove Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",305,000060
+LABETTE,Fairview Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",16,000070
+LABETTE,Fairview Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000070
+LABETTE,Fairview Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",83,000070
+LABETTE,Hackberry Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",33,000080
+LABETTE,Hackberry Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000080
+LABETTE,Hackberry Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",118,000080
+LABETTE,Howard Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",44,000090
+LABETTE,Howard Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000090
+LABETTE,Howard Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",117,000090
+LABETTE,Labette Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",23,000100
+LABETTE,Labette Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000100
+LABETTE,Labette Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",157,000100
+LABETTE,Liberty Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",44,000110
+LABETTE,Liberty Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000110
+LABETTE,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",139,000110
+LABETTE,Montana Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",26,000120
+LABETTE,Montana Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000120
+LABETTE,Montana Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",55,000120
+LABETTE,Mound Valley Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",83,000130
+LABETTE,Mound Valley Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",17,000130
+LABETTE,Mound Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",231,000130
+LABETTE,Mount Pleasant Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",136,000140
+LABETTE,Mount Pleasant Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",17,000140
+LABETTE,Mount Pleasant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",396,000140
+LABETTE,Neosho Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",21,000150
+LABETTE,Neosho Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000150
+LABETTE,Neosho Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,000150
+LABETTE,North Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",78,00016A
+LABETTE,North Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,00016A
+LABETTE,North Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",216,00016A
+LABETTE,North Township Enclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00016B
+LABETTE,North Township Enclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00016B
+LABETTE,North Township Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00016B
+LABETTE,Oswego City Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",48,000180
+LABETTE,Oswego City Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,000180
+LABETTE,Oswego City Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",175,000180
+LABETTE,Oswego City Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",61,00019A
+LABETTE,Oswego City Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,00019A
+LABETTE,Oswego City Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",167,00019A
+LABETTE,Oswego City Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",48,000200
+LABETTE,Oswego City Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000200
+LABETTE,Oswego City Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",115,000200
+LABETTE,Oswego Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",32,000210
+LABETTE,Oswego Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000210
+LABETTE,Oswego Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",100,000210
+LABETTE,Parsons Ward 1 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",106,000220
+LABETTE,Parsons Ward 1 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000220
+LABETTE,Parsons Ward 1 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",187,000220
+LABETTE,Parsons Ward 1 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",60,000230
+LABETTE,Parsons Ward 1 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000230
+LABETTE,Parsons Ward 1 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,000230
+LABETTE,Parsons Ward 1 Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",71,00024A
+LABETTE,Parsons Ward 1 Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,00024A
+LABETTE,Parsons Ward 1 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",67,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",39,000250
+LABETTE,Parsons Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000250
+LABETTE,Parsons Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",69,000250
+LABETTE,Parsons Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",118,000260
+LABETTE,Parsons Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000260
+LABETTE,Parsons Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",155,000260
+LABETTE,Parsons Ward 2 Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",118,00027A
+LABETTE,Parsons Ward 2 Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,00027A
+LABETTE,Parsons Ward 2 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",147,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",49,000280
+LABETTE,Parsons Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000280
+LABETTE,Parsons Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",76,000280
+LABETTE,Parsons Ward 3 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",158,00029A
+LABETTE,Parsons Ward 3 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,00029A
+LABETTE,Parsons Ward 3 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",163,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",100,000300
+LABETTE,Parsons Ward 3 Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000300
+LABETTE,Parsons Ward 3 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",153,000300
+LABETTE,Parsons Ward 3 Precinct 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",158,000310
+LABETTE,Parsons Ward 3 Precinct 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,000310
+LABETTE,Parsons Ward 3 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",231,000310
+LABETTE,Parsons Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",62,000320
+LABETTE,Parsons Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000320
+LABETTE,Parsons Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",87,000320
+LABETTE,Parsons Ward 4 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",104,000330
+LABETTE,Parsons Ward 4 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000330
+LABETTE,Parsons Ward 4 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",125,000330
+LABETTE,Parsons Ward 4 Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",76,000340
+LABETTE,Parsons Ward 4 Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,000340
+LABETTE,Parsons Ward 4 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",114,000340
+LABETTE,Parsons Ward 4 Precinct 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",90,000350
+LABETTE,Parsons Ward 4 Precinct 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000350
+LABETTE,Parsons Ward 4 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",203,000350
+LABETTE,Walton Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",119,000370
+LABETTE,Walton Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000370
+LABETTE,Walton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",250,000370
+LABETTE,Osage Township S14,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120020
+LABETTE,Osage Township S14,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120020
+LABETTE,Osage Township S14,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120020
+LABETTE,Osage Township S15,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",81,120030
+LABETTE,Osage Township S15,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,120030
+LABETTE,Osage Township S15,United States House of Representatives,2,Republican,"Jenkins, Lynn",224,120030
+LABETTE,Richland Township H1 A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",5,12004A
+LABETTE,Richland Township H1 A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,12004A
+LABETTE,Richland Township H1 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",26,12004A
+LABETTE,Richland Township H1 B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,12004B
+LABETTE,Richland Township H1 B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,12004B
+LABETTE,Richland Township H1 B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12004B
+LABETTE,Richland Township H1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",3,120040
+LABETTE,Richland Township H1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120040
+LABETTE,Richland Township H1,United States House of Representatives,2,Republican,"Jenkins, Lynn",13,120040
+LABETTE,Richland Township H7,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",18,120050
+LABETTE,Richland Township H7,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,120050
+LABETTE,Richland Township H7,United States House of Representatives,2,Republican,"Jenkins, Lynn",52,120050
+LABETTE,Oswego City Ward 1 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900010
+LABETTE,Oswego City Ward 1 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900010
+LABETTE,Oswego City Ward 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010

--- a/2012/20121106__ks__general__lane__precinct.csv
+++ b/2012/20121106__ks__general__lane__precinct.csv
@@ -1,0 +1,231 @@
+county,precinct,office,district,party,candidate,votes,vtd
+LANE,Alamota Township,Kansas House of Representatives,118,Republican,"Hineman, Don",39,000010
+LANE,Dighton Township 2,Kansas House of Representatives,118,Republican,"Hineman, Don",64,000020
+LANE,Dighton Township 3,Kansas House of Representatives,118,Republican,"Hineman, Don",29,000030
+LANE,Cheyenne Township,Kansas House of Representatives,118,Republican,"Hineman, Don",119,000040
+LANE,Dighton Township 1,Kansas House of Representatives,118,Republican,"Hineman, Don",34,000050
+LANE,Dighton City Precinct 1,Kansas House of Representatives,118,Republican,"Hineman, Don",183,000060
+LANE,Dighton City Precinct 2,Kansas House of Representatives,118,Republican,"Hineman, Don",245,000070
+LANE,Dighton City Precinct 3,Kansas House of Representatives,118,Republican,"Hineman, Don",83,000080
+LANE,White Rock Township,Kansas House of Representatives,118,Republican,"Hineman, Don",11,000100
+LANE,Wilson Township,Kansas House of Representatives,118,Republican,"Hineman, Don",34,000110
+LANE,Alamota Township,Kansas Senate,33,Republican,"Holmes, Mitch",33,000010
+LANE,Dighton Township 2,Kansas Senate,33,Republican,"Holmes, Mitch",57,000020
+LANE,Dighton Township 3,Kansas Senate,33,Republican,"Holmes, Mitch",28,000030
+LANE,Cheyenne Township,Kansas Senate,33,Republican,"Holmes, Mitch",106,000040
+LANE,Dighton Township 1,Kansas Senate,33,Republican,"Holmes, Mitch",29,000050
+LANE,Dighton City Precinct 1,Kansas Senate,33,Republican,"Holmes, Mitch",165,000060
+LANE,Dighton City Precinct 2,Kansas Senate,33,Republican,"Holmes, Mitch",213,000070
+LANE,Dighton City Precinct 3,Kansas Senate,33,Republican,"Holmes, Mitch",73,000080
+LANE,White Rock Township,Kansas Senate,33,Republican,"Holmes, Mitch",11,000100
+LANE,Wilson Township,Kansas Senate,33,Republican,"Holmes, Mitch",29,000110
+LANE,Alamota Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+LANE,Alamota Township,President / Vice President,,Democratic,"Obama, Barack",5,000010
+LANE,Alamota Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+LANE,Alamota Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+LANE,Alamota Township,President / Vice President,,Republican,"Romney, Mitt",39,000010
+LANE,Dighton Township 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Barnett, Andre",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Bush, Kent W",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Christensen, Will",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Goode, Virgil",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Stein, Jill E",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+LANE,Dighton Township 2,President / Vice President,,Democratic,"Obama, Barack",5,000020
+LANE,Dighton Township 2,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+LANE,Dighton Township 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+LANE,Dighton Township 2,President / Vice President,,Republican,"Romney, Mitt",63,000020
+LANE,Dighton Township 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Barnett, Andre",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Bush, Kent W",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Christensen, Will",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Goode, Virgil",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Stein, Jill E",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+LANE,Dighton Township 3,President / Vice President,,Democratic,"Obama, Barack",6,000030
+LANE,Dighton Township 3,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+LANE,Dighton Township 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+LANE,Dighton Township 3,President / Vice President,,Republican,"Romney, Mitt",27,000030
+LANE,Cheyenne Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+LANE,Cheyenne Township,President / Vice President,,Democratic,"Obama, Barack",22,000040
+LANE,Cheyenne Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+LANE,Cheyenne Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000040
+LANE,Cheyenne Township,President / Vice President,,Republican,"Romney, Mitt",105,000040
+LANE,Dighton Township 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Barnett, Andre",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Bush, Kent W",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Christensen, Will",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Goode, Virgil",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Stein, Jill E",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+LANE,Dighton Township 1,President / Vice President,,Democratic,"Obama, Barack",10,000050
+LANE,Dighton Township 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+LANE,Dighton Township 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+LANE,Dighton Township 1,President / Vice President,,Republican,"Romney, Mitt",29,000050
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,Democratic,"Obama, Barack",45,000060
+LANE,Dighton City Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000060
+LANE,Dighton City Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,Republican,"Romney, Mitt",157,000060
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,Democratic,"Obama, Barack",59,000070
+LANE,Dighton City Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",5,000070
+LANE,Dighton City Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000070
+LANE,Dighton City Precinct 2,President / Vice President,,Republican,"Romney, Mitt",200,000070
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,Democratic,"Obama, Barack",12,000080
+LANE,Dighton City Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",2,000080
+LANE,Dighton City Precinct 3,President / Vice President,,Republican,"Romney, Mitt",75,000080
+LANE,White Rock Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+LANE,White Rock Township,President / Vice President,,Democratic,"Obama, Barack",3,000100
+LANE,White Rock Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+LANE,White Rock Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+LANE,White Rock Township,President / Vice President,,Republican,"Romney, Mitt",11,000100
+LANE,Wilson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+LANE,Wilson Township,President / Vice President,,Democratic,"Obama, Barack",5,000110
+LANE,Wilson Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+LANE,Wilson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+LANE,Wilson Township,President / Vice President,,Republican,"Romney, Mitt",33,000110
+LANE,Alamota Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000010
+LANE,Dighton Township 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",62,000020
+LANE,Dighton Township 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000030
+LANE,Cheyenne Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",114,000040
+LANE,Dighton Township 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000050
+LANE,Dighton City Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",166,000060
+LANE,Dighton City Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",225,000070
+LANE,Dighton City Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",73,000080
+LANE,White Rock Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000100
+LANE,Wilson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000110

--- a/2012/20121106__ks__general__leavenworth__precinct.csv
+++ b/2012/20121106__ks__general__leavenworth__precinct.csv
@@ -1,0 +1,1675 @@
+county,precinct,office,district,party,candidate,votes,vtd
+LEAVENWORTH,Alexandria Township,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",134,000010
+LEAVENWORTH,Alexandria Township,Kansas House of Representatives,42,Republican,"O'Brien, Connie",256,000010
+LEAVENWORTH,Basehor City,Kansas House of Representatives,38,Democratic,"Henderson, Pete",1103,000020
+LEAVENWORTH,Basehor City,Kansas House of Representatives,38,Republican,"Dove, Willie",1076,000020
+LEAVENWORTH,Basehor Township Voting District,Kansas House of Representatives,38,Democratic,"Henderson, Pete",444,000030
+LEAVENWORTH,Basehor Township Voting District,Kansas House of Representatives,38,Republican,"Dove, Willie",491,000030
+LEAVENWORTH,Easton Township,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",233,000040
+LEAVENWORTH,Easton Township,Kansas House of Representatives,42,Republican,"O'Brien, Connie",288,000040
+LEAVENWORTH,Fairmount Township Voting District,Kansas House of Representatives,38,Democratic,"Henderson, Pete",560,000050
+LEAVENWORTH,Fairmount Township Voting District,Kansas House of Representatives,38,Republican,"Dove, Willie",760,000050
+LEAVENWORTH,High Prairie Township,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",410,000060
+LEAVENWORTH,High Prairie Township,Kansas House of Representatives,42,Republican,"O'Brien, Connie",654,000060
+LEAVENWORTH,Kickapoo Township,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",387,000070
+LEAVENWORTH,Kickapoo Township,Kansas House of Representatives,42,Republican,"O'Brien, Connie",561,000070
+LEAVENWORTH,Lansing Ward 1,Kansas House of Representatives,40,Democratic,"Johnson, Linda",269,000080
+LEAVENWORTH,Lansing Ward 1,Kansas House of Representatives,40,Republican,"Bradford, John",300,000080
+LEAVENWORTH,Lansing Ward 2 Precinct 1,Kansas House of Representatives,40,Democratic,"Johnson, Linda",524,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,Kansas House of Representatives,40,Republican,"Bradford, John",822,000090
+LEAVENWORTH,Lansing Ward 3,Kansas House of Representatives,40,Democratic,"Johnson, Linda",310,000100
+LEAVENWORTH,Lansing Ward 3,Kansas House of Representatives,40,Republican,"Bradford, John",448,000100
+LEAVENWORTH,Lansing Ward 4,Kansas House of Representatives,40,Democratic,"Johnson, Linda",463,000110
+LEAVENWORTH,Lansing Ward 4,Kansas House of Representatives,40,Republican,"Bradford, John",663,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Kansas House of Representatives,41,Democratic,"Meier, Melanie",232,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Kansas House of Representatives,41,Republican,"Goodman, Jana",95,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Kansas House of Representatives,41,Democratic,"Meier, Melanie",160,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Kansas House of Representatives,41,Republican,"Goodman, Jana",121,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Kansas House of Representatives,41,Democratic,"Meier, Melanie",191,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Kansas House of Representatives,41,Republican,"Goodman, Jana",120,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Kansas House of Representatives,40,Democratic,"Johnson, Linda",285,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Kansas House of Representatives,40,Republican,"Bradford, John",143,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Kansas House of Representatives,41,Democratic,"Meier, Melanie",306,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Kansas House of Representatives,41,Republican,"Goodman, Jana",216,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Kansas House of Representatives,41,Democratic,"Meier, Melanie",200,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Kansas House of Representatives,41,Republican,"Goodman, Jana",180,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Kansas House of Representatives,41,Democratic,"Meier, Melanie",197,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Kansas House of Representatives,41,Republican,"Goodman, Jana",166,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Kansas House of Representatives,41,Democratic,"Meier, Melanie",206,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Kansas House of Representatives,41,Republican,"Goodman, Jana",168,00019A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,Kansas House of Representatives,41,Democratic,"Meier, Melanie",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,Kansas House of Representatives,41,Republican,"Goodman, Jana",0,00019B
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Kansas House of Representatives,41,Democratic,"Meier, Melanie",329,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Kansas House of Representatives,41,Republican,"Goodman, Jana",291,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Kansas House of Representatives,41,Democratic,"Meier, Melanie",205,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Kansas House of Representatives,41,Republican,"Goodman, Jana",198,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Kansas House of Representatives,41,Democratic,"Meier, Melanie",305,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Kansas House of Representatives,41,Republican,"Goodman, Jana",226,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Kansas House of Representatives,41,Democratic,"Meier, Melanie",249,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Kansas House of Representatives,41,Republican,"Goodman, Jana",158,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Kansas House of Representatives,40,Democratic,"Johnson, Linda",263,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Kansas House of Representatives,40,Republican,"Bradford, John",144,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Kansas House of Representatives,41,Democratic,"Meier, Melanie",382,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Kansas House of Representatives,41,Republican,"Goodman, Jana",394,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Kansas House of Representatives,41,Democratic,"Meier, Melanie",428,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Kansas House of Representatives,41,Republican,"Goodman, Jana",389,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Kansas House of Representatives,40,Democratic,"Johnson, Linda",160,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Kansas House of Representatives,40,Republican,"Bradford, John",33,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Kansas House of Representatives,40,Democratic,"Johnson, Linda",753,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Kansas House of Representatives,40,Republican,"Bradford, John",573,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Kansas House of Representatives,40,Democratic,"Johnson, Linda",769,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Kansas House of Representatives,40,Republican,"Bradford, John",767,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,Kansas House of Representatives,40,Democratic,"Johnson, Linda",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,Kansas House of Representatives,40,Republican,"Bradford, John",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,Kansas House of Representatives,40,Democratic,"Johnson, Linda",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,Kansas House of Representatives,40,Republican,"Bradford, John",0,00029D
+LEAVENWORTH,Sherman Township,Kansas House of Representatives,38,Democratic,"Henderson, Pete",493,000320
+LEAVENWORTH,Sherman Township,Kansas House of Representatives,38,Republican,"Dove, Willie",771,000320
+LEAVENWORTH,South Delaware 2,Kansas House of Representatives,40,Democratic,"Johnson, Linda",0,000340
+LEAVENWORTH,South Delaware 2,Kansas House of Representatives,40,Republican,"Bradford, John",0,000340
+LEAVENWORTH,Stranger Township Voting District,Kansas House of Representatives,38,Democratic,"Henderson, Pete",348,000350
+LEAVENWORTH,Stranger Township Voting District,Kansas House of Representatives,38,Republican,"Dove, Willie",454,000350
+LEAVENWORTH,Tonganoxie North Precinct,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",364,000360
+LEAVENWORTH,Tonganoxie North Precinct,Kansas House of Representatives,42,Republican,"O'Brien, Connie",793,000360
+LEAVENWORTH,Tonganoxie South Precinct,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",286,000370
+LEAVENWORTH,Tonganoxie South Precinct,Kansas House of Representatives,42,Republican,"O'Brien, Connie",492,000370
+LEAVENWORTH,Tonganoxie Township,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",389,000380
+LEAVENWORTH,Tonganoxie Township,Kansas House of Representatives,42,Republican,"O'Brien, Connie",756,000380
+LEAVENWORTH,Walnut Township Voting District,Kansas House of Representatives,38,Democratic,"Henderson, Pete",258,000390
+LEAVENWORTH,Walnut Township Voting District,Kansas House of Representatives,38,Republican,"Dove, Willie",291,000390
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,Kansas House of Representatives,38,Democratic,"Henderson, Pete",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,Kansas House of Representatives,38,Republican,"Dove, Willie",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,Kansas House of Representatives,38,Democratic,"Henderson, Pete",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,Kansas House of Representatives,38,Republican,"Dove, Willie",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,Kansas House of Representatives,40,Democratic,"Johnson, Linda",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,Kansas House of Representatives,40,Republican,"Bradford, John",0,120030
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,Kansas House of Representatives,41,Democratic,"Meier, Melanie",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,Kansas House of Representatives,41,Republican,"Goodman, Jana",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Kansas House of Representatives,41,Democratic,"Meier, Melanie",37,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Kansas House of Representatives,41,Republican,"Goodman, Jana",56,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",30,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Kansas House of Representatives,42,Republican,"O'Brien, Connie",48,120050
+LEAVENWORTH,Missouri River H41,Kansas House of Representatives,41,Democratic,"Meier, Melanie",0,120060
+LEAVENWORTH,Missouri River H41,Kansas House of Representatives,41,Republican,"Goodman, Jana",0,120060
+LEAVENWORTH,Missouri River H42,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",0,120070
+LEAVENWORTH,Missouri River H42,Kansas House of Representatives,42,Republican,"O'Brien, Connie",0,120070
+LEAVENWORTH,Reno Township H38,Kansas House of Representatives,38,Democratic,"Henderson, Pete",59,120080
+LEAVENWORTH,Reno Township H38,Kansas House of Representatives,38,Republican,"Dove, Willie",59,120080
+LEAVENWORTH,Reno Township H42,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",228,120090
+LEAVENWORTH,Reno Township H42,Kansas House of Representatives,42,Republican,"O'Brien, Connie",382,120090
+LEAVENWORTH,South Delaware 1 S3 H38,Kansas House of Representatives,38,Democratic,"Henderson, Pete",53,120100
+LEAVENWORTH,South Delaware 1 S3 H38,Kansas House of Representatives,38,Republican,"Dove, Willie",92,120100
+LEAVENWORTH,South Delaware 1 S3 H40,Kansas House of Representatives,40,Democratic,"Johnson, Linda",37,120110
+LEAVENWORTH,South Delaware 1 S3 H40,Kansas House of Representatives,40,Republican,"Bradford, John",63,120110
+LEAVENWORTH,South Delaware 1 S5 H38,Kansas House of Representatives,38,Democratic,"Henderson, Pete",4,120120
+LEAVENWORTH,South Delaware 1 S5 H38,Kansas House of Representatives,38,Republican,"Dove, Willie",0,120120
+LEAVENWORTH,South Delaware 1 S5 H40 A,Kansas House of Representatives,40,Democratic,"Johnson, Linda",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,Kansas House of Representatives,40,Republican,"Bradford, John",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40,Kansas House of Representatives,40,Democratic,"Johnson, Linda",106,120130
+LEAVENWORTH,South Delaware 1 S5 H40,Kansas House of Representatives,40,Republican,"Bradford, John",165,120130
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,Kansas House of Representatives,40,Democratic,"Johnson, Linda",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,Kansas House of Representatives,40,Republican,"Bradford, John",0,800010
+LEAVENWORTH,Basehor City Exclave 1,Kansas House of Representatives,38,Democratic,"Henderson, Pete",0,900010
+LEAVENWORTH,Basehor City Exclave 1,Kansas House of Representatives,38,Republican,"Dove, Willie",0,900010
+LEAVENWORTH,Basehor City Exclave 2,Kansas House of Representatives,38,Democratic,"Henderson, Pete",0,900020
+LEAVENWORTH,Basehor City Exclave 2,Kansas House of Representatives,38,Republican,"Dove, Willie",0,900020
+LEAVENWORTH,Basehor City Exclave 3,Kansas House of Representatives,38,Democratic,"Henderson, Pete",0,900030
+LEAVENWORTH,Basehor City Exclave 3,Kansas House of Representatives,38,Republican,"Dove, Willie",0,900030
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,Kansas House of Representatives,40,Democratic,"Johnson, Linda",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,Kansas House of Representatives,40,Republican,"Bradford, John",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,Kansas House of Representatives,40,Democratic,"Johnson, Linda",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,Kansas House of Representatives,40,Republican,"Bradford, John",0,900050
+LEAVENWORTH,South Delaware 1 Part B,Kansas House of Representatives,40,Democratic,"Johnson, Linda",0,900060
+LEAVENWORTH,South Delaware 1 Part B,Kansas House of Representatives,40,Republican,"Bradford, John",0,900060
+LEAVENWORTH,Tonganoxie South Exclave,Kansas House of Representatives,42,Democratic,"Fevurly, Harold D. Jr.",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,Kansas House of Representatives,42,Republican,"O'Brien, Connie",0,900080
+LEAVENWORTH,Alexandria Township,Kansas Senate,3,Democratic,"Holland, Tom",125,000010
+LEAVENWORTH,Alexandria Township,Kansas Senate,3,Republican,"Brown, Anthony R.",266,000010
+LEAVENWORTH,Basehor City,Kansas Senate,3,Democratic,"Holland, Tom",922,000020
+LEAVENWORTH,Basehor City,Kansas Senate,3,Republican,"Brown, Anthony R.",1239,000020
+LEAVENWORTH,Basehor Township Voting District,Kansas Senate,3,Democratic,"Holland, Tom",369,000030
+LEAVENWORTH,Basehor Township Voting District,Kansas Senate,3,Republican,"Brown, Anthony R.",561,000030
+LEAVENWORTH,Easton Township,Kansas Senate,3,Democratic,"Holland, Tom",225,000040
+LEAVENWORTH,Easton Township,Kansas Senate,3,Republican,"Brown, Anthony R.",289,000040
+LEAVENWORTH,Fairmount Township Voting District,Kansas Senate,3,Democratic,"Holland, Tom",525,000050
+LEAVENWORTH,Fairmount Township Voting District,Kansas Senate,3,Republican,"Brown, Anthony R.",776,000050
+LEAVENWORTH,High Prairie Township,Kansas Senate,3,Democratic,"Holland, Tom",408,000060
+LEAVENWORTH,High Prairie Township,Kansas Senate,3,Republican,"Brown, Anthony R.",651,000060
+LEAVENWORTH,Kickapoo Township,Kansas Senate,3,Democratic,"Holland, Tom",378,000070
+LEAVENWORTH,Kickapoo Township,Kansas Senate,3,Republican,"Brown, Anthony R.",572,000070
+LEAVENWORTH,Lansing Ward 1,Kansas Senate,5,Democratic,"Kultala, Kelly",247,000080
+LEAVENWORTH,Lansing Ward 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",325,000080
+LEAVENWORTH,Lansing Ward 2 Precinct 1,Kansas Senate,5,Democratic,"Kultala, Kelly",466,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",874,000090
+LEAVENWORTH,Lansing Ward 3,Kansas Senate,5,Democratic,"Kultala, Kelly",303,000100
+LEAVENWORTH,Lansing Ward 3,Kansas Senate,5,Republican,"Fitzgerald, Steve",456,000100
+LEAVENWORTH,Lansing Ward 4,Kansas Senate,5,Democratic,"Kultala, Kelly",441,000110
+LEAVENWORTH,Lansing Ward 4,Kansas Senate,5,Republican,"Fitzgerald, Steve",693,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Kansas Senate,5,Democratic,"Kultala, Kelly",200,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",121,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Kansas Senate,5,Democratic,"Kultala, Kelly",136,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",140,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Kansas Senate,5,Democratic,"Kultala, Kelly",155,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Kansas Senate,5,Republican,"Fitzgerald, Steve",153,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Kansas Senate,5,Democratic,"Kultala, Kelly",247,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Kansas Senate,5,Republican,"Fitzgerald, Steve",182,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Kansas Senate,5,Democratic,"Kultala, Kelly",264,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",264,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Kansas Senate,5,Democratic,"Kultala, Kelly",166,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",212,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Kansas Senate,5,Democratic,"Kultala, Kelly",182,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",177,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Kansas Senate,5,Democratic,"Kultala, Kelly",171,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Kansas Senate,5,Republican,"Fitzgerald, Steve",198,00019A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,Kansas Senate,5,Democratic,"Kultala, Kelly",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,00019B
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Kansas Senate,5,Democratic,"Kultala, Kelly",256,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Kansas Senate,5,Republican,"Fitzgerald, Steve",363,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Kansas Senate,5,Democratic,"Kultala, Kelly",158,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Kansas Senate,5,Republican,"Fitzgerald, Steve",245,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Kansas Senate,5,Democratic,"Kultala, Kelly",250,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",276,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Kansas Senate,5,Democratic,"Kultala, Kelly",227,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Kansas Senate,5,Republican,"Fitzgerald, Steve",174,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Kansas Senate,5,Democratic,"Kultala, Kelly",204,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Kansas Senate,5,Republican,"Fitzgerald, Steve",205,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Kansas Senate,5,Democratic,"Kultala, Kelly",327,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Kansas Senate,5,Republican,"Fitzgerald, Steve",453,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Kansas Senate,5,Democratic,"Kultala, Kelly",380,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Kansas Senate,5,Republican,"Fitzgerald, Steve",439,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Kansas Senate,5,Democratic,"Kultala, Kelly",137,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",62,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Kansas Senate,5,Democratic,"Kultala, Kelly",597,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Kansas Senate,5,Republican,"Fitzgerald, Steve",734,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Kansas Senate,5,Democratic,"Kultala, Kelly",641,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Kansas Senate,5,Republican,"Fitzgerald, Steve",909,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,Kansas Senate,5,Democratic,"Kultala, Kelly",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,Kansas Senate,5,Democratic,"Kultala, Kelly",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,00029D
+LEAVENWORTH,Sherman Township,Kansas Senate,3,Democratic,"Holland, Tom",470,000320
+LEAVENWORTH,Sherman Township,Kansas Senate,3,Republican,"Brown, Anthony R.",795,000320
+LEAVENWORTH,South Delaware 2,Kansas Senate,5,Democratic,"Kultala, Kelly",0,000340
+LEAVENWORTH,South Delaware 2,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,000340
+LEAVENWORTH,Stranger Township Voting District,Kansas Senate,3,Democratic,"Holland, Tom",310,000350
+LEAVENWORTH,Stranger Township Voting District,Kansas Senate,3,Republican,"Brown, Anthony R.",500,000350
+LEAVENWORTH,Tonganoxie North Precinct,Kansas Senate,3,Democratic,"Holland, Tom",509,000360
+LEAVENWORTH,Tonganoxie North Precinct,Kansas Senate,3,Republican,"Brown, Anthony R.",652,000360
+LEAVENWORTH,Tonganoxie South Precinct,Kansas Senate,3,Democratic,"Holland, Tom",365,000370
+LEAVENWORTH,Tonganoxie South Precinct,Kansas Senate,3,Republican,"Brown, Anthony R.",415,000370
+LEAVENWORTH,Tonganoxie Township,Kansas Senate,3,Democratic,"Holland, Tom",475,000380
+LEAVENWORTH,Tonganoxie Township,Kansas Senate,3,Republican,"Brown, Anthony R.",664,000380
+LEAVENWORTH,Walnut Township Voting District,Kansas Senate,3,Democratic,"Holland, Tom",228,000390
+LEAVENWORTH,Walnut Township Voting District,Kansas Senate,3,Republican,"Brown, Anthony R.",337,000390
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,Kansas Senate,5,Democratic,"Kultala, Kelly",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,Kansas Senate,5,Democratic,"Kultala, Kelly",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,Kansas Senate,5,Democratic,"Kultala, Kelly",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,120030
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,Kansas Senate,5,Democratic,"Kultala, Kelly",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Kansas Senate,5,Democratic,"Kultala, Kelly",25,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Kansas Senate,5,Republican,"Fitzgerald, Steve",68,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Kansas Senate,5,Democratic,"Kultala, Kelly",32,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Kansas Senate,5,Republican,"Fitzgerald, Steve",54,120050
+LEAVENWORTH,Missouri River H41,Kansas Senate,3,Democratic,"Holland, Tom",0,120060
+LEAVENWORTH,Missouri River H41,Kansas Senate,3,Republican,"Brown, Anthony R.",0,120060
+LEAVENWORTH,Missouri River H42,Kansas Senate,3,Democratic,"Holland, Tom",0,120070
+LEAVENWORTH,Missouri River H42,Kansas Senate,3,Republican,"Brown, Anthony R.",0,120070
+LEAVENWORTH,Reno Township H38,Kansas Senate,3,Democratic,"Holland, Tom",53,120080
+LEAVENWORTH,Reno Township H38,Kansas Senate,3,Republican,"Brown, Anthony R.",66,120080
+LEAVENWORTH,Reno Township H42,Kansas Senate,3,Democratic,"Holland, Tom",275,120090
+LEAVENWORTH,Reno Township H42,Kansas Senate,3,Republican,"Brown, Anthony R.",338,120090
+LEAVENWORTH,South Delaware 1 S3 H38,Kansas Senate,3,Democratic,"Holland, Tom",46,120100
+LEAVENWORTH,South Delaware 1 S3 H38,Kansas Senate,3,Republican,"Brown, Anthony R.",102,120100
+LEAVENWORTH,South Delaware 1 S3 H40,Kansas Senate,3,Democratic,"Holland, Tom",38,120110
+LEAVENWORTH,South Delaware 1 S3 H40,Kansas Senate,3,Republican,"Brown, Anthony R.",61,120110
+LEAVENWORTH,South Delaware 1 S5 H38,Kansas Senate,5,Democratic,"Kultala, Kelly",2,120120
+LEAVENWORTH,South Delaware 1 S5 H38,Kansas Senate,5,Republican,"Fitzgerald, Steve",2,120120
+LEAVENWORTH,South Delaware 1 S5 H40 A,Kansas Senate,5,Democratic,"Kultala, Kelly",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40,Kansas Senate,5,Democratic,"Kultala, Kelly",104,120130
+LEAVENWORTH,South Delaware 1 S5 H40,Kansas Senate,5,Republican,"Fitzgerald, Steve",173,120130
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,Kansas Senate,5,Democratic,"Kultala, Kelly",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,800010
+LEAVENWORTH,Basehor City Exclave 1,Kansas Senate,3,Democratic,"Holland, Tom",0,900010
+LEAVENWORTH,Basehor City Exclave 1,Kansas Senate,3,Republican,"Brown, Anthony R.",0,900010
+LEAVENWORTH,Basehor City Exclave 2,Kansas Senate,3,Democratic,"Holland, Tom",0,900020
+LEAVENWORTH,Basehor City Exclave 2,Kansas Senate,3,Republican,"Brown, Anthony R.",0,900020
+LEAVENWORTH,Basehor City Exclave 3,Kansas Senate,3,Democratic,"Holland, Tom",0,900030
+LEAVENWORTH,Basehor City Exclave 3,Kansas Senate,3,Republican,"Brown, Anthony R.",0,900030
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,Kansas Senate,5,Democratic,"Kultala, Kelly",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,Kansas Senate,5,Democratic,"Kultala, Kelly",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,900050
+LEAVENWORTH,South Delaware 1 Part B,Kansas Senate,5,Democratic,"Kultala, Kelly",0,900060
+LEAVENWORTH,South Delaware 1 Part B,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,900060
+LEAVENWORTH,Tonganoxie South Exclave,Kansas Senate,3,Democratic,"Holland, Tom",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,Kansas Senate,3,Republican,"Brown, Anthony R.",0,900080
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,Democratic,"Obama, Barack",100,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,Republican,"Romney, Mitt",288,000010
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Barnett, Andre",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Bush, Kent W",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Christensen, Will",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Goode, Virgil",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Stein, Jill E",1,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,Democratic,"Obama, Barack",820,000020
+LEAVENWORTH,Basehor City,President / Vice President,,Libertarian,"Johnson, Gary",21,000020
+LEAVENWORTH,Basehor City,President / Vice President,,Reform,"Baldwin, Chuck",11,000020
+LEAVENWORTH,Basehor City,President / Vice President,,Republican,"Romney, Mitt",1405,000020
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Barnett, Andre",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Barr, Roseanne C",1,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Bush, Kent W",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Christensen, Will",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Goode, Virgil",1,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Stein, Jill E",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,Democratic,"Obama, Barack",324,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,Libertarian,"Johnson, Gary",17,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,Republican,"Romney, Mitt",620,000030
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,Democratic,"Obama, Barack",164,000040
+LEAVENWORTH,Easton Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000040
+LEAVENWORTH,Easton Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000040
+LEAVENWORTH,Easton Township,President / Vice President,,Republican,"Romney, Mitt",363,000040
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Barnett, Andre",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Bush, Kent W",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Christensen, Will",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Goode, Virgil",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Stein, Jill E",1,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,Democratic,"Obama, Barack",487,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,Libertarian,"Johnson, Gary",28,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,Reform,"Baldwin, Chuck",7,000050
+LEAVENWORTH,Fairmount Township Voting District,President / Vice President,,Republican,"Romney, Mitt",839,000050
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,Democratic,"Obama, Barack",328,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,Libertarian,"Johnson, Gary",20,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,Republican,"Romney, Mitt",747,000060
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,Democratic,"Obama, Barack",312,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,Reform,"Baldwin, Chuck",9,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,Republican,"Romney, Mitt",650,000070
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,Democratic,"Obama, Barack",233,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",19,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,Republican,"Romney, Mitt",331,000080
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",457,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",15,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",10,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",905,000090
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Stein, Jill E",2,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,Democratic,"Obama, Barack",299,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",8,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,Republican,"Romney, Mitt",469,000100
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,Democratic,"Obama, Barack",433,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",18,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",4,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,Republican,"Romney, Mitt",703,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",225,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",109,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",1,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",142,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",7,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",132,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",150,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",9,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",160,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",252,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",8,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",182,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",2,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",275,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",18,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",4,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",239,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",197,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",6,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",191,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",199,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",10,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",5,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",154,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",187,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",11,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",8,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",172,00019A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Ayers, Avery L",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Barnett, Andre",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Barr, Roseanne C",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Bush, Kent W",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Christensen, Will",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Duncan, Richard A",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Goode, Virgil",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Hoefling, Tom",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Knill, Dennis J",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Reed, Jill A.",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Rogers, Rick L",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Stein, Jill E",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Thorne, Kevin M",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,write - in,"Warner, Gerald L.",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,Democratic,"Obama, Barack",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,Libertarian,"Johnson, Gary",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,Reform,"Baldwin, Chuck",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,President / Vice President,,Republican,"Romney, Mitt",0,00019B
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",258,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",10,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",5,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",353,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Goode, Virgil",1,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Stein, Jill E",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,Democratic,"Obama, Barack",145,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",8,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",5,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,Republican,"Romney, Mitt",249,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",257,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",6,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",5,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",272,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",2,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",227,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",10,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",179,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",206,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",12,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",3,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",195,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Goode, Virgil",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Stein, Jill E",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,Democratic,"Obama, Barack",323,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",10,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",5,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,Republican,"Romney, Mitt",451,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Barnett, Andre",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Bush, Kent W",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Christensen, Will",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Goode, Virgil",1,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Stein, Jill E",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,Democratic,"Obama, Barack",338,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",10,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,Reform,"Baldwin, Chuck",4,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,Republican,"Romney, Mitt",479,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",152,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",5,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",46,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",1,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",603,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",22,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",5,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",722,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",1,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",610,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",20,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",3,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",949,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Ayers, Avery L",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Barnett, Andre",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Bush, Kent W",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Christensen, Will",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Duncan, Richard A",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Goode, Virgil",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Knill, Dennis J",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Reed, Jill A.",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Rogers, Rick L",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Stein, Jill E",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,Democratic,"Obama, Barack",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,President / Vice President,,Republican,"Romney, Mitt",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Ayers, Avery L",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Barnett, Andre",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Barr, Roseanne C",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Bush, Kent W",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Christensen, Will",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Duncan, Richard A",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Goode, Virgil",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Hoefling, Tom",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Knill, Dennis J",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Reed, Jill A.",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Rogers, Rick L",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Stein, Jill E",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Thorne, Kevin M",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,write - in,"Warner, Gerald L.",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,Democratic,"Obama, Barack",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,Libertarian,"Johnson, Gary",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,Reform,"Baldwin, Chuck",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,President / Vice President,,Republican,"Romney, Mitt",0,00029D
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Barnett, Andre",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Bush, Kent W",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Christensen, Will",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Goode, Virgil",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Stein, Jill E",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,Democratic,"Obama, Barack",454,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",26,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,Republican,"Romney, Mitt",820,000320
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Ayers, Avery L",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Barnett, Andre",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Bush, Kent W",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Christensen, Will",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Duncan, Richard A",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Goode, Virgil",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Knill, Dennis J",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Reed, Jill A.",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Rogers, Rick L",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Stein, Jill E",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,Democratic,"Obama, Barack",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,Republican,"Romney, Mitt",0,000340
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Ayers, Avery L",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Barnett, Andre",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Barr, Roseanne C",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Bush, Kent W",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Christensen, Will",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Duncan, Richard A",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Goode, Virgil",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Knill, Dennis J",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Reed, Jill A.",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Rogers, Rick L",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Stein, Jill E",1,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Thorne, Kevin M",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Warner, Gerald L.",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,Democratic,"Obama, Barack",282,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,Libertarian,"Johnson, Gary",9,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,Reform,"Baldwin, Chuck",3,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,Republican,"Romney, Mitt",527,000350
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Ayers, Avery L",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Barnett, Andre",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Barr, Roseanne C",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Bush, Kent W",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Christensen, Will",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Duncan, Richard A",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Goode, Virgil",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Knill, Dennis J",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Reed, Jill A.",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Rogers, Rick L",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Stein, Jill E",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Thorne, Kevin M",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Warner, Gerald L.",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,Democratic,"Obama, Barack",435,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,Libertarian,"Johnson, Gary",22,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,Reform,"Baldwin, Chuck",7,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,Republican,"Romney, Mitt",725,000360
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Ayers, Avery L",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Barnett, Andre",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Barr, Roseanne C",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Bush, Kent W",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Christensen, Will",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Duncan, Richard A",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Goode, Virgil",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Knill, Dennis J",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Reed, Jill A.",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Rogers, Rick L",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Stein, Jill E",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Thorne, Kevin M",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Warner, Gerald L.",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,Democratic,"Obama, Barack",308,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,Libertarian,"Johnson, Gary",20,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,Reform,"Baldwin, Chuck",9,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,Republican,"Romney, Mitt",459,000370
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Ayers, Avery L",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Barnett, Andre",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Bush, Kent W",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Christensen, Will",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Duncan, Richard A",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Goode, Virgil",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Knill, Dennis J",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Reed, Jill A.",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Rogers, Rick L",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Stein, Jill E",1,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,Democratic,"Obama, Barack",427,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,Libertarian,"Johnson, Gary",29,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,Republican,"Romney, Mitt",712,000380
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Ayers, Avery L",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Barnett, Andre",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Barr, Roseanne C",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Bush, Kent W",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Christensen, Will",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Duncan, Richard A",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Goode, Virgil",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Hoefling, Tom",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Knill, Dennis J",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Reed, Jill A.",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Rogers, Rick L",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Stein, Jill E",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Thorne, Kevin M",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Warner, Gerald L.",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,Democratic,"Obama, Barack",200,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,Libertarian,"Johnson, Gary",16,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,Reform,"Baldwin, Chuck",4,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,Republican,"Romney, Mitt",365,000390
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Ayers, Avery L",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Barnett, Andre",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Bush, Kent W",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Christensen, Will",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Duncan, Richard A",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Goode, Virgil",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Hoefling, Tom",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Knill, Dennis J",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Reed, Jill A.",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Rogers, Rick L",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Stein, Jill E",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,Democratic,"Obama, Barack",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,President / Vice President,,Republican,"Romney, Mitt",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Barnett, Andre",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Bush, Kent W",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Christensen, Will",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Goode, Virgil",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Stein, Jill E",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,Democratic,"Obama, Barack",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,President / Vice President,,Republican,"Romney, Mitt",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Barnett, Andre",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Bush, Kent W",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Christensen, Will",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Goode, Virgil",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Stein, Jill E",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,Democratic,"Obama, Barack",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,President / Vice President,,Republican,"Romney, Mitt",0,120030
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Ayers, Avery L",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Barnett, Andre",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Bush, Kent W",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Christensen, Will",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Duncan, Richard A",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Goode, Virgil",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Hoefling, Tom",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Knill, Dennis J",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Reed, Jill A.",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Rogers, Rick L",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Stein, Jill E",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,Democratic,"Obama, Barack",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,President / Vice President,,Republican,"Romney, Mitt",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Barnett, Andre",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Bush, Kent W",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Christensen, Will",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Goode, Virgil",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Stein, Jill E",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,Democratic,"Obama, Barack",30,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,Libertarian,"Johnson, Gary",2,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,Reform,"Baldwin, Chuck",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,Republican,"Romney, Mitt",69,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Barnett, Andre",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Bush, Kent W",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Christensen, Will",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Goode, Virgil",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Stein, Jill E",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,Democratic,"Obama, Barack",34,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,Libertarian,"Johnson, Gary",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,Reform,"Baldwin, Chuck",1,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,Republican,"Romney, Mitt",56,120050
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Ayers, Avery L",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Barnett, Andre",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Barr, Roseanne C",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Bush, Kent W",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Christensen, Will",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Duncan, Richard A",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Goode, Virgil",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Knill, Dennis J",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Reed, Jill A.",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Rogers, Rick L",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Stein, Jill E",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Thorne, Kevin M",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Warner, Gerald L.",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,Democratic,"Obama, Barack",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,Libertarian,"Johnson, Gary",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,Reform,"Baldwin, Chuck",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,Republican,"Romney, Mitt",0,120060
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Ayers, Avery L",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Barnett, Andre",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Barr, Roseanne C",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Bush, Kent W",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Christensen, Will",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Duncan, Richard A",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Goode, Virgil",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Knill, Dennis J",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Reed, Jill A.",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Rogers, Rick L",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Stein, Jill E",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Thorne, Kevin M",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Warner, Gerald L.",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,Democratic,"Obama, Barack",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,Libertarian,"Johnson, Gary",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,Reform,"Baldwin, Chuck",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,Republican,"Romney, Mitt",0,120070
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Ayers, Avery L",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Barnett, Andre",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Barr, Roseanne C",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Bush, Kent W",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Christensen, Will",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Duncan, Richard A",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Goode, Virgil",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Knill, Dennis J",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Reed, Jill A.",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Rogers, Rick L",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Stein, Jill E",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Thorne, Kevin M",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Warner, Gerald L.",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,Democratic,"Obama, Barack",54,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,Libertarian,"Johnson, Gary",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,Reform,"Baldwin, Chuck",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,Republican,"Romney, Mitt",67,120080
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Ayers, Avery L",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Barnett, Andre",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Barr, Roseanne C",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Bush, Kent W",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Christensen, Will",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Duncan, Richard A",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Goode, Virgil",1,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Knill, Dennis J",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Reed, Jill A.",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Rogers, Rick L",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Stein, Jill E",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Thorne, Kevin M",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Warner, Gerald L.",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,Democratic,"Obama, Barack",259,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,Libertarian,"Johnson, Gary",10,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,Reform,"Baldwin, Chuck",4,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,Republican,"Romney, Mitt",349,120090
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Ayers, Avery L",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Barnett, Andre",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Barr, Roseanne C",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Bush, Kent W",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Christensen, Will",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Duncan, Richard A",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Goode, Virgil",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Hoefling, Tom",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Knill, Dennis J",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Reed, Jill A.",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Rogers, Rick L",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Stein, Jill E",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Thorne, Kevin M",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,write - in,"Warner, Gerald L.",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,Democratic,"Obama, Barack",38,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,Libertarian,"Johnson, Gary",0,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,Reform,"Baldwin, Chuck",1,120100
+LEAVENWORTH,South Delaware 1 S3 H38,President / Vice President,,Republican,"Romney, Mitt",114,120100
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Ayers, Avery L",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Barnett, Andre",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Barr, Roseanne C",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Bush, Kent W",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Christensen, Will",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Duncan, Richard A",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Goode, Virgil",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Hoefling, Tom",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Knill, Dennis J",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Reed, Jill A.",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Rogers, Rick L",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Stein, Jill E",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Thorne, Kevin M",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,write - in,"Warner, Gerald L.",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,Democratic,"Obama, Barack",33,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,Libertarian,"Johnson, Gary",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,Reform,"Baldwin, Chuck",0,120110
+LEAVENWORTH,South Delaware 1 S3 H40,President / Vice President,,Republican,"Romney, Mitt",70,120110
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Ayers, Avery L",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Barnett, Andre",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Barr, Roseanne C",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Bush, Kent W",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Christensen, Will",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Duncan, Richard A",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Goode, Virgil",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Hoefling, Tom",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Knill, Dennis J",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Reed, Jill A.",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Rogers, Rick L",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Stein, Jill E",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Thorne, Kevin M",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,write - in,"Warner, Gerald L.",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,Democratic,"Obama, Barack",3,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,Libertarian,"Johnson, Gary",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,Reform,"Baldwin, Chuck",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,President / Vice President,,Republican,"Romney, Mitt",1,120120
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Ayers, Avery L",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Barnett, Andre",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Bush, Kent W",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Christensen, Will",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Duncan, Richard A",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Goode, Virgil",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Hoefling, Tom",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Knill, Dennis J",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Reed, Jill A.",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Rogers, Rick L",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Stein, Jill E",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,Democratic,"Obama, Barack",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,President / Vice President,,Republican,"Romney, Mitt",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Ayers, Avery L",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Barnett, Andre",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Barr, Roseanne C",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Bush, Kent W",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Christensen, Will",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Duncan, Richard A",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Goode, Virgil",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Hoefling, Tom",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Knill, Dennis J",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Reed, Jill A.",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Rogers, Rick L",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Stein, Jill E",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Thorne, Kevin M",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Warner, Gerald L.",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,Democratic,"Obama, Barack",97,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,Libertarian,"Johnson, Gary",5,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,Reform,"Baldwin, Chuck",3,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,Republican,"Romney, Mitt",171,120130
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Ayers, Avery L",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Barnett, Andre",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Barr, Roseanne C",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Bush, Kent W",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Christensen, Will",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Duncan, Richard A",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Goode, Virgil",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Hoefling, Tom",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Knill, Dennis J",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Reed, Jill A.",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Rogers, Rick L",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Stein, Jill E",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Thorne, Kevin M",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,write - in,"Warner, Gerald L.",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,Democratic,"Obama, Barack",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,Libertarian,"Johnson, Gary",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,Reform,"Baldwin, Chuck",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,President / Vice President,,Republican,"Romney, Mitt",0,800010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Christensen, Will",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900010
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Christensen, Will",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900020
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Barnett, Andre",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Bush, Kent W",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Christensen, Will",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Goode, Virgil",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Stein, Jill E",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,Democratic,"Obama, Barack",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,Republican,"Romney, Mitt",0,900030
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Barnett, Andre",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Bush, Kent W",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Christensen, Will",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Goode, Virgil",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Stein, Jill E",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,Democratic,"Obama, Barack",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,President / Vice President,,Republican,"Romney, Mitt",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Ayers, Avery L",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Barnett, Andre",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Barr, Roseanne C",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Bush, Kent W",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Christensen, Will",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Duncan, Richard A",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Goode, Virgil",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Knill, Dennis J",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Reed, Jill A.",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Rogers, Rick L",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Stein, Jill E",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Thorne, Kevin M",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,write - in,"Warner, Gerald L.",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,Democratic,"Obama, Barack",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,Reform,"Baldwin, Chuck",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,President / Vice President,,Republican,"Romney, Mitt",0,900050
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Ayers, Avery L",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Barnett, Andre",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Bush, Kent W",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Christensen, Will",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Duncan, Richard A",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Goode, Virgil",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Knill, Dennis J",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Reed, Jill A.",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Rogers, Rick L",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Stein, Jill E",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,Democratic,"Obama, Barack",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,900060
+LEAVENWORTH,South Delaware 1 Part B,President / Vice President,,Republican,"Romney, Mitt",0,900060
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Christensen, Will",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900080
+LEAVENWORTH,Alexandria Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",84,000010
+LEAVENWORTH,Alexandria Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",25,000010
+LEAVENWORTH,Alexandria Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",286,000010
+LEAVENWORTH,Basehor City,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",694,000020
+LEAVENWORTH,Basehor City,United States House of Representatives,2,Libertarian,"Hawver, Dennis",81,000020
+LEAVENWORTH,Basehor City,United States House of Representatives,2,Republican,"Jenkins, Lynn",1395,000020
+LEAVENWORTH,Basehor Township Voting District,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",278,000030
+LEAVENWORTH,Basehor Township Voting District,United States House of Representatives,2,Libertarian,"Hawver, Dennis",30,000030
+LEAVENWORTH,Basehor Township Voting District,United States House of Representatives,2,Republican,"Jenkins, Lynn",631,000030
+LEAVENWORTH,Easton Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",114,000040
+LEAVENWORTH,Easton Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",45,000040
+LEAVENWORTH,Easton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",370,000040
+LEAVENWORTH,Fairmount Township Voting District,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",408,000050
+LEAVENWORTH,Fairmount Township Voting District,United States House of Representatives,2,Libertarian,"Hawver, Dennis",58,000050
+LEAVENWORTH,Fairmount Township Voting District,United States House of Representatives,2,Republican,"Jenkins, Lynn",849,000050
+LEAVENWORTH,High Prairie Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",245,000060
+LEAVENWORTH,High Prairie Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",72,000060
+LEAVENWORTH,High Prairie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",748,000060
+LEAVENWORTH,Kickapoo Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",234,000070
+LEAVENWORTH,Kickapoo Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",58,000070
+LEAVENWORTH,Kickapoo Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",675,000070
+LEAVENWORTH,Lansing Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",174,000080
+LEAVENWORTH,Lansing Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",34,000080
+LEAVENWORTH,Lansing Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",360,000080
+LEAVENWORTH,Lansing Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",350,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",55,000090
+LEAVENWORTH,Lansing Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",929,000090
+LEAVENWORTH,Lansing Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",225,000100
+LEAVENWORTH,Lansing Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",35,000100
+LEAVENWORTH,Lansing Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",500,000100
+LEAVENWORTH,Lansing Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",334,000110
+LEAVENWORTH,Lansing Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",50,000110
+LEAVENWORTH,Lansing Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",728,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",171,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",132,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",103,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",17,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",156,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",110,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",27,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",173,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",184,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",34,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",199,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",223,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",36,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",269,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",149,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",20,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",207,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",136,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",208,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",133,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",23,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",210,00019A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00019B
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1 Fort A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00019B
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",198,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",30,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",382,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",107,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",25,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",265,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",188,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",29,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",312,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",180,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",20,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",200,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",147,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",30,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",228,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",260,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",31,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",488,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",264,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States House of Representatives,2,Libertarian,"Hawver, Dennis",29,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",515,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",107,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",82,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",476,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",56,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",788,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",495,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",49,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",998,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00029C
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00029D
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00029D
+LEAVENWORTH,Sherman Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",364,000320
+LEAVENWORTH,Sherman Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",74,000320
+LEAVENWORTH,Sherman Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",831,000320
+LEAVENWORTH,South Delaware 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,000340
+LEAVENWORTH,South Delaware 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000340
+LEAVENWORTH,South Delaware 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,000340
+LEAVENWORTH,Stranger Township Voting District,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",215,000350
+LEAVENWORTH,Stranger Township Voting District,United States House of Representatives,2,Libertarian,"Hawver, Dennis",40,000350
+LEAVENWORTH,Stranger Township Voting District,United States House of Representatives,2,Republican,"Jenkins, Lynn",550,000350
+LEAVENWORTH,Tonganoxie North Precinct,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",340,000360
+LEAVENWORTH,Tonganoxie North Precinct,United States House of Representatives,2,Libertarian,"Hawver, Dennis",73,000360
+LEAVENWORTH,Tonganoxie North Precinct,United States House of Representatives,2,Republican,"Jenkins, Lynn",737,000360
+LEAVENWORTH,Tonganoxie South Precinct,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",269,000370
+LEAVENWORTH,Tonganoxie South Precinct,United States House of Representatives,2,Libertarian,"Hawver, Dennis",52,000370
+LEAVENWORTH,Tonganoxie South Precinct,United States House of Representatives,2,Republican,"Jenkins, Lynn",452,000370
+LEAVENWORTH,Tonganoxie Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",350,000380
+LEAVENWORTH,Tonganoxie Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",63,000380
+LEAVENWORTH,Tonganoxie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",735,000380
+LEAVENWORTH,Walnut Township Voting District,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",170,000390
+LEAVENWORTH,Walnut Township Voting District,United States House of Representatives,2,Libertarian,"Hawver, Dennis",31,000390
+LEAVENWORTH,Walnut Township Voting District,United States House of Representatives,2,Republican,"Jenkins, Lynn",372,000390
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12002A
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H38,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120020
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120030
+LEAVENWORTH,Lansing Ward 2 Precinct 2 H40,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120030
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12004A
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",27,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States House of Representatives,2,Republican,"Jenkins, Lynn",61,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",29,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States House of Representatives,2,Republican,"Jenkins, Lynn",56,120050
+LEAVENWORTH,Missouri River H41,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120060
+LEAVENWORTH,Missouri River H41,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120060
+LEAVENWORTH,Missouri River H41,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120060
+LEAVENWORTH,Missouri River H42,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120070
+LEAVENWORTH,Missouri River H42,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120070
+LEAVENWORTH,Missouri River H42,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120070
+LEAVENWORTH,Reno Township H38,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",43,120080
+LEAVENWORTH,Reno Township H38,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,120080
+LEAVENWORTH,Reno Township H38,United States House of Representatives,2,Republican,"Jenkins, Lynn",71,120080
+LEAVENWORTH,Reno Township H42,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",236,120090
+LEAVENWORTH,Reno Township H42,United States House of Representatives,2,Libertarian,"Hawver, Dennis",35,120090
+LEAVENWORTH,Reno Township H42,United States House of Representatives,2,Republican,"Jenkins, Lynn",342,120090
+LEAVENWORTH,South Delaware 1 S3 H38,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",32,120100
+LEAVENWORTH,South Delaware 1 S3 H38,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,120100
+LEAVENWORTH,South Delaware 1 S3 H38,United States House of Representatives,2,Republican,"Jenkins, Lynn",111,120100
+LEAVENWORTH,South Delaware 1 S3 H40,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",21,120110
+LEAVENWORTH,South Delaware 1 S3 H40,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,120110
+LEAVENWORTH,South Delaware 1 S3 H40,United States House of Representatives,2,Republican,"Jenkins, Lynn",79,120110
+LEAVENWORTH,South Delaware 1 S5 H38,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",2,120120
+LEAVENWORTH,South Delaware 1 S5 H38,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120120
+LEAVENWORTH,South Delaware 1 S5 H38,United States House of Representatives,2,Republican,"Jenkins, Lynn",2,120120
+LEAVENWORTH,South Delaware 1 S5 H40 A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12013A
+LEAVENWORTH,South Delaware 1 S5 H40,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",74,120130
+LEAVENWORTH,South Delaware 1 S5 H40,United States House of Representatives,2,Libertarian,"Hawver, Dennis",17,120130
+LEAVENWORTH,South Delaware 1 S5 H40,United States House of Representatives,2,Republican,"Jenkins, Lynn",182,120130
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,800010
+LEAVENWORTH,Lansing Ward 2 Precinct 1 B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,800010
+LEAVENWORTH,Basehor City Exclave 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900010
+LEAVENWORTH,Basehor City Exclave 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900010
+LEAVENWORTH,Basehor City Exclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+LEAVENWORTH,Basehor City Exclave 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900020
+LEAVENWORTH,Basehor City Exclave 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900020
+LEAVENWORTH,Basehor City Exclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+LEAVENWORTH,Basehor City Exclave 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900030
+LEAVENWORTH,Basehor City Exclave 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900030
+LEAVENWORTH,Basehor City Exclave 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part D,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900040
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900050
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3 Part E,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900050
+LEAVENWORTH,South Delaware 1 Part B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900060
+LEAVENWORTH,South Delaware 1 Part B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900060
+LEAVENWORTH,South Delaware 1 Part B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900060
+LEAVENWORTH,Tonganoxie South Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900080

--- a/2012/20121106__ks__general__lincoln__precinct.csv
+++ b/2012/20121106__ks__general__lincoln__precinct.csv
@@ -1,0 +1,577 @@
+county,precinct,office,district,party,candidate,votes,vtd
+LINCOLN,Battle Creek Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",22,000010
+LINCOLN,Beaver Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",25,00002A
+LINCOLN,Cedron Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",13,000030
+LINCOLN,Colorado Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",96,000040
+LINCOLN,Elkhorn Township Part A,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",76,00005A
+LINCOLN,Franklin Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",43,000060
+LINCOLN,Golden Belt Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",21,000070
+LINCOLN,Grant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",34,000080
+LINCOLN,Hanover Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",21,000090
+LINCOLN,Highland Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",27,000100
+LINCOLN,Indiana Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",38,000110
+LINCOLN,Lincoln Precinct 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",189,000120
+LINCOLN,Lincoln Precinct 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",242,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00013B
+LINCOLN,Logan Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",25,000140
+LINCOLN,Madison Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",36,000150
+LINCOLN,Marion Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",16,000160
+LINCOLN,Orange Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",30,000170
+LINCOLN,Pleasant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",172,000180
+LINCOLN,Salt Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",23,000190
+LINCOLN,Scott Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",51,000200
+LINCOLN,Valley Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",16,000210
+LINCOLN,Vesper Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",45,000220
+LINCOLN,Marion Township Enclave 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",0,900010
+LINCOLN,Battle Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000010
+LINCOLN,Battle Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",25,000010
+LINCOLN,Beaver Township,Kansas Senate,36,Democratic,"Clark, Marquis",5,00002A
+LINCOLN,Beaver Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",24,00002A
+LINCOLN,Cedron Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000030
+LINCOLN,Cedron Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",11,000030
+LINCOLN,Colorado Township,Kansas Senate,36,Democratic,"Clark, Marquis",18,000040
+LINCOLN,Colorado Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",86,000040
+LINCOLN,Elkhorn Township Part A,Kansas Senate,36,Democratic,"Clark, Marquis",4,00005A
+LINCOLN,Elkhorn Township Part A,Kansas Senate,36,Republican,"Bowers, Elaine S.",79,00005A
+LINCOLN,Franklin Township,Kansas Senate,36,Democratic,"Clark, Marquis",5,000060
+LINCOLN,Franklin Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",48,000060
+LINCOLN,Golden Belt Township,Kansas Senate,36,Democratic,"Clark, Marquis",9,000070
+LINCOLN,Golden Belt Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000070
+LINCOLN,Grant Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000080
+LINCOLN,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",32,000080
+LINCOLN,Hanover Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000090
+LINCOLN,Hanover Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",20,000090
+LINCOLN,Highland Township,Kansas Senate,36,Democratic,"Clark, Marquis",8,000100
+LINCOLN,Highland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",27,000100
+LINCOLN,Indiana Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000110
+LINCOLN,Indiana Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",42,000110
+LINCOLN,Lincoln Precinct 1,Kansas Senate,36,Democratic,"Clark, Marquis",31,000120
+LINCOLN,Lincoln Precinct 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",189,000120
+LINCOLN,Lincoln Precinct 2,Kansas Senate,36,Democratic,"Clark, Marquis",37,00013A
+LINCOLN,Lincoln Precinct 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",239,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,Kansas Senate,36,Democratic,"Clark, Marquis",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00013B
+LINCOLN,Logan Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000140
+LINCOLN,Logan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",30,000140
+LINCOLN,Madison Township,Kansas Senate,36,Democratic,"Clark, Marquis",8,000150
+LINCOLN,Madison Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",33,000150
+LINCOLN,Marion Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000160
+LINCOLN,Marion Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",18,000160
+LINCOLN,Orange Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000170
+LINCOLN,Orange Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",31,000170
+LINCOLN,Pleasant Township,Kansas Senate,36,Democratic,"Clark, Marquis",34,000180
+LINCOLN,Pleasant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",156,000180
+LINCOLN,Salt Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000190
+LINCOLN,Salt Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",25,000190
+LINCOLN,Scott Township,Kansas Senate,36,Democratic,"Clark, Marquis",7,000200
+LINCOLN,Scott Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",47,000200
+LINCOLN,Valley Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000210
+LINCOLN,Valley Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000210
+LINCOLN,Vesper Township,Kansas Senate,36,Democratic,"Clark, Marquis",11,000220
+LINCOLN,Vesper Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",40,000220
+LINCOLN,Marion Township Enclave 1,Kansas Senate,36,Democratic,"Clark, Marquis",0,900010
+LINCOLN,Marion Township Enclave 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,900010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,Democratic,"Obama, Barack",6,000010
+LINCOLN,Battle Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+LINCOLN,Battle Creek Township,President / Vice President,,Republican,"Romney, Mitt",19,000010
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Ayers, Avery L",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Barnett, Andre",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Bush, Kent W",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Christensen, Will",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Duncan, Richard A",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Goode, Virgil",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Knill, Dennis J",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Reed, Jill A.",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Rogers, Rick L",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Stein, Jill E",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,Democratic,"Obama, Barack",5,00002A
+LINCOLN,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,Reform,"Baldwin, Chuck",1,00002A
+LINCOLN,Beaver Township,President / Vice President,,Republican,"Romney, Mitt",23,00002A
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+LINCOLN,Cedron Township,President / Vice President,,Democratic,"Obama, Barack",3,000030
+LINCOLN,Cedron Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+LINCOLN,Cedron Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+LINCOLN,Cedron Township,President / Vice President,,Republican,"Romney, Mitt",11,000030
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+LINCOLN,Colorado Township,President / Vice President,,Democratic,"Obama, Barack",27,000040
+LINCOLN,Colorado Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+LINCOLN,Colorado Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+LINCOLN,Colorado Township,President / Vice President,,Republican,"Romney, Mitt",79,000040
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Barnett, Andre",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Bush, Kent W",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Christensen, Will",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Goode, Virgil",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Stein, Jill E",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,Democratic,"Obama, Barack",10,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,Reform,"Baldwin, Chuck",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,Republican,"Romney, Mitt",72,00005A
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+LINCOLN,Franklin Township,President / Vice President,,Democratic,"Obama, Barack",7,000060
+LINCOLN,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+LINCOLN,Franklin Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+LINCOLN,Franklin Township,President / Vice President,,Republican,"Romney, Mitt",46,000060
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,Democratic,"Obama, Barack",9,000070
+LINCOLN,Golden Belt Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,Republican,"Romney, Mitt",17,000070
+LINCOLN,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+LINCOLN,Grant Township,President / Vice President,,Democratic,"Obama, Barack",5,000080
+LINCOLN,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+LINCOLN,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+LINCOLN,Grant Township,President / Vice President,,Republican,"Romney, Mitt",31,000080
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+LINCOLN,Hanover Township,President / Vice President,,Democratic,"Obama, Barack",1,000090
+LINCOLN,Hanover Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+LINCOLN,Hanover Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+LINCOLN,Hanover Township,President / Vice President,,Republican,"Romney, Mitt",20,000090
+LINCOLN,Highland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+LINCOLN,Highland Township,President / Vice President,,Democratic,"Obama, Barack",8,000100
+LINCOLN,Highland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+LINCOLN,Highland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+LINCOLN,Highland Township,President / Vice President,,Republican,"Romney, Mitt",27,000100
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+LINCOLN,Indiana Township,President / Vice President,,Democratic,"Obama, Barack",7,000110
+LINCOLN,Indiana Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000110
+LINCOLN,Indiana Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+LINCOLN,Indiana Township,President / Vice President,,Republican,"Romney, Mitt",39,000110
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,Democratic,"Obama, Barack",49,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,Republican,"Romney, Mitt",175,000120
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,Democratic,"Obama, Barack",58,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",3,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,Republican,"Romney, Mitt",226,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00013B
+LINCOLN,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+LINCOLN,Logan Township,President / Vice President,,Democratic,"Obama, Barack",5,000140
+LINCOLN,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+LINCOLN,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+LINCOLN,Logan Township,President / Vice President,,Republican,"Romney, Mitt",30,000140
+LINCOLN,Madison Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+LINCOLN,Madison Township,President / Vice President,,Democratic,"Obama, Barack",8,000150
+LINCOLN,Madison Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+LINCOLN,Madison Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+LINCOLN,Madison Township,President / Vice President,,Republican,"Romney, Mitt",36,000150
+LINCOLN,Marion Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+LINCOLN,Marion Township,President / Vice President,,Democratic,"Obama, Barack",0,000160
+LINCOLN,Marion Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+LINCOLN,Marion Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000160
+LINCOLN,Marion Township,President / Vice President,,Republican,"Romney, Mitt",18,000160
+LINCOLN,Orange Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+LINCOLN,Orange Township,President / Vice President,,Democratic,"Obama, Barack",4,000170
+LINCOLN,Orange Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+LINCOLN,Orange Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+LINCOLN,Orange Township,President / Vice President,,Republican,"Romney, Mitt",28,000170
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,Democratic,"Obama, Barack",47,000180
+LINCOLN,Pleasant Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000180
+LINCOLN,Pleasant Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,Republican,"Romney, Mitt",145,000180
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,Democratic,"Obama, Barack",6,000190
+LINCOLN,Salt Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,Republican,"Romney, Mitt",22,000190
+LINCOLN,Scott Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+LINCOLN,Scott Township,President / Vice President,,Democratic,"Obama, Barack",9,000200
+LINCOLN,Scott Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000200
+LINCOLN,Scott Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000200
+LINCOLN,Scott Township,President / Vice President,,Republican,"Romney, Mitt",43,000200
+LINCOLN,Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+LINCOLN,Valley Township,President / Vice President,,Democratic,"Obama, Barack",5,000210
+LINCOLN,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+LINCOLN,Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+LINCOLN,Valley Township,President / Vice President,,Republican,"Romney, Mitt",16,000210
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+LINCOLN,Vesper Township,President / Vice President,,Democratic,"Obama, Barack",10,000220
+LINCOLN,Vesper Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000220
+LINCOLN,Vesper Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+LINCOLN,Vesper Township,President / Vice President,,Republican,"Romney, Mitt",42,000220
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Christensen, Will",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900010
+LINCOLN,Battle Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000010
+LINCOLN,Beaver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,00002A
+LINCOLN,Cedron Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000030
+LINCOLN,Colorado Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",94,000040
+LINCOLN,Elkhorn Township Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",74,00005A
+LINCOLN,Franklin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000060
+LINCOLN,Golden Belt Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000070
+LINCOLN,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000080
+LINCOLN,Hanover Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000090
+LINCOLN,Highland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000100
+LINCOLN,Indiana Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000110
+LINCOLN,Lincoln Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",188,000120
+LINCOLN,Lincoln Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",247,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00013B
+LINCOLN,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000140
+LINCOLN,Madison Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000150
+LINCOLN,Marion Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000160
+LINCOLN,Orange Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000170
+LINCOLN,Pleasant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",163,000180
+LINCOLN,Salt Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000190
+LINCOLN,Scott Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000200
+LINCOLN,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000210
+LINCOLN,Vesper Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",46,000220
+LINCOLN,Marion Township Enclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010

--- a/2012/20121106__ks__general__linn__precinct.csv
+++ b/2012/20121106__ks__general__linn__precinct.csv
@@ -1,0 +1,352 @@
+county,precinct,office,district,party,candidate,votes,vtd
+LINN,Blue Mound Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",59,000010
+LINN,Blue Mound Township,Kansas House of Representatives,4,Republican,"Read, Marty",158,000010
+LINN,Centerville Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",78,000020
+LINN,Centerville Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",126,000020
+LINN,Liberty Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",157,000030
+LINN,Liberty Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",281,000030
+LINN,Mound City Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",150,000040
+LINN,Mound City Township,Kansas House of Representatives,4,Republican,"Read, Marty",508,000040
+LINN,North Lincoln,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",257,000050
+LINN,North Lincoln,Kansas House of Representatives,4,Republican,"Read, Marty",555,000050
+LINN,North Potosi,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",116,000060
+LINN,North Potosi,Kansas House of Representatives,4,Republican,"Read, Marty",305,000060
+LINN,Paris Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",60,000070
+LINN,Paris Township,Kansas House of Representatives,4,Republican,"Read, Marty",222,000070
+LINN,Scott Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",94,000080
+LINN,Scott Township,Kansas House of Representatives,4,Republican,"Read, Marty",256,000080
+LINN,Sheridan Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",52,000090
+LINN,Sheridan Township,Kansas House of Representatives,4,Republican,"Read, Marty",193,000090
+LINN,South Lincoln,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",68,000100
+LINN,South Lincoln,Kansas House of Representatives,4,Republican,"Read, Marty",201,000100
+LINN,South Potosi,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",103,000110
+LINN,South Potosi,Kansas House of Representatives,4,Republican,"Read, Marty",272,000110
+LINN,Stanton Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",29,000120
+LINN,Stanton Township,Kansas House of Representatives,4,Republican,"Read, Marty",65,000120
+LINN,Valley Township,Kansas House of Representatives,4,Democratic,"Palmer, Shirley J.",27,000130
+LINN,Valley Township,Kansas House of Representatives,4,Republican,"Read, Marty",42,000130
+LINN,Blue Mound Township,Kansas Senate,12,Democratic,"Cassells, Denise",66,000010
+LINN,Blue Mound Township,Kansas Senate,12,Republican,"Tyson, Caryn",145,000010
+LINN,Centerville Township,Kansas Senate,12,Democratic,"Cassells, Denise",58,000020
+LINN,Centerville Township,Kansas Senate,12,Republican,"Tyson, Caryn",147,000020
+LINN,Liberty Township,Kansas Senate,12,Democratic,"Cassells, Denise",105,000030
+LINN,Liberty Township,Kansas Senate,12,Republican,"Tyson, Caryn",335,000030
+LINN,Mound City Township,Kansas Senate,12,Democratic,"Cassells, Denise",207,000040
+LINN,Mound City Township,Kansas Senate,12,Republican,"Tyson, Caryn",435,000040
+LINN,North Lincoln,Kansas Senate,12,Democratic,"Cassells, Denise",244,000050
+LINN,North Lincoln,Kansas Senate,12,Republican,"Tyson, Caryn",557,000050
+LINN,North Potosi,Kansas Senate,12,Democratic,"Cassells, Denise",151,000060
+LINN,North Potosi,Kansas Senate,12,Republican,"Tyson, Caryn",265,000060
+LINN,Paris Township,Kansas Senate,12,Democratic,"Cassells, Denise",82,000070
+LINN,Paris Township,Kansas Senate,12,Republican,"Tyson, Caryn",195,000070
+LINN,Scott Township,Kansas Senate,12,Democratic,"Cassells, Denise",109,000080
+LINN,Scott Township,Kansas Senate,12,Republican,"Tyson, Caryn",237,000080
+LINN,Sheridan Township,Kansas Senate,12,Democratic,"Cassells, Denise",63,000090
+LINN,Sheridan Township,Kansas Senate,12,Republican,"Tyson, Caryn",183,000090
+LINN,South Lincoln,Kansas Senate,12,Democratic,"Cassells, Denise",78,000100
+LINN,South Lincoln,Kansas Senate,12,Republican,"Tyson, Caryn",185,000100
+LINN,South Potosi,Kansas Senate,12,Democratic,"Cassells, Denise",106,000110
+LINN,South Potosi,Kansas Senate,12,Republican,"Tyson, Caryn",262,000110
+LINN,Stanton Township,Kansas Senate,12,Democratic,"Cassells, Denise",31,000120
+LINN,Stanton Township,Kansas Senate,12,Republican,"Tyson, Caryn",63,000120
+LINN,Valley Township,Kansas Senate,12,Democratic,"Cassells, Denise",23,000130
+LINN,Valley Township,Kansas Senate,12,Republican,"Tyson, Caryn",44,000130
+LINN,Blue Mound Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+LINN,Blue Mound Township,President / Vice President,,Democratic,"Obama, Barack",54,000010
+LINN,Blue Mound Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000010
+LINN,Blue Mound Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+LINN,Blue Mound Township,President / Vice President,,Republican,"Romney, Mitt",157,000010
+LINN,Centerville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+LINN,Centerville Township,President / Vice President,,Democratic,"Obama, Barack",49,000020
+LINN,Centerville Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+LINN,Centerville Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+LINN,Centerville Township,President / Vice President,,Republican,"Romney, Mitt",158,000020
+LINN,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",1,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+LINN,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",129,000030
+LINN,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000030
+LINN,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",6,000030
+LINN,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",302,000030
+LINN,Mound City Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+LINN,Mound City Township,President / Vice President,,Democratic,"Obama, Barack",145,000040
+LINN,Mound City Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000040
+LINN,Mound City Township,President / Vice President,,Reform,"Baldwin, Chuck",8,000040
+LINN,Mound City Township,President / Vice President,,Republican,"Romney, Mitt",502,000040
+LINN,North Lincoln,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Barnett, Andre",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Bush, Kent W",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Christensen, Will",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Goode, Virgil",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Stein, Jill E",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+LINN,North Lincoln,President / Vice President,,Democratic,"Obama, Barack",253,000050
+LINN,North Lincoln,President / Vice President,,Libertarian,"Johnson, Gary",18,000050
+LINN,North Lincoln,President / Vice President,,Reform,"Baldwin, Chuck",8,000050
+LINN,North Lincoln,President / Vice President,,Republican,"Romney, Mitt",544,000050
+LINN,North Potosi,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Barnett, Andre",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Barr, Roseanne C",1,000060
+LINN,North Potosi,President / Vice President,,write - in,"Bush, Kent W",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Christensen, Will",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Goode, Virgil",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Stein, Jill E",1,000060
+LINN,North Potosi,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+LINN,North Potosi,President / Vice President,,Democratic,"Obama, Barack",124,000060
+LINN,North Potosi,President / Vice President,,Libertarian,"Johnson, Gary",8,000060
+LINN,North Potosi,President / Vice President,,Reform,"Baldwin, Chuck",2,000060
+LINN,North Potosi,President / Vice President,,Republican,"Romney, Mitt",292,000060
+LINN,Paris Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+LINN,Paris Township,President / Vice President,,Democratic,"Obama, Barack",69,000070
+LINN,Paris Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+LINN,Paris Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000070
+LINN,Paris Township,President / Vice President,,Republican,"Romney, Mitt",206,000070
+LINN,Scott Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+LINN,Scott Township,President / Vice President,,Democratic,"Obama, Barack",97,000080
+LINN,Scott Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000080
+LINN,Scott Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000080
+LINN,Scott Township,President / Vice President,,Republican,"Romney, Mitt",252,000080
+LINN,Sheridan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+LINN,Sheridan Township,President / Vice President,,Democratic,"Obama, Barack",51,000090
+LINN,Sheridan Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000090
+LINN,Sheridan Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000090
+LINN,Sheridan Township,President / Vice President,,Republican,"Romney, Mitt",183,000090
+LINN,South Lincoln,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Barnett, Andre",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Bush, Kent W",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Christensen, Will",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Goode, Virgil",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Stein, Jill E",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+LINN,South Lincoln,President / Vice President,,Democratic,"Obama, Barack",68,000100
+LINN,South Lincoln,President / Vice President,,Libertarian,"Johnson, Gary",7,000100
+LINN,South Lincoln,President / Vice President,,Reform,"Baldwin, Chuck",3,000100
+LINN,South Lincoln,President / Vice President,,Republican,"Romney, Mitt",191,000100
+LINN,South Potosi,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Barnett, Andre",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Bush, Kent W",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Christensen, Will",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Goode, Virgil",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Stein, Jill E",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+LINN,South Potosi,President / Vice President,,Democratic,"Obama, Barack",85,000110
+LINN,South Potosi,President / Vice President,,Libertarian,"Johnson, Gary",9,000110
+LINN,South Potosi,President / Vice President,,Reform,"Baldwin, Chuck",3,000110
+LINN,South Potosi,President / Vice President,,Republican,"Romney, Mitt",277,000110
+LINN,Stanton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+LINN,Stanton Township,President / Vice President,,Democratic,"Obama, Barack",26,000120
+LINN,Stanton Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+LINN,Stanton Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000120
+LINN,Stanton Township,President / Vice President,,Republican,"Romney, Mitt",66,000120
+LINN,Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+LINN,Valley Township,President / Vice President,,Democratic,"Obama, Barack",20,000130
+LINN,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000130
+LINN,Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+LINN,Valley Township,President / Vice President,,Republican,"Romney, Mitt",47,000130
+LINN,Blue Mound Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",39,000010
+LINN,Blue Mound Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,000010
+LINN,Blue Mound Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",161,000010
+LINN,Centerville Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",36,000020
+LINN,Centerville Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000020
+LINN,Centerville Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",161,000020
+LINN,Liberty Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",88,000030
+LINN,Liberty Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,000030
+LINN,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",334,000030
+LINN,Mound City Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",123,000040
+LINN,Mound City Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,000040
+LINN,Mound City Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",504,000040
+LINN,North Lincoln,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",184,000050
+LINN,North Lincoln,United States House of Representatives,2,Libertarian,"Hawver, Dennis",37,000050
+LINN,North Lincoln,United States House of Representatives,2,Republican,"Jenkins, Lynn",581,000050
+LINN,North Potosi,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",100,000060
+LINN,North Potosi,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,000060
+LINN,North Potosi,United States House of Representatives,2,Republican,"Jenkins, Lynn",311,000060
+LINN,Paris Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",58,000070
+LINN,Paris Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000070
+LINN,Paris Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",213,000070
+LINN,Scott Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",77,000080
+LINN,Scott Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000080
+LINN,Scott Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",265,000080
+LINN,Sheridan Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",34,000090
+LINN,Sheridan Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000090
+LINN,Sheridan Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",203,000090
+LINN,South Lincoln,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",45,000100
+LINN,South Lincoln,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,000100
+LINN,South Lincoln,United States House of Representatives,2,Republican,"Jenkins, Lynn",201,000100
+LINN,South Potosi,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",56,000110
+LINN,South Potosi,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,000110
+LINN,South Potosi,United States House of Representatives,2,Republican,"Jenkins, Lynn",299,000110
+LINN,Stanton Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",18,000120
+LINN,Stanton Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000120
+LINN,Stanton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",68,000120
+LINN,Valley Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",19,000130
+LINN,Valley Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000130
+LINN,Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",43,000130

--- a/2012/20121106__ks__general__logan__precinct.csv
+++ b/2012/20121106__ks__general__logan__precinct.csv
@@ -1,0 +1,289 @@
+county,precinct,office,district,party,candidate,votes,vtd
+LOGAN,Augustine Township,Kansas House of Representatives,118,Republican,"Hineman, Don",10,000010
+LOGAN,Elkader Township,Kansas House of Representatives,118,Republican,"Hineman, Don",2,000020
+LOGAN,Lees Township,Kansas House of Representatives,118,Republican,"Hineman, Don",6,000030
+LOGAN,Logansport Township,Kansas House of Representatives,118,Republican,"Hineman, Don",3,000040
+LOGAN,McAllaster Township,Kansas House of Representatives,118,Republican,"Hineman, Don",16,000050
+LOGAN,Monument Township,Kansas House of Representatives,118,Republican,"Hineman, Don",59,000060
+LOGAN,Oakley Precinct 1,Kansas House of Representatives,118,Republican,"Hineman, Don",490,000070
+LOGAN,Oakley Precinct 2,Kansas House of Representatives,118,Republican,"Hineman, Don",389,000080
+LOGAN,Paxton Township,Kansas House of Representatives,118,Republican,"Hineman, Don",22,000090
+LOGAN,Russell Springs Township,Kansas House of Representatives,118,Republican,"Hineman, Don",21,000100
+LOGAN,Western Township,Kansas House of Representatives,118,Republican,"Hineman, Don",23,000110
+LOGAN,Winona Township,Kansas House of Representatives,118,Republican,"Hineman, Don",128,000120
+LOGAN,Augustine Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,000010
+LOGAN,Augustine Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",11,000010
+LOGAN,Elkader Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,000020
+LOGAN,Elkader Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",2,000020
+LOGAN,Lees Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",5,000030
+LOGAN,Lees Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",2,000030
+LOGAN,Logansport Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",1,000040
+LOGAN,Logansport Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",3,000040
+LOGAN,McAllaster Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",3,000050
+LOGAN,McAllaster Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",13,000050
+LOGAN,Monument Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",11,000060
+LOGAN,Monument Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",53,000060
+LOGAN,Oakley Precinct 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",117,000070
+LOGAN,Oakley Precinct 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",447,000070
+LOGAN,Oakley Precinct 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",107,000080
+LOGAN,Oakley Precinct 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",332,000080
+LOGAN,Paxton Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,000090
+LOGAN,Paxton Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",23,000090
+LOGAN,Russell Springs Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",6,000100
+LOGAN,Russell Springs Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",21,000100
+LOGAN,Western Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",2,000110
+LOGAN,Western Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",23,000110
+LOGAN,Winona Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",27,000120
+LOGAN,Winona Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",107,000120
+LOGAN,Augustine Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+LOGAN,Augustine Township,President / Vice President,,Democratic,"Obama, Barack",0,000010
+LOGAN,Augustine Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+LOGAN,Augustine Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+LOGAN,Augustine Township,President / Vice President,,Republican,"Romney, Mitt",11,000010
+LOGAN,Elkader Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+LOGAN,Elkader Township,President / Vice President,,Democratic,"Obama, Barack",0,000020
+LOGAN,Elkader Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+LOGAN,Elkader Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+LOGAN,Elkader Township,President / Vice President,,Republican,"Romney, Mitt",2,000020
+LOGAN,Lees Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+LOGAN,Lees Township,President / Vice President,,Democratic,"Obama, Barack",2,000030
+LOGAN,Lees Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+LOGAN,Lees Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+LOGAN,Lees Township,President / Vice President,,Republican,"Romney, Mitt",5,000030
+LOGAN,Logansport Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+LOGAN,Logansport Township,President / Vice President,,Democratic,"Obama, Barack",0,000040
+LOGAN,Logansport Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+LOGAN,Logansport Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+LOGAN,Logansport Township,President / Vice President,,Republican,"Romney, Mitt",4,000040
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+LOGAN,McAllaster Township,President / Vice President,,Democratic,"Obama, Barack",1,000050
+LOGAN,McAllaster Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+LOGAN,McAllaster Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000050
+LOGAN,McAllaster Township,President / Vice President,,Republican,"Romney, Mitt",15,000050
+LOGAN,Monument Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+LOGAN,Monument Township,President / Vice President,,Democratic,"Obama, Barack",9,000060
+LOGAN,Monument Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+LOGAN,Monument Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+LOGAN,Monument Township,President / Vice President,,Republican,"Romney, Mitt",57,000060
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,Democratic,"Obama, Barack",80,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",7,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",5,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,Republican,"Romney, Mitt",484,000070
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,Democratic,"Obama, Barack",74,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",7,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",5,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,Republican,"Romney, Mitt",358,000080
+LOGAN,Paxton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+LOGAN,Paxton Township,President / Vice President,,Democratic,"Obama, Barack",0,000090
+LOGAN,Paxton Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+LOGAN,Paxton Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+LOGAN,Paxton Township,President / Vice President,,Republican,"Romney, Mitt",23,000090
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,Democratic,"Obama, Barack",7,000100
+LOGAN,Russell Springs Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,Republican,"Romney, Mitt",22,000100
+LOGAN,Western Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+LOGAN,Western Township,President / Vice President,,Democratic,"Obama, Barack",0,000110
+LOGAN,Western Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+LOGAN,Western Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+LOGAN,Western Township,President / Vice President,,Republican,"Romney, Mitt",25,000110
+LOGAN,Winona Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+LOGAN,Winona Township,President / Vice President,,Democratic,"Obama, Barack",24,000120
+LOGAN,Winona Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000120
+LOGAN,Winona Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000120
+LOGAN,Winona Township,President / Vice President,,Republican,"Romney, Mitt",120,000120
+LOGAN,Augustine Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000010
+LOGAN,Elkader Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",1,000020
+LOGAN,Lees Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",5,000030
+LOGAN,Logansport Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,000040
+LOGAN,McAllaster Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000050
+LOGAN,Monument Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",60,000060
+LOGAN,Oakley Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",511,000070
+LOGAN,Oakley Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",378,000080
+LOGAN,Paxton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000090
+LOGAN,Russell Springs Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000100
+LOGAN,Western Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000110
+LOGAN,Winona Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",125,000120

--- a/2012/20121106__ks__general__lyon__precinct.csv
+++ b/2012/20121106__ks__general__lyon__precinct.csv
@@ -1,0 +1,1343 @@
+county,precinct,office,district,party,candidate,votes,vtd
+LYON,Precinct 01,Kansas House of Representatives,60,Democratic,"Ballard, William L.",149,000010
+LYON,Precinct 01,Kansas House of Representatives,60,Republican,"Hill, Don",305,000010
+LYON,Precinct 02,Kansas House of Representatives,60,Democratic,"Ballard, William L.",112,000020
+LYON,Precinct 02,Kansas House of Representatives,60,Republican,"Hill, Don",193,000020
+LYON,Precinct 03,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",166,000030
+LYON,Precinct 03,Kansas House of Representatives,76,Republican,"Mast, Peggy",229,000030
+LYON,Precinct 04,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",171,000040
+LYON,Precinct 04,Kansas House of Representatives,76,Republican,"Mast, Peggy",279,000040
+LYON,Precinct 05,Kansas House of Representatives,60,Democratic,"Ballard, William L.",116,00005A
+LYON,Precinct 05,Kansas House of Representatives,60,Republican,"Hill, Don",153,00005A
+LYON,Precinct 05 Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00005B
+LYON,Precinct 05 Part A,Kansas House of Representatives,60,Republican,"Hill, Don",0,00005B
+LYON,Precinct 05 Part B,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00005C
+LYON,Precinct 05 Part B,Kansas House of Representatives,60,Republican,"Hill, Don",0,00005C
+LYON,Precinct 06 Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",147,00006A
+LYON,Precinct 06 Part A,Kansas House of Representatives,60,Republican,"Hill, Don",184,00006A
+LYON,Precinct 06 Part A Exclave,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00006B
+LYON,Precinct 06 Part A Exclave,Kansas House of Representatives,60,Republican,"Hill, Don",0,00006B
+LYON,Precinct 06 Part B Exclave,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00006C
+LYON,Precinct 06 Part B Exclave,Kansas House of Representatives,60,Republican,"Hill, Don",0,00006C
+LYON,Precinct 07,Kansas House of Representatives,60,Democratic,"Ballard, William L.",84,000070
+LYON,Precinct 07,Kansas House of Representatives,60,Republican,"Hill, Don",101,000070
+LYON,Precinct 08,Kansas House of Representatives,60,Democratic,"Ballard, William L.",140,000080
+LYON,Precinct 08,Kansas House of Representatives,60,Republican,"Hill, Don",191,000080
+LYON,Precinct 09,Kansas House of Representatives,60,Democratic,"Ballard, William L.",103,000090
+LYON,Precinct 09,Kansas House of Representatives,60,Republican,"Hill, Don",182,000090
+LYON,Precinct 10,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",134,000100
+LYON,Precinct 10,Kansas House of Representatives,76,Republican,"Mast, Peggy",207,000100
+LYON,Precinct 11,Kansas House of Representatives,60,Democratic,"Ballard, William L.",119,000110
+LYON,Precinct 11,Kansas House of Representatives,60,Republican,"Hill, Don",185,000110
+LYON,Precinct 12,Kansas House of Representatives,60,Democratic,"Ballard, William L.",102,000120
+LYON,Precinct 12,Kansas House of Representatives,60,Republican,"Hill, Don",189,000120
+LYON,Precinct 13,Kansas House of Representatives,60,Democratic,"Ballard, William L.",151,000130
+LYON,Precinct 13,Kansas House of Representatives,60,Republican,"Hill, Don",303,000130
+LYON,Precinct 14,Kansas House of Representatives,60,Democratic,"Ballard, William L.",106,000140
+LYON,Precinct 14,Kansas House of Representatives,60,Republican,"Hill, Don",415,000140
+LYON,Precinct 15,Kansas House of Representatives,60,Democratic,"Ballard, William L.",70,000150
+LYON,Precinct 15,Kansas House of Representatives,60,Republican,"Hill, Don",226,000150
+LYON,Precinct 16,Kansas House of Representatives,60,Democratic,"Ballard, William L.",127,000160
+LYON,Precinct 16,Kansas House of Representatives,60,Republican,"Hill, Don",285,000160
+LYON,Precinct 17 Exclave Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00017A
+LYON,Precinct 17 Exclave Part A,Kansas House of Representatives,60,Republican,"Hill, Don",0,00017A
+LYON,Precinct 17 Enclave Part B,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00017B
+LYON,Precinct 17 Enclave Part B,Kansas House of Representatives,60,Republican,"Hill, Don",0,00017B
+LYON,Precinct 17,Kansas House of Representatives,60,Democratic,"Ballard, William L.",121,000170
+LYON,Precinct 17,Kansas House of Representatives,60,Republican,"Hill, Don",289,000170
+LYON,Precinct 18 Enclave Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00018A
+LYON,Precinct 18 Enclave Part A,Kansas House of Representatives,60,Republican,"Hill, Don",0,00018A
+LYON,Precinct 18,Kansas House of Representatives,60,Democratic,"Ballard, William L.",92,000180
+LYON,Precinct 18,Kansas House of Representatives,60,Republican,"Hill, Don",289,000180
+LYON,Precinct 19,Kansas House of Representatives,60,Democratic,"Ballard, William L.",148,000190
+LYON,Precinct 19,Kansas House of Representatives,60,Republican,"Hill, Don",439,000190
+LYON,Precinct 20 Exclave Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00020A
+LYON,Precinct 20 Exclave Part A,Kansas House of Representatives,60,Republican,"Hill, Don",0,00020A
+LYON,Precinct 20,Kansas House of Representatives,60,Democratic,"Ballard, William L.",114,000200
+LYON,Precinct 20,Kansas House of Representatives,60,Republican,"Hill, Don",412,000200
+LYON,Precinct 21,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",59,000210
+LYON,Precinct 21,Kansas House of Representatives,51,Republican,"Highland, Ron",119,000210
+LYON,Precinct 22,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",33,000220
+LYON,Precinct 22,Kansas House of Representatives,51,Republican,"Highland, Ron",77,000220
+LYON,Precinct 23,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",41,000230
+LYON,Precinct 23,Kansas House of Representatives,51,Republican,"Highland, Ron",88,000230
+LYON,Precinct 24,Kansas House of Representatives,60,Democratic,"Ballard, William L.",145,000240
+LYON,Precinct 24,Kansas House of Representatives,60,Republican,"Hill, Don",454,000240
+LYON,Precinct 25,Kansas House of Representatives,60,Democratic,"Ballard, William L.",94,000250
+LYON,Precinct 25,Kansas House of Representatives,60,Republican,"Hill, Don",385,000250
+LYON,Precinct 26,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",65,000260
+LYON,Precinct 26,Kansas House of Representatives,51,Republican,"Highland, Ron",130,000260
+LYON,Precinct 27,Kansas House of Representatives,60,Democratic,"Ballard, William L.",80,000270
+LYON,Precinct 27,Kansas House of Representatives,60,Republican,"Hill, Don",299,000270
+LYON,Precinct 28,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",78,00028A
+LYON,Precinct 28,Kansas House of Representatives,76,Republican,"Mast, Peggy",257,00028A
+LYON,Precinct 28 Enclave A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00028B
+LYON,Precinct 28 Enclave A,Kansas House of Representatives,60,Republican,"Hill, Don",0,00028B
+LYON,Precinct 28 Enclave Part B,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00028C
+LYON,Precinct 28 Enclave Part B,Kansas House of Representatives,60,Republican,"Hill, Don",0,00028C
+LYON,Precinct 29 Exclave Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00029A
+LYON,Precinct 29 Exclave Part A,Kansas House of Representatives,60,Republican,"Hill, Don",0,00029A
+LYON,Precinct 29,Kansas House of Representatives,60,Democratic,"Ballard, William L.",42,000290
+LYON,Precinct 29,Kansas House of Representatives,60,Republican,"Hill, Don",126,000290
+LYON,Precinct 30,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",167,000300
+LYON,Precinct 30,Kansas House of Representatives,76,Republican,"Mast, Peggy",312,000300
+LYON,Precinct 31,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",259,000310
+LYON,Precinct 31,Kansas House of Representatives,76,Republican,"Mast, Peggy",328,000310
+LYON,Precinct 32,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",144,000320
+LYON,Precinct 32,Kansas House of Representatives,76,Republican,"Mast, Peggy",217,000320
+LYON,Precinct 29 A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,120020
+LYON,Precinct 29 A,Kansas House of Representatives,60,Republican,"Hill, Don",0,120020
+LYON,Precinct 19 Exclave Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,300010
+LYON,Precinct 19 Exclave Part A,Kansas House of Representatives,60,Republican,"Hill, Don",0,300010
+LYON,Precinct 19 Exclave Part B,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,300020
+LYON,Precinct 19 Exclave Part B,Kansas House of Representatives,60,Republican,"Hill, Don",0,300020
+LYON,Precinct 09 Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,900020
+LYON,Precinct 09 Part A,Kansas House of Representatives,60,Republican,"Hill, Don",0,900020
+LYON,Precinct 29 Enclave,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,900030
+LYON,Precinct 29 Enclave,Kansas House of Representatives,60,Republican,"Hill, Don",0,900030
+LYON,Precinct 29 Enclave 2,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,900040
+LYON,Precinct 29 Enclave 2,Kansas House of Representatives,60,Republican,"Hill, Don",0,900040
+LYON,Precinct 29 Enclave 3,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,900050
+LYON,Precinct 29 Enclave 3,Kansas House of Representatives,60,Republican,"Hill, Don",0,900050
+LYON,Precinct 01,Kansas Senate,17,Democratic,"Moran, Susan K.",191,000010
+LYON,Precinct 01,Kansas Senate,17,Republican,"Longbine, Jeff",264,000010
+LYON,Precinct 02,Kansas Senate,17,Democratic,"Moran, Susan K.",141,000020
+LYON,Precinct 02,Kansas Senate,17,Republican,"Longbine, Jeff",166,000020
+LYON,Precinct 03,Kansas Senate,17,Democratic,"Moran, Susan K.",187,000030
+LYON,Precinct 03,Kansas Senate,17,Republican,"Longbine, Jeff",204,000030
+LYON,Precinct 04,Kansas Senate,17,Democratic,"Moran, Susan K.",221,000040
+LYON,Precinct 04,Kansas Senate,17,Republican,"Longbine, Jeff",233,000040
+LYON,Precinct 05,Kansas Senate,17,Democratic,"Moran, Susan K.",133,00005A
+LYON,Precinct 05,Kansas Senate,17,Republican,"Longbine, Jeff",140,00005A
+LYON,Precinct 05 Part A,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00005B
+LYON,Precinct 05 Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,00005B
+LYON,Precinct 05 Part B,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00005C
+LYON,Precinct 05 Part B,Kansas Senate,17,Republican,"Longbine, Jeff",0,00005C
+LYON,Precinct 06 Part A,Kansas Senate,17,Democratic,"Moran, Susan K.",185,00006A
+LYON,Precinct 06 Part A,Kansas Senate,17,Republican,"Longbine, Jeff",143,00006A
+LYON,Precinct 06 Part A Exclave,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00006B
+LYON,Precinct 06 Part A Exclave,Kansas Senate,17,Republican,"Longbine, Jeff",0,00006B
+LYON,Precinct 06 Part B Exclave,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00006C
+LYON,Precinct 06 Part B Exclave,Kansas Senate,17,Republican,"Longbine, Jeff",0,00006C
+LYON,Precinct 07,Kansas Senate,17,Democratic,"Moran, Susan K.",90,000070
+LYON,Precinct 07,Kansas Senate,17,Republican,"Longbine, Jeff",97,000070
+LYON,Precinct 08,Kansas Senate,17,Democratic,"Moran, Susan K.",156,000080
+LYON,Precinct 08,Kansas Senate,17,Republican,"Longbine, Jeff",175,000080
+LYON,Precinct 09,Kansas Senate,17,Democratic,"Moran, Susan K.",112,000090
+LYON,Precinct 09,Kansas Senate,17,Republican,"Longbine, Jeff",174,000090
+LYON,Precinct 10,Kansas Senate,17,Democratic,"Moran, Susan K.",125,000100
+LYON,Precinct 10,Kansas Senate,17,Republican,"Longbine, Jeff",211,000100
+LYON,Precinct 11,Kansas Senate,17,Democratic,"Moran, Susan K.",151,000110
+LYON,Precinct 11,Kansas Senate,17,Republican,"Longbine, Jeff",151,000110
+LYON,Precinct 12,Kansas Senate,17,Democratic,"Moran, Susan K.",129,000120
+LYON,Precinct 12,Kansas Senate,17,Republican,"Longbine, Jeff",164,000120
+LYON,Precinct 13,Kansas Senate,17,Democratic,"Moran, Susan K.",183,000130
+LYON,Precinct 13,Kansas Senate,17,Republican,"Longbine, Jeff",277,000130
+LYON,Precinct 14,Kansas Senate,17,Democratic,"Moran, Susan K.",179,000140
+LYON,Precinct 14,Kansas Senate,17,Republican,"Longbine, Jeff",345,000140
+LYON,Precinct 15,Kansas Senate,17,Democratic,"Moran, Susan K.",99,000150
+LYON,Precinct 15,Kansas Senate,17,Republican,"Longbine, Jeff",200,000150
+LYON,Precinct 16,Kansas Senate,17,Democratic,"Moran, Susan K.",147,000160
+LYON,Precinct 16,Kansas Senate,17,Republican,"Longbine, Jeff",268,000160
+LYON,Precinct 17 Exclave Part A,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00017A
+LYON,Precinct 17 Exclave Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,00017A
+LYON,Precinct 17 Enclave Part B,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00017B
+LYON,Precinct 17 Enclave Part B,Kansas Senate,17,Republican,"Longbine, Jeff",0,00017B
+LYON,Precinct 17,Kansas Senate,17,Democratic,"Moran, Susan K.",156,000170
+LYON,Precinct 17,Kansas Senate,17,Republican,"Longbine, Jeff",254,000170
+LYON,Precinct 18 Enclave Part A,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00018A
+LYON,Precinct 18 Enclave Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,00018A
+LYON,Precinct 18,Kansas Senate,17,Democratic,"Moran, Susan K.",98,000180
+LYON,Precinct 18,Kansas Senate,17,Republican,"Longbine, Jeff",281,000180
+LYON,Precinct 19,Kansas Senate,17,Democratic,"Moran, Susan K.",170,000190
+LYON,Precinct 19,Kansas Senate,17,Republican,"Longbine, Jeff",417,000190
+LYON,Precinct 20 Exclave Part A,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00020A
+LYON,Precinct 20 Exclave Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,00020A
+LYON,Precinct 20,Kansas Senate,17,Democratic,"Moran, Susan K.",154,000200
+LYON,Precinct 20,Kansas Senate,17,Republican,"Longbine, Jeff",373,000200
+LYON,Precinct 21,Kansas Senate,17,Democratic,"Moran, Susan K.",66,000210
+LYON,Precinct 21,Kansas Senate,17,Republican,"Longbine, Jeff",131,000210
+LYON,Precinct 22,Kansas Senate,17,Democratic,"Moran, Susan K.",35,000220
+LYON,Precinct 22,Kansas Senate,17,Republican,"Longbine, Jeff",76,000220
+LYON,Precinct 23,Kansas Senate,17,Democratic,"Moran, Susan K.",50,000230
+LYON,Precinct 23,Kansas Senate,17,Republican,"Longbine, Jeff",88,000230
+LYON,Precinct 24,Kansas Senate,17,Democratic,"Moran, Susan K.",201,000240
+LYON,Precinct 24,Kansas Senate,17,Republican,"Longbine, Jeff",399,000240
+LYON,Precinct 25,Kansas Senate,17,Democratic,"Moran, Susan K.",132,000250
+LYON,Precinct 25,Kansas Senate,17,Republican,"Longbine, Jeff",348,000250
+LYON,Precinct 26,Kansas Senate,17,Democratic,"Moran, Susan K.",78,000260
+LYON,Precinct 26,Kansas Senate,17,Republican,"Longbine, Jeff",140,000260
+LYON,Precinct 27,Kansas Senate,17,Democratic,"Moran, Susan K.",110,000270
+LYON,Precinct 27,Kansas Senate,17,Republican,"Longbine, Jeff",269,000270
+LYON,Precinct 28,Kansas Senate,17,Democratic,"Moran, Susan K.",117,00028A
+LYON,Precinct 28,Kansas Senate,17,Republican,"Longbine, Jeff",214,00028A
+LYON,Precinct 28 Enclave A,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00028B
+LYON,Precinct 28 Enclave A,Kansas Senate,17,Republican,"Longbine, Jeff",0,00028B
+LYON,Precinct 28 Enclave Part B,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00028C
+LYON,Precinct 28 Enclave Part B,Kansas Senate,17,Republican,"Longbine, Jeff",0,00028C
+LYON,Precinct 29 Exclave Part A,Kansas Senate,17,Democratic,"Moran, Susan K.",0,00029A
+LYON,Precinct 29 Exclave Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,00029A
+LYON,Precinct 29,Kansas Senate,17,Democratic,"Moran, Susan K.",55,000290
+LYON,Precinct 29,Kansas Senate,17,Republican,"Longbine, Jeff",113,000290
+LYON,Precinct 30,Kansas Senate,17,Democratic,"Moran, Susan K.",165,000300
+LYON,Precinct 30,Kansas Senate,17,Republican,"Longbine, Jeff",308,000300
+LYON,Precinct 31,Kansas Senate,17,Democratic,"Moran, Susan K.",185,000310
+LYON,Precinct 31,Kansas Senate,17,Republican,"Longbine, Jeff",403,000310
+LYON,Precinct 32,Kansas Senate,17,Democratic,"Moran, Susan K.",150,000320
+LYON,Precinct 32,Kansas Senate,17,Republican,"Longbine, Jeff",212,000320
+LYON,Precinct 29 A,Kansas Senate,17,Democratic,"Moran, Susan K.",0,120020
+LYON,Precinct 29 A,Kansas Senate,17,Republican,"Longbine, Jeff",0,120020
+LYON,Precinct 19 Exclave Part A,Kansas Senate,17,Democratic,"Moran, Susan K.",0,300010
+LYON,Precinct 19 Exclave Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,300010
+LYON,Precinct 19 Exclave Part B,Kansas Senate,17,Democratic,"Moran, Susan K.",0,300020
+LYON,Precinct 19 Exclave Part B,Kansas Senate,17,Republican,"Longbine, Jeff",0,300020
+LYON,Precinct 04 Part A,Kansas Senate,17,Democratic,"Moran, Susan K.",0,400010
+LYON,Precinct 04 Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,400010
+LYON,Precinct 04 Part B,Kansas Senate,17,Democratic,"Moran, Susan K.",0,400020
+LYON,Precinct 04 Part B,Kansas Senate,17,Republican,"Longbine, Jeff",0,400020
+LYON,Precinct 04 Part C,Kansas Senate,17,Democratic,"Moran, Susan K.",0,400030
+LYON,Precinct 04 Part C,Kansas Senate,17,Republican,"Longbine, Jeff",0,400030
+LYON,Precinct 04 Part D,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900010
+LYON,Precinct 04 Part D,Kansas Senate,17,Republican,"Longbine, Jeff",0,900010
+LYON,Precinct 09 Part A,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900020
+LYON,Precinct 09 Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,900020
+LYON,Precinct 29 Enclave,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900030
+LYON,Precinct 29 Enclave,Kansas Senate,17,Republican,"Longbine, Jeff",0,900030
+LYON,Precinct 29 Enclave 2,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900040
+LYON,Precinct 29 Enclave 2,Kansas Senate,17,Republican,"Longbine, Jeff",0,900040
+LYON,Precinct 29 Enclave 3,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900050
+LYON,Precinct 29 Enclave 3,Kansas Senate,17,Republican,"Longbine, Jeff",0,900050
+LYON,Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Stein, Jill E",1,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+LYON,Precinct 01,President / Vice President,,Democratic,"Obama, Barack",270,000010
+LYON,Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",5,000010
+LYON,Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+LYON,Precinct 01,President / Vice President,,Republican,"Romney, Mitt",196,000010
+LYON,Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+LYON,Precinct 02,President / Vice President,,Democratic,"Obama, Barack",176,000020
+LYON,Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",6,000020
+LYON,Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",3,000020
+LYON,Precinct 02,President / Vice President,,Republican,"Romney, Mitt",134,000020
+LYON,Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+LYON,Precinct 03,President / Vice President,,Democratic,"Obama, Barack",208,000030
+LYON,Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",6,000030
+LYON,Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+LYON,Precinct 03,President / Vice President,,Republican,"Romney, Mitt",193,000030
+LYON,Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Stein, Jill E",1,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+LYON,Precinct 04,President / Vice President,,Democratic,"Obama, Barack",253,000040
+LYON,Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",14,000040
+LYON,Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+LYON,Precinct 04,President / Vice President,,Republican,"Romney, Mitt",191,000040
+LYON,Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,00005A
+LYON,Precinct 05,President / Vice President,,Democratic,"Obama, Barack",161,00005A
+LYON,Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",5,00005A
+LYON,Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",2,00005A
+LYON,Precinct 05,President / Vice President,,Republican,"Romney, Mitt",112,00005A
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Barnett, Andre",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Bush, Kent W",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Christensen, Will",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Goode, Virgil",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Stein, Jill E",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,Democratic,"Obama, Barack",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,Reform,"Baldwin, Chuck",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,Republican,"Romney, Mitt",0,00005B
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Ayers, Avery L",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Barnett, Andre",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Bush, Kent W",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Christensen, Will",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Duncan, Richard A",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Goode, Virgil",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Knill, Dennis J",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Reed, Jill A.",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Rogers, Rick L",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Stein, Jill E",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,Democratic,"Obama, Barack",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,Republican,"Romney, Mitt",0,00005C
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Barnett, Andre",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Bush, Kent W",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Christensen, Will",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Goode, Virgil",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Stein, Jill E",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,Democratic,"Obama, Barack",220,00006A
+LYON,Precinct 06 Part A,President / Vice President,,Libertarian,"Johnson, Gary",5,00006A
+LYON,Precinct 06 Part A,President / Vice President,,Reform,"Baldwin, Chuck",3,00006A
+LYON,Precinct 06 Part A,President / Vice President,,Republican,"Romney, Mitt",121,00006A
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Christensen, Will",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00006B
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Christensen, Will",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00006C
+LYON,Precinct 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Barnett, Andre",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Bush, Kent W",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Christensen, Will",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Goode, Virgil",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Stein, Jill E",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+LYON,Precinct 07,President / Vice President,,Democratic,"Obama, Barack",116,000070
+LYON,Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+LYON,Precinct 07,President / Vice President,,Reform,"Baldwin, Chuck",2,000070
+LYON,Precinct 07,President / Vice President,,Republican,"Romney, Mitt",76,000070
+LYON,Precinct 08,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Barnett, Andre",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Bush, Kent W",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Christensen, Will",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Goode, Virgil",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Stein, Jill E",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+LYON,Precinct 08,President / Vice President,,Democratic,"Obama, Barack",186,000080
+LYON,Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",13,000080
+LYON,Precinct 08,President / Vice President,,Reform,"Baldwin, Chuck",2,000080
+LYON,Precinct 08,President / Vice President,,Republican,"Romney, Mitt",138,000080
+LYON,Precinct 09,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Barnett, Andre",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Bush, Kent W",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Christensen, Will",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Goode, Virgil",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Stein, Jill E",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+LYON,Precinct 09,President / Vice President,,Democratic,"Obama, Barack",140,000090
+LYON,Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",4,000090
+LYON,Precinct 09,President / Vice President,,Reform,"Baldwin, Chuck",4,000090
+LYON,Precinct 09,President / Vice President,,Republican,"Romney, Mitt",148,000090
+LYON,Precinct 10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Barnett, Andre",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Bush, Kent W",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Christensen, Will",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Goode, Virgil",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Stein, Jill E",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+LYON,Precinct 10,President / Vice President,,Democratic,"Obama, Barack",171,000100
+LYON,Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",9,000100
+LYON,Precinct 10,President / Vice President,,Reform,"Baldwin, Chuck",5,000100
+LYON,Precinct 10,President / Vice President,,Republican,"Romney, Mitt",165,000100
+LYON,Precinct 11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Barnett, Andre",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Bush, Kent W",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Christensen, Will",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Goode, Virgil",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Stein, Jill E",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+LYON,Precinct 11,President / Vice President,,Democratic,"Obama, Barack",151,000110
+LYON,Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",10,000110
+LYON,Precinct 11,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+LYON,Precinct 11,President / Vice President,,Republican,"Romney, Mitt",147,000110
+LYON,Precinct 12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Barnett, Andre",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Bush, Kent W",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Christensen, Will",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Goode, Virgil",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Stein, Jill E",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+LYON,Precinct 12,President / Vice President,,Democratic,"Obama, Barack",147,000120
+LYON,Precinct 12,President / Vice President,,Libertarian,"Johnson, Gary",8,000120
+LYON,Precinct 12,President / Vice President,,Reform,"Baldwin, Chuck",1,000120
+LYON,Precinct 12,President / Vice President,,Republican,"Romney, Mitt",146,000120
+LYON,Precinct 13,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Barnett, Andre",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Bush, Kent W",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Christensen, Will",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Goode, Virgil",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Stein, Jill E",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+LYON,Precinct 13,President / Vice President,,Democratic,"Obama, Barack",206,000130
+LYON,Precinct 13,President / Vice President,,Libertarian,"Johnson, Gary",11,000130
+LYON,Precinct 13,President / Vice President,,Reform,"Baldwin, Chuck",3,000130
+LYON,Precinct 13,President / Vice President,,Republican,"Romney, Mitt",255,000130
+LYON,Precinct 14,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Barnett, Andre",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Bush, Kent W",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Christensen, Will",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Goode, Virgil",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Stein, Jill E",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+LYON,Precinct 14,President / Vice President,,Democratic,"Obama, Barack",250,000140
+LYON,Precinct 14,President / Vice President,,Libertarian,"Johnson, Gary",8,000140
+LYON,Precinct 14,President / Vice President,,Reform,"Baldwin, Chuck",2,000140
+LYON,Precinct 14,President / Vice President,,Republican,"Romney, Mitt",267,000140
+LYON,Precinct 15,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Barnett, Andre",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Bush, Kent W",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Christensen, Will",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Goode, Virgil",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Stein, Jill E",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+LYON,Precinct 15,President / Vice President,,Democratic,"Obama, Barack",126,000150
+LYON,Precinct 15,President / Vice President,,Libertarian,"Johnson, Gary",3,000150
+LYON,Precinct 15,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+LYON,Precinct 15,President / Vice President,,Republican,"Romney, Mitt",176,000150
+LYON,Precinct 16,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Barnett, Andre",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Bush, Kent W",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Christensen, Will",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Goode, Virgil",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Stein, Jill E",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+LYON,Precinct 16,President / Vice President,,Democratic,"Obama, Barack",191,000160
+LYON,Precinct 16,President / Vice President,,Libertarian,"Johnson, Gary",4,000160
+LYON,Precinct 16,President / Vice President,,Reform,"Baldwin, Chuck",2,000160
+LYON,Precinct 16,President / Vice President,,Republican,"Romney, Mitt",231,000160
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Barnett, Andre",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Bush, Kent W",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Christensen, Will",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Goode, Virgil",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Stein, Jill E",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,Democratic,"Obama, Barack",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,Reform,"Baldwin, Chuck",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,Republican,"Romney, Mitt",0,00017A
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Ayers, Avery L",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Barnett, Andre",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Bush, Kent W",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Christensen, Will",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Duncan, Richard A",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Goode, Virgil",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Knill, Dennis J",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Reed, Jill A.",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Rogers, Rick L",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Stein, Jill E",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,Democratic,"Obama, Barack",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,Republican,"Romney, Mitt",0,00017B
+LYON,Precinct 17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Barnett, Andre",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Bush, Kent W",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Christensen, Will",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Goode, Virgil",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Stein, Jill E",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+LYON,Precinct 17,President / Vice President,,Democratic,"Obama, Barack",197,000170
+LYON,Precinct 17,President / Vice President,,Libertarian,"Johnson, Gary",9,000170
+LYON,Precinct 17,President / Vice President,,Reform,"Baldwin, Chuck",3,000170
+LYON,Precinct 17,President / Vice President,,Republican,"Romney, Mitt",215,000170
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Barnett, Andre",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Bush, Kent W",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Christensen, Will",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Goode, Virgil",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Stein, Jill E",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,Democratic,"Obama, Barack",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,Reform,"Baldwin, Chuck",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,Republican,"Romney, Mitt",0,00018A
+LYON,Precinct 18,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Barnett, Andre",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Bush, Kent W",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Christensen, Will",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Goode, Virgil",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Stein, Jill E",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+LYON,Precinct 18,President / Vice President,,Democratic,"Obama, Barack",151,000180
+LYON,Precinct 18,President / Vice President,,Libertarian,"Johnson, Gary",8,000180
+LYON,Precinct 18,President / Vice President,,Reform,"Baldwin, Chuck",1,000180
+LYON,Precinct 18,President / Vice President,,Republican,"Romney, Mitt",229,000180
+LYON,Precinct 19,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Barnett, Andre",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Bush, Kent W",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Christensen, Will",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Goode, Virgil",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Stein, Jill E",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+LYON,Precinct 19,President / Vice President,,Democratic,"Obama, Barack",260,000190
+LYON,Precinct 19,President / Vice President,,Libertarian,"Johnson, Gary",5,000190
+LYON,Precinct 19,President / Vice President,,Reform,"Baldwin, Chuck",5,000190
+LYON,Precinct 19,President / Vice President,,Republican,"Romney, Mitt",329,000190
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Barnett, Andre",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Bush, Kent W",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Christensen, Will",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Goode, Virgil",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Stein, Jill E",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,Democratic,"Obama, Barack",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,Reform,"Baldwin, Chuck",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,Republican,"Romney, Mitt",0,00020A
+LYON,Precinct 20,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Barnett, Andre",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Bush, Kent W",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Christensen, Will",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Goode, Virgil",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Stein, Jill E",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+LYON,Precinct 20,President / Vice President,,Democratic,"Obama, Barack",218,000200
+LYON,Precinct 20,President / Vice President,,Libertarian,"Johnson, Gary",3,000200
+LYON,Precinct 20,President / Vice President,,Reform,"Baldwin, Chuck",2,000200
+LYON,Precinct 20,President / Vice President,,Republican,"Romney, Mitt",314,000200
+LYON,Precinct 21,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Barnett, Andre",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Bush, Kent W",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Christensen, Will",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Goode, Virgil",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Stein, Jill E",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+LYON,Precinct 21,President / Vice President,,Democratic,"Obama, Barack",68,000210
+LYON,Precinct 21,President / Vice President,,Libertarian,"Johnson, Gary",2,000210
+LYON,Precinct 21,President / Vice President,,Reform,"Baldwin, Chuck",1,000210
+LYON,Precinct 21,President / Vice President,,Republican,"Romney, Mitt",128,000210
+LYON,Precinct 22,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Barnett, Andre",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Bush, Kent W",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Christensen, Will",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Goode, Virgil",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Stein, Jill E",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+LYON,Precinct 22,President / Vice President,,Democratic,"Obama, Barack",36,000220
+LYON,Precinct 22,President / Vice President,,Libertarian,"Johnson, Gary",1,000220
+LYON,Precinct 22,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+LYON,Precinct 22,President / Vice President,,Republican,"Romney, Mitt",73,000220
+LYON,Precinct 23,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Barnett, Andre",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Bush, Kent W",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Christensen, Will",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Goode, Virgil",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Stein, Jill E",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+LYON,Precinct 23,President / Vice President,,Democratic,"Obama, Barack",46,000230
+LYON,Precinct 23,President / Vice President,,Libertarian,"Johnson, Gary",6,000230
+LYON,Precinct 23,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+LYON,Precinct 23,President / Vice President,,Republican,"Romney, Mitt",87,000230
+LYON,Precinct 24,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Barnett, Andre",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Bush, Kent W",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Christensen, Will",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Goode, Virgil",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Stein, Jill E",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+LYON,Precinct 24,President / Vice President,,Democratic,"Obama, Barack",198,000240
+LYON,Precinct 24,President / Vice President,,Libertarian,"Johnson, Gary",12,000240
+LYON,Precinct 24,President / Vice President,,Reform,"Baldwin, Chuck",5,000240
+LYON,Precinct 24,President / Vice President,,Republican,"Romney, Mitt",400,000240
+LYON,Precinct 25,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Barnett, Andre",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Bush, Kent W",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Christensen, Will",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Goode, Virgil",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Stein, Jill E",1,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+LYON,Precinct 25,President / Vice President,,Democratic,"Obama, Barack",139,000250
+LYON,Precinct 25,President / Vice President,,Libertarian,"Johnson, Gary",6,000250
+LYON,Precinct 25,President / Vice President,,Reform,"Baldwin, Chuck",1,000250
+LYON,Precinct 25,President / Vice President,,Republican,"Romney, Mitt",337,000250
+LYON,Precinct 26,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Barnett, Andre",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Bush, Kent W",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Christensen, Will",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Goode, Virgil",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Stein, Jill E",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+LYON,Precinct 26,President / Vice President,,Democratic,"Obama, Barack",83,000260
+LYON,Precinct 26,President / Vice President,,Libertarian,"Johnson, Gary",6,000260
+LYON,Precinct 26,President / Vice President,,Reform,"Baldwin, Chuck",2,000260
+LYON,Precinct 26,President / Vice President,,Republican,"Romney, Mitt",129,000260
+LYON,Precinct 27,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Barnett, Andre",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Bush, Kent W",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Christensen, Will",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Goode, Virgil",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Stein, Jill E",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+LYON,Precinct 27,President / Vice President,,Democratic,"Obama, Barack",131,000270
+LYON,Precinct 27,President / Vice President,,Libertarian,"Johnson, Gary",11,000270
+LYON,Precinct 27,President / Vice President,,Reform,"Baldwin, Chuck",4,000270
+LYON,Precinct 27,President / Vice President,,Republican,"Romney, Mitt",248,000270
+LYON,Precinct 28,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Ayers, Avery L",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Barnett, Andre",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Barr, Roseanne C",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Bush, Kent W",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Christensen, Will",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Duncan, Richard A",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Goode, Virgil",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Hoefling, Tom",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Knill, Dennis J",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Reed, Jill A.",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Rogers, Rick L",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Stein, Jill E",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Thorne, Kevin M",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Warner, Gerald L.",0,00028A
+LYON,Precinct 28,President / Vice President,,Democratic,"Obama, Barack",107,00028A
+LYON,Precinct 28,President / Vice President,,Libertarian,"Johnson, Gary",6,00028A
+LYON,Precinct 28,President / Vice President,,Reform,"Baldwin, Chuck",1,00028A
+LYON,Precinct 28,President / Vice President,,Republican,"Romney, Mitt",224,00028A
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Barnett, Andre",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Bush, Kent W",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Christensen, Will",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Goode, Virgil",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Stein, Jill E",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,Democratic,"Obama, Barack",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,Republican,"Romney, Mitt",0,00028B
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Ayers, Avery L",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Barnett, Andre",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Bush, Kent W",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Christensen, Will",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Duncan, Richard A",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Goode, Virgil",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Knill, Dennis J",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Reed, Jill A.",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Rogers, Rick L",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Stein, Jill E",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,Democratic,"Obama, Barack",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,Republican,"Romney, Mitt",0,00028C
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Barnett, Andre",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Bush, Kent W",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Christensen, Will",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Goode, Virgil",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Stein, Jill E",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,Democratic,"Obama, Barack",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,Reform,"Baldwin, Chuck",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,Republican,"Romney, Mitt",0,00029A
+LYON,Precinct 29,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Barnett, Andre",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Bush, Kent W",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Christensen, Will",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Goode, Virgil",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Stein, Jill E",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+LYON,Precinct 29,President / Vice President,,Democratic,"Obama, Barack",43,000290
+LYON,Precinct 29,President / Vice President,,Libertarian,"Johnson, Gary",3,000290
+LYON,Precinct 29,President / Vice President,,Reform,"Baldwin, Chuck",1,000290
+LYON,Precinct 29,President / Vice President,,Republican,"Romney, Mitt",121,000290
+LYON,Precinct 30,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Barnett, Andre",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Bush, Kent W",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Christensen, Will",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Goode, Virgil",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Stein, Jill E",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+LYON,Precinct 30,President / Vice President,,Democratic,"Obama, Barack",161,000300
+LYON,Precinct 30,President / Vice President,,Libertarian,"Johnson, Gary",12,000300
+LYON,Precinct 30,President / Vice President,,Reform,"Baldwin, Chuck",3,000300
+LYON,Precinct 30,President / Vice President,,Republican,"Romney, Mitt",304,000300
+LYON,Precinct 31,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Barnett, Andre",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Bush, Kent W",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Christensen, Will",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Goode, Virgil",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Stein, Jill E",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+LYON,Precinct 31,President / Vice President,,Democratic,"Obama, Barack",171,000310
+LYON,Precinct 31,President / Vice President,,Libertarian,"Johnson, Gary",10,000310
+LYON,Precinct 31,President / Vice President,,Reform,"Baldwin, Chuck",1,000310
+LYON,Precinct 31,President / Vice President,,Republican,"Romney, Mitt",415,000310
+LYON,Precinct 32,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Barnett, Andre",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Bush, Kent W",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Christensen, Will",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Goode, Virgil",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Stein, Jill E",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+LYON,Precinct 32,President / Vice President,,Democratic,"Obama, Barack",130,000320
+LYON,Precinct 32,President / Vice President,,Libertarian,"Johnson, Gary",13,000320
+LYON,Precinct 32,President / Vice President,,Reform,"Baldwin, Chuck",2,000320
+LYON,Precinct 32,President / Vice President,,Republican,"Romney, Mitt",221,000320
+LYON,Precinct 29 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Barnett, Andre",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Bush, Kent W",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Christensen, Will",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Goode, Virgil",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Stein, Jill E",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+LYON,Precinct 29 A,President / Vice President,,Democratic,"Obama, Barack",0,120020
+LYON,Precinct 29 A,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+LYON,Precinct 29 A,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+LYON,Precinct 29 A,President / Vice President,,Republican,"Romney, Mitt",0,120020
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Ayers, Avery L",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Barnett, Andre",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Bush, Kent W",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Christensen, Will",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Duncan, Richard A",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Goode, Virgil",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Hoefling, Tom",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Knill, Dennis J",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Reed, Jill A.",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Rogers, Rick L",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Stein, Jill E",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,Democratic,"Obama, Barack",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,Reform,"Baldwin, Chuck",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,Republican,"Romney, Mitt",0,300010
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Ayers, Avery L",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Barnett, Andre",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Bush, Kent W",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Christensen, Will",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Duncan, Richard A",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Goode, Virgil",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Hoefling, Tom",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Knill, Dennis J",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Reed, Jill A.",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Rogers, Rick L",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Stein, Jill E",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,Democratic,"Obama, Barack",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,Republican,"Romney, Mitt",0,300020
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Barnett, Andre",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Bush, Kent W",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Christensen, Will",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Goode, Virgil",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Stein, Jill E",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,Democratic,"Obama, Barack",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,Reform,"Baldwin, Chuck",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,Republican,"Romney, Mitt",0,400010
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Ayers, Avery L",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Barnett, Andre",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Bush, Kent W",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Christensen, Will",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Duncan, Richard A",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Goode, Virgil",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Knill, Dennis J",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Reed, Jill A.",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Rogers, Rick L",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Stein, Jill E",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,Democratic,"Obama, Barack",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,Republican,"Romney, Mitt",0,400020
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Ayers, Avery L",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Barnett, Andre",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Barr, Roseanne C",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Bush, Kent W",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Christensen, Will",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Duncan, Richard A",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Goode, Virgil",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Hoefling, Tom",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Knill, Dennis J",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Reed, Jill A.",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Rogers, Rick L",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Stein, Jill E",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Thorne, Kevin M",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Warner, Gerald L.",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,Democratic,"Obama, Barack",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,Libertarian,"Johnson, Gary",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,Reform,"Baldwin, Chuck",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,Republican,"Romney, Mitt",0,400030
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Barnett, Andre",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Bush, Kent W",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Christensen, Will",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Goode, Virgil",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Stein, Jill E",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,Democratic,"Obama, Barack",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,Republican,"Romney, Mitt",0,900010
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Barnett, Andre",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Bush, Kent W",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Christensen, Will",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Goode, Virgil",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Stein, Jill E",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,Democratic,"Obama, Barack",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,Republican,"Romney, Mitt",0,900020
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Barnett, Andre",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Bush, Kent W",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Christensen, Will",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Goode, Virgil",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Stein, Jill E",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,Democratic,"Obama, Barack",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,Republican,"Romney, Mitt",0,900030
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Christensen, Will",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900040
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Ayers, Avery L",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Barnett, Andre",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Barr, Roseanne C",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Bush, Kent W",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Christensen, Will",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Duncan, Richard A",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Goode, Virgil",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Knill, Dennis J",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Reed, Jill A.",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Rogers, Rick L",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Stein, Jill E",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Thorne, Kevin M",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Warner, Gerald L.",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,Democratic,"Obama, Barack",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,Reform,"Baldwin, Chuck",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,Republican,"Romney, Mitt",0,900050
+LYON,Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",294,000010
+LYON,Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",225,000020
+LYON,Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",287,000030
+LYON,Precinct 04,United States House of Representatives,1,Republican,"Huelskamp, Tim",336,000040
+LYON,Precinct 05,United States House of Representatives,1,Republican,"Huelskamp, Tim",209,00005A
+LYON,Precinct 05 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00005B
+LYON,Precinct 05 Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00005C
+LYON,Precinct 06 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",213,00006A
+LYON,Precinct 06 Part A Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006B
+LYON,Precinct 06 Part B Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006C
+LYON,Precinct 07,United States House of Representatives,1,Republican,"Huelskamp, Tim",134,000070
+LYON,Precinct 08,United States House of Representatives,1,Republican,"Huelskamp, Tim",232,000080
+LYON,Precinct 09,United States House of Representatives,1,Republican,"Huelskamp, Tim",223,000090
+LYON,Precinct 10,United States House of Representatives,1,Republican,"Huelskamp, Tim",253,000100
+LYON,Precinct 11,United States House of Representatives,1,Republican,"Huelskamp, Tim",214,000110
+LYON,Precinct 12,United States House of Representatives,1,Republican,"Huelskamp, Tim",221,000120
+LYON,Precinct 13,United States House of Representatives,1,Republican,"Huelskamp, Tim",350,000130
+LYON,Precinct 14,United States House of Representatives,1,Republican,"Huelskamp, Tim",352,000140
+LYON,Precinct 15,United States House of Representatives,1,Republican,"Huelskamp, Tim",210,000150
+LYON,Precinct 16,United States House of Representatives,1,Republican,"Huelskamp, Tim",289,000160
+LYON,Precinct 17 Exclave Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00017A
+LYON,Precinct 17 Enclave Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00017B
+LYON,Precinct 17,United States House of Representatives,1,Republican,"Huelskamp, Tim",306,000170
+LYON,Precinct 18 Enclave Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00018A
+LYON,Precinct 18,United States House of Representatives,1,Republican,"Huelskamp, Tim",287,000180
+LYON,Precinct 19,United States House of Representatives,1,Republican,"Huelskamp, Tim",434,000190
+LYON,Precinct 20 Exclave Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00020A
+LYON,Precinct 20,United States House of Representatives,1,Republican,"Huelskamp, Tim",409,000200
+LYON,Precinct 21,United States House of Representatives,1,Republican,"Huelskamp, Tim",148,000210
+LYON,Precinct 22,United States House of Representatives,1,Republican,"Huelskamp, Tim",94,000220
+LYON,Precinct 23,United States House of Representatives,1,Republican,"Huelskamp, Tim",103,000230
+LYON,Precinct 24,United States House of Representatives,1,Republican,"Huelskamp, Tim",502,000240
+LYON,Precinct 25,United States House of Representatives,1,Republican,"Huelskamp, Tim",390,000250
+LYON,Precinct 26,United States House of Representatives,1,Republican,"Huelskamp, Tim",175,000260
+LYON,Precinct 27,United States House of Representatives,1,Republican,"Huelskamp, Tim",317,000270
+LYON,Precinct 28,United States House of Representatives,1,Republican,"Huelskamp, Tim",255,00028A
+LYON,Precinct 28 Enclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00028B
+LYON,Precinct 28 Enclave Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00028C
+LYON,Precinct 29 Exclave Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00029A
+LYON,Precinct 29,United States House of Representatives,1,Republican,"Huelskamp, Tim",132,000290
+LYON,Precinct 30,United States House of Representatives,1,Republican,"Huelskamp, Tim",370,000300
+LYON,Precinct 31,United States House of Representatives,1,Republican,"Huelskamp, Tim",486,000310
+LYON,Precinct 32,United States House of Representatives,1,Republican,"Huelskamp, Tim",291,000320
+LYON,Precinct 29 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120020
+LYON,Precinct 19 Exclave Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,300010
+LYON,Precinct 19 Exclave Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,300020
+LYON,Precinct 04 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,400010
+LYON,Precinct 04 Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,400020
+LYON,Precinct 04 Part C,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,400030
+LYON,Precinct 04 Part D,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+LYON,Precinct 09 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+LYON,Precinct 29 Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900030
+LYON,Precinct 29 Enclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900040
+LYON,Precinct 29 Enclave 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900050

--- a/2012/20121106__ks__general__marion__precinct.csv
+++ b/2012/20121106__ks__general__marion__precinct.csv
@@ -1,0 +1,869 @@
+county,precinct,office,district,party,candidate,votes,vtd
+MARION,Blaine Township,Kansas House of Representatives,70,Republican,"Barker, John E",65,000010
+MARION,Catlin Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",70,000020
+MARION,Centre Township,Kansas House of Representatives,70,Republican,"Barker, John E",240,000030
+MARION,Clark Township,Kansas House of Representatives,70,Republican,"Barker, John E",54,000040
+MARION,Clear Creek Township,Kansas House of Representatives,70,Republican,"Barker, John E",191,000050
+MARION,Colfax Township,Kansas House of Representatives,70,Republican,"Barker, John E",84,000060
+MARION,Doyle Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",14,000070
+MARION,Durham Park Township,Kansas House of Representatives,70,Republican,"Barker, John E",87,000080
+MARION,East Branch Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",92,000090
+MARION,Fairplay Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",53,000100
+MARION,Florence Ward 1,Kansas House of Representatives,74,Republican,"Schroeder, Don",66,00011A
+MARION,Florence Ward 1 Exclave,Kansas House of Representatives,74,Republican,"Schroeder, Don",0,00011B
+MARION,Florence Ward 2,Kansas House of Representatives,74,Republican,"Schroeder, Don",76,000120
+MARION,Gale Township,Kansas House of Representatives,70,Republican,"Barker, John E",82,000130
+MARION,Grant Township,Kansas House of Representatives,70,Republican,"Barker, John E",51,000140
+MARION,Hillsboro Ward 1,Kansas House of Representatives,74,Republican,"Schroeder, Don",473,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Kansas House of Representatives,74,Republican,"Schroeder, Don",0,00016C
+MARION,Lehigh Township,Kansas House of Representatives,70,Republican,"Barker, John E",111,000170
+MARION,Liberty Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",150,000180
+MARION,Logan Township,Kansas House of Representatives,70,Republican,"Barker, John E",19,000190
+MARION,Lost Springs Township,Kansas House of Representatives,70,Republican,"Barker, John E",77,000200
+MARION,Marion North Ward,Kansas House of Representatives,70,Republican,"Barker, John E",348,000210
+MARION,Marion South Ward,Kansas House of Representatives,70,Republican,"Barker, John E",317,00022A
+MARION,Marion South Ward Exclave,Kansas House of Representatives,70,Republican,"Barker, John E",0,00022B
+MARION,Menno Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",158,000230
+MARION,Milton Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",90,000240
+MARION,Moore Township,Kansas House of Representatives,70,Republican,"Barker, John E",26,000250
+MARION,Peabody East,Kansas House of Representatives,74,Republican,"Schroeder, Don",153,000260
+MARION,Peabody West,Kansas House of Representatives,74,Republican,"Schroeder, Don",244,000270
+MARION,Risley Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",118,000280
+MARION,Summit Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",30,000290
+MARION,West Branch Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",360,000300
+MARION,Wilson Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",81,000310
+MARION,ENT TEST,Kansas House of Representatives,74,Republican,"Schroeder, Don",0,120001
+MARION,Hillsboro Ward 2,Kansas House of Representatives,74,Republican,"Schroeder, Don",585,900010
+MARION,Hillsboro Ward 2 Exclave A,Kansas House of Representatives,74,Republican,"Schroeder, Don",0,900020
+MARION,SUPPLEMENTAL VOTES,Kansas House of Representatives,70,Republican,"Barker, John E",1,999001
+MARION,Blaine Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",21,000010
+MARION,Blaine Township,Kansas Senate,35,Republican,"Emler, Jay Scott",55,000010
+MARION,Catlin Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",27,000020
+MARION,Catlin Township,Kansas Senate,35,Republican,"Emler, Jay Scott",54,000020
+MARION,Centre Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",82,000030
+MARION,Centre Township,Kansas Senate,35,Republican,"Emler, Jay Scott",191,000030
+MARION,Clark Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",15,000040
+MARION,Clark Township,Kansas Senate,35,Republican,"Emler, Jay Scott",46,000040
+MARION,Clear Creek Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",58,000050
+MARION,Clear Creek Township,Kansas Senate,35,Republican,"Emler, Jay Scott",152,000050
+MARION,Colfax Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",35,000060
+MARION,Colfax Township,Kansas Senate,35,Republican,"Emler, Jay Scott",58,000060
+MARION,Doyle Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",6,000070
+MARION,Doyle Township,Kansas Senate,35,Republican,"Emler, Jay Scott",13,000070
+MARION,Durham Park Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",24,000080
+MARION,Durham Park Township,Kansas Senate,35,Republican,"Emler, Jay Scott",71,000080
+MARION,East Branch Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",27,000090
+MARION,East Branch Township,Kansas Senate,35,Republican,"Emler, Jay Scott",69,000090
+MARION,Fairplay Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",18,000100
+MARION,Fairplay Township,Kansas Senate,35,Republican,"Emler, Jay Scott",42,000100
+MARION,Florence Ward 1,Kansas Senate,35,Libertarian,"Bryant, Jesse",24,00011A
+MARION,Florence Ward 1,Kansas Senate,35,Republican,"Emler, Jay Scott",49,00011A
+MARION,Florence Ward 1 Exclave,Kansas Senate,35,Libertarian,"Bryant, Jesse",0,00011B
+MARION,Florence Ward 1 Exclave,Kansas Senate,35,Republican,"Emler, Jay Scott",0,00011B
+MARION,Florence Ward 2,Kansas Senate,35,Libertarian,"Bryant, Jesse",41,000120
+MARION,Florence Ward 2,Kansas Senate,35,Republican,"Emler, Jay Scott",46,000120
+MARION,Gale Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",27,000130
+MARION,Gale Township,Kansas Senate,35,Republican,"Emler, Jay Scott",78,000130
+MARION,Grant Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",20,000140
+MARION,Grant Township,Kansas Senate,35,Republican,"Emler, Jay Scott",47,000140
+MARION,Hillsboro Ward 1,Kansas Senate,35,Libertarian,"Bryant, Jesse",101,000150
+MARION,Hillsboro Ward 1,Kansas Senate,35,Republican,"Emler, Jay Scott",391,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Kansas Senate,35,Libertarian,"Bryant, Jesse",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Kansas Senate,35,Republican,"Emler, Jay Scott",0,00016C
+MARION,Lehigh Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",24,000170
+MARION,Lehigh Township,Kansas Senate,35,Republican,"Emler, Jay Scott",96,000170
+MARION,Liberty Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",40,000180
+MARION,Liberty Township,Kansas Senate,35,Republican,"Emler, Jay Scott",121,000180
+MARION,Logan Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",3,000190
+MARION,Logan Township,Kansas Senate,35,Republican,"Emler, Jay Scott",20,000190
+MARION,Lost Springs Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",26,000200
+MARION,Lost Springs Township,Kansas Senate,35,Republican,"Emler, Jay Scott",58,000200
+MARION,Marion North Ward,Kansas Senate,35,Libertarian,"Bryant, Jesse",118,000210
+MARION,Marion North Ward,Kansas Senate,35,Republican,"Emler, Jay Scott",277,000210
+MARION,Marion South Ward,Kansas Senate,35,Libertarian,"Bryant, Jesse",101,00022A
+MARION,Marion South Ward,Kansas Senate,35,Republican,"Emler, Jay Scott",283,00022A
+MARION,Marion South Ward Exclave,Kansas Senate,35,Libertarian,"Bryant, Jesse",0,00022B
+MARION,Marion South Ward Exclave,Kansas Senate,35,Republican,"Emler, Jay Scott",0,00022B
+MARION,Menno Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",49,000230
+MARION,Menno Township,Kansas Senate,35,Republican,"Emler, Jay Scott",122,000230
+MARION,Milton Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",48,000240
+MARION,Milton Township,Kansas Senate,35,Republican,"Emler, Jay Scott",54,000240
+MARION,Moore Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",12,000250
+MARION,Moore Township,Kansas Senate,35,Republican,"Emler, Jay Scott",19,000250
+MARION,Peabody East,Kansas Senate,35,Libertarian,"Bryant, Jesse",63,000260
+MARION,Peabody East,Kansas Senate,35,Republican,"Emler, Jay Scott",117,000260
+MARION,Peabody West,Kansas Senate,35,Libertarian,"Bryant, Jesse",110,000270
+MARION,Peabody West,Kansas Senate,35,Republican,"Emler, Jay Scott",163,000270
+MARION,Risley Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",16,000280
+MARION,Risley Township,Kansas Senate,35,Republican,"Emler, Jay Scott",105,000280
+MARION,Summit Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",14,000290
+MARION,Summit Township,Kansas Senate,35,Republican,"Emler, Jay Scott",20,000290
+MARION,West Branch Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",116,000300
+MARION,West Branch Township,Kansas Senate,35,Republican,"Emler, Jay Scott",277,000300
+MARION,Wilson Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",25,000310
+MARION,Wilson Township,Kansas Senate,35,Republican,"Emler, Jay Scott",64,000310
+MARION,ENT TEST,Kansas Senate,35,Libertarian,"Bryant, Jesse",0,120001
+MARION,ENT TEST,Kansas Senate,35,Republican,"Emler, Jay Scott",0,120001
+MARION,Hillsboro Ward 2,Kansas Senate,35,Libertarian,"Bryant, Jesse",100,900010
+MARION,Hillsboro Ward 2,Kansas Senate,35,Republican,"Emler, Jay Scott",510,900010
+MARION,Hillsboro Ward 2 Exclave A,Kansas Senate,35,Libertarian,"Bryant, Jesse",0,900020
+MARION,Hillsboro Ward 2 Exclave A,Kansas Senate,35,Republican,"Emler, Jay Scott",0,900020
+MARION,SUPPLEMENTAL VOTES,Kansas Senate,35,Republican,"Emler, Jay Scott",1,999001
+MARION,Blaine Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+MARION,Blaine Township,President / Vice President,,Democratic,"Obama, Barack",20,000010
+MARION,Blaine Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+MARION,Blaine Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+MARION,Blaine Township,President / Vice President,,Republican,"Romney, Mitt",61,000010
+MARION,Catlin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Stein, Jill E",1,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+MARION,Catlin Township,President / Vice President,,Democratic,"Obama, Barack",22,000020
+MARION,Catlin Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+MARION,Catlin Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+MARION,Catlin Township,President / Vice President,,Republican,"Romney, Mitt",64,000020
+MARION,Centre Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+MARION,Centre Township,President / Vice President,,Democratic,"Obama, Barack",72,000030
+MARION,Centre Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000030
+MARION,Centre Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000030
+MARION,Centre Township,President / Vice President,,Republican,"Romney, Mitt",228,000030
+MARION,Clark Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+MARION,Clark Township,President / Vice President,,Democratic,"Obama, Barack",6,000040
+MARION,Clark Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000040
+MARION,Clark Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+MARION,Clark Township,President / Vice President,,Republican,"Romney, Mitt",55,000040
+MARION,Clear Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+MARION,Clear Creek Township,President / Vice President,,Democratic,"Obama, Barack",38,000050
+MARION,Clear Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000050
+MARION,Clear Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000050
+MARION,Clear Creek Township,President / Vice President,,Republican,"Romney, Mitt",182,000050
+MARION,Colfax Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+MARION,Colfax Township,President / Vice President,,Democratic,"Obama, Barack",30,000060
+MARION,Colfax Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+MARION,Colfax Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+MARION,Colfax Township,President / Vice President,,Republican,"Romney, Mitt",70,000060
+MARION,Doyle Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+MARION,Doyle Township,President / Vice President,,Democratic,"Obama, Barack",5,000070
+MARION,Doyle Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+MARION,Doyle Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+MARION,Doyle Township,President / Vice President,,Republican,"Romney, Mitt",14,000070
+MARION,Durham Park Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+MARION,Durham Park Township,President / Vice President,,Democratic,"Obama, Barack",27,000080
+MARION,Durham Park Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+MARION,Durham Park Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+MARION,Durham Park Township,President / Vice President,,Republican,"Romney, Mitt",73,000080
+MARION,East Branch Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+MARION,East Branch Township,President / Vice President,,Democratic,"Obama, Barack",33,000090
+MARION,East Branch Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+MARION,East Branch Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000090
+MARION,East Branch Township,President / Vice President,,Republican,"Romney, Mitt",68,000090
+MARION,Fairplay Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+MARION,Fairplay Township,President / Vice President,,Democratic,"Obama, Barack",7,000100
+MARION,Fairplay Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+MARION,Fairplay Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+MARION,Fairplay Township,President / Vice President,,Republican,"Romney, Mitt",59,000100
+MARION,Florence Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Christensen, Will",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00011A
+MARION,Florence Ward 1,President / Vice President,,Democratic,"Obama, Barack",27,00011A
+MARION,Florence Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",0,00011A
+MARION,Florence Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,00011A
+MARION,Florence Ward 1,President / Vice President,,Republican,"Romney, Mitt",49,00011A
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00011B
+MARION,Florence Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+MARION,Florence Ward 2,President / Vice President,,Democratic,"Obama, Barack",30,000120
+MARION,Florence Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000120
+MARION,Florence Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+MARION,Florence Ward 2,President / Vice President,,Republican,"Romney, Mitt",54,000120
+MARION,Gale Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+MARION,Gale Township,President / Vice President,,Democratic,"Obama, Barack",24,000130
+MARION,Gale Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+MARION,Gale Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+MARION,Gale Township,President / Vice President,,Republican,"Romney, Mitt",85,000130
+MARION,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+MARION,Grant Township,President / Vice President,,Democratic,"Obama, Barack",18,000140
+MARION,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+MARION,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+MARION,Grant Township,President / Vice President,,Republican,"Romney, Mitt",54,000140
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,Democratic,"Obama, Barack",104,000150
+MARION,Hillsboro Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000150
+MARION,Hillsboro Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",4,000150
+MARION,Hillsboro Ward 1,President / Vice President,,Republican,"Romney, Mitt",414,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Ayers, Avery L",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Barnett, Andre",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Barr, Roseanne C",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Bush, Kent W",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Christensen, Will",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Duncan, Richard A",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Goode, Virgil",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Hoefling, Tom",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Knill, Dennis J",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Reed, Jill A.",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Rogers, Rick L",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Stein, Jill E",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Thorne, Kevin M",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Warner, Gerald L.",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,Democratic,"Obama, Barack",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,Libertarian,"Johnson, Gary",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,Reform,"Baldwin, Chuck",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,Republican,"Romney, Mitt",0,00016C
+MARION,Lehigh Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+MARION,Lehigh Township,President / Vice President,,Democratic,"Obama, Barack",22,000170
+MARION,Lehigh Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000170
+MARION,Lehigh Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+MARION,Lehigh Township,President / Vice President,,Republican,"Romney, Mitt",103,000170
+MARION,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+MARION,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",39,000180
+MARION,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000180
+MARION,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+MARION,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",125,000180
+MARION,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+MARION,Logan Township,President / Vice President,,Democratic,"Obama, Barack",3,000190
+MARION,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+MARION,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+MARION,Logan Township,President / Vice President,,Republican,"Romney, Mitt",20,000190
+MARION,Lost Springs Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+MARION,Lost Springs Township,President / Vice President,,Democratic,"Obama, Barack",19,000200
+MARION,Lost Springs Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000200
+MARION,Lost Springs Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000200
+MARION,Lost Springs Township,President / Vice President,,Republican,"Romney, Mitt",71,000200
+MARION,Marion North Ward,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Barnett, Andre",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Bush, Kent W",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Christensen, Will",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Goode, Virgil",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Stein, Jill E",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+MARION,Marion North Ward,President / Vice President,,Democratic,"Obama, Barack",129,000210
+MARION,Marion North Ward,President / Vice President,,Libertarian,"Johnson, Gary",6,000210
+MARION,Marion North Ward,President / Vice President,,Reform,"Baldwin, Chuck",3,000210
+MARION,Marion North Ward,President / Vice President,,Republican,"Romney, Mitt",290,000210
+MARION,Marion South Ward,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Ayers, Avery L",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Barnett, Andre",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Barr, Roseanne C",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Bush, Kent W",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Christensen, Will",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Duncan, Richard A",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Goode, Virgil",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Hoefling, Tom",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Knill, Dennis J",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Reed, Jill A.",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Rogers, Rick L",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Stein, Jill E",1,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Thorne, Kevin M",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Warner, Gerald L.",0,00022A
+MARION,Marion South Ward,President / Vice President,,Democratic,"Obama, Barack",111,00022A
+MARION,Marion South Ward,President / Vice President,,Libertarian,"Johnson, Gary",3,00022A
+MARION,Marion South Ward,President / Vice President,,Reform,"Baldwin, Chuck",4,00022A
+MARION,Marion South Ward,President / Vice President,,Republican,"Romney, Mitt",284,00022A
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Christensen, Will",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00022B
+MARION,Menno Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Stein, Jill E",1,000230
+MARION,Menno Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+MARION,Menno Township,President / Vice President,,Democratic,"Obama, Barack",58,000230
+MARION,Menno Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+MARION,Menno Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000230
+MARION,Menno Township,President / Vice President,,Republican,"Romney, Mitt",122,000230
+MARION,Milton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+MARION,Milton Township,President / Vice President,,Democratic,"Obama, Barack",29,000240
+MARION,Milton Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000240
+MARION,Milton Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000240
+MARION,Milton Township,President / Vice President,,Republican,"Romney, Mitt",72,000240
+MARION,Moore Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+MARION,Moore Township,President / Vice President,,Democratic,"Obama, Barack",4,000250
+MARION,Moore Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000250
+MARION,Moore Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000250
+MARION,Moore Township,President / Vice President,,Republican,"Romney, Mitt",25,000250
+MARION,Peabody East,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Barnett, Andre",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Bush, Kent W",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Christensen, Will",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Goode, Virgil",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Stein, Jill E",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+MARION,Peabody East,President / Vice President,,Democratic,"Obama, Barack",63,000260
+MARION,Peabody East,President / Vice President,,Libertarian,"Johnson, Gary",2,000260
+MARION,Peabody East,President / Vice President,,Reform,"Baldwin, Chuck",1,000260
+MARION,Peabody East,President / Vice President,,Republican,"Romney, Mitt",128,000260
+MARION,Peabody West,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Barnett, Andre",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Bush, Kent W",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Christensen, Will",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Goode, Virgil",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Stein, Jill E",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+MARION,Peabody West,President / Vice President,,Democratic,"Obama, Barack",107,000270
+MARION,Peabody West,President / Vice President,,Libertarian,"Johnson, Gary",5,000270
+MARION,Peabody West,President / Vice President,,Reform,"Baldwin, Chuck",8,000270
+MARION,Peabody West,President / Vice President,,Republican,"Romney, Mitt",187,000270
+MARION,Risley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Barnett, Andre",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Bush, Kent W",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Christensen, Will",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Goode, Virgil",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Stein, Jill E",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+MARION,Risley Township,President / Vice President,,Democratic,"Obama, Barack",13,000280
+MARION,Risley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000280
+MARION,Risley Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000280
+MARION,Risley Township,President / Vice President,,Republican,"Romney, Mitt",110,000280
+MARION,Summit Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Barnett, Andre",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Bush, Kent W",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Christensen, Will",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Goode, Virgil",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Stein, Jill E",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+MARION,Summit Township,President / Vice President,,Democratic,"Obama, Barack",16,000290
+MARION,Summit Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000290
+MARION,Summit Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000290
+MARION,Summit Township,President / Vice President,,Republican,"Romney, Mitt",19,000290
+MARION,West Branch Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Barnett, Andre",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Bush, Kent W",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Christensen, Will",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Goode, Virgil",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Stein, Jill E",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+MARION,West Branch Township,President / Vice President,,Democratic,"Obama, Barack",177,000300
+MARION,West Branch Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000300
+MARION,West Branch Township,President / Vice President,,Reform,"Baldwin, Chuck",6,000300
+MARION,West Branch Township,President / Vice President,,Republican,"Romney, Mitt",225,000300
+MARION,Wilson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Barnett, Andre",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Bush, Kent W",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Christensen, Will",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Goode, Virgil",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Stein, Jill E",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+MARION,Wilson Township,President / Vice President,,Democratic,"Obama, Barack",14,000310
+MARION,Wilson Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000310
+MARION,Wilson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000310
+MARION,Wilson Township,President / Vice President,,Republican,"Romney, Mitt",81,000310
+MARION,ENT TEST,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Ayers, Avery L",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Barnett, Andre",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Barr, Roseanne C",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Bush, Kent W",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Christensen, Will",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Duncan, Richard A",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Goode, Virgil",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Hoefling, Tom",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Knill, Dennis J",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Reed, Jill A.",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Rogers, Rick L",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Stein, Jill E",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Thorne, Kevin M",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120001
+MARION,ENT TEST,President / Vice President,,write - in,"Warner, Gerald L.",0,120001
+MARION,ENT TEST,President / Vice President,,Democratic,"Obama, Barack",0,120001
+MARION,ENT TEST,President / Vice President,,Libertarian,"Johnson, Gary",0,120001
+MARION,ENT TEST,President / Vice President,,Reform,"Baldwin, Chuck",0,120001
+MARION,ENT TEST,President / Vice President,,Republican,"Romney, Mitt",0,120001
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Christensen, Will",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,Democratic,"Obama, Barack",116,900010
+MARION,Hillsboro Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",12,900010
+MARION,Hillsboro Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",5,900010
+MARION,Hillsboro Ward 2,President / Vice President,,Republican,"Romney, Mitt",494,900010
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,900020
+MARION,SUPPLEMENTAL VOTES,President / Vice President,,Democratic,"Obama, Barack",2,999001
+MARION,SUPPLEMENTAL VOTES,President / Vice President,,Republican,"Romney, Mitt",3,999001
+MARION,Blaine Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",67,000010
+MARION,Catlin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",73,000020
+MARION,Centre Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",250,000030
+MARION,Clark Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",57,000040
+MARION,Clear Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",195,000050
+MARION,Colfax Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",82,000060
+MARION,Doyle Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000070
+MARION,Durham Park Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",82,000080
+MARION,East Branch Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",84,000090
+MARION,Fairplay Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",58,000100
+MARION,Florence Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",64,00011A
+MARION,Florence Ward 1 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00011B
+MARION,Florence Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",78,000120
+MARION,Gale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",91,000130
+MARION,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000140
+MARION,Hillsboro Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",465,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00016C
+MARION,Lehigh Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",110,000170
+MARION,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",150,000180
+MARION,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000190
+MARION,Lost Springs Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",74,000200
+MARION,Marion North Ward,United States House of Representatives,1,Republican,"Huelskamp, Tim",363,000210
+MARION,Marion South Ward,United States House of Representatives,1,Republican,"Huelskamp, Tim",337,00022A
+MARION,Marion South Ward Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022B
+MARION,Menno Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",148,000230
+MARION,Milton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",92,000240
+MARION,Moore Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000250
+MARION,Peabody East,United States House of Representatives,1,Republican,"Huelskamp, Tim",153,000260
+MARION,Peabody West,United States House of Representatives,1,Republican,"Huelskamp, Tim",249,000270
+MARION,Risley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",114,000280
+MARION,Summit Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000290
+MARION,West Branch Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",327,000300
+MARION,Wilson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",81,000310
+MARION,Hillsboro Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",567,900010
+MARION,Hillsboro Ward 2 Exclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+MARION,SUPPLEMENTAL VOTES,United States House of Representatives,1,Republican,"Huelskamp, Tim",2,999001

--- a/2012/20121106__ks__general__marshall__precinct.csv
+++ b/2012/20121106__ks__general__marshall__precinct.csv
@@ -1,0 +1,939 @@
+county,precinct,office,district,party,candidate,votes,vtd
+MARSHALL,Balderson Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",11,000010
+MARSHALL,Balderson Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",33,000010
+MARSHALL,Bigelow Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",10,000020
+MARSHALL,Bigelow Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",8,000020
+MARSHALL,Blue Rapids City,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",99,000030
+MARSHALL,Blue Rapids City,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",275,000030
+MARSHALL,Blue Rapids Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",7,000040
+MARSHALL,Blue Rapids Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",19,000040
+MARSHALL,Center Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",14,000050
+MARSHALL,Center Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",53,000050
+MARSHALL,Clear Fork Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",3,000060
+MARSHALL,Clear Fork Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",12,000060
+MARSHALL,Cleveland Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",18,000070
+MARSHALL,Cleveland Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",38,000070
+MARSHALL,Cottage Hill Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",13,000080
+MARSHALL,Cottage Hill Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",64,000080
+MARSHALL,East Vermillion Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",55,000090
+MARSHALL,East Vermillion Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",168,000090
+MARSHALL,Elm Creek Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",29,000100
+MARSHALL,Elm Creek Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",54,000100
+MARSHALL,Herkimer Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",28,000130
+MARSHALL,Herkimer Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",95,000130
+MARSHALL,Lincoln Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",10,000140
+MARSHALL,Lincoln Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",65,000140
+MARSHALL,Logan Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",43,000150
+MARSHALL,Logan Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",107,000150
+MARSHALL,Marysville City Ward 1,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",146,000160
+MARSHALL,Marysville City Ward 1,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",285,000160
+MARSHALL,Marysville City Ward 2,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",129,00017A
+MARSHALL,Marysville City Ward 2,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",234,00017A
+MARSHALL,Marysville City Ward 2 Exclave,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",0,00017B
+MARSHALL,Marysville City Ward 3,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",85,00018A
+MARSHALL,Marysville City Ward 3,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",165,00018A
+MARSHALL,Marysville City Ward 3 Exclave,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",135,00019A
+MARSHALL,Marysville City Ward 4 Part A,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",237,00019A
+MARSHALL,Marysville City Ward 4 Part B,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",0,00019C
+MARSHALL,Marysville Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",58,000200
+MARSHALL,Marysville Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",81,000200
+MARSHALL,Murray Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",63,000210
+MARSHALL,Murray Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",226,000210
+MARSHALL,Noble Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",29,000220
+MARSHALL,Noble Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",70,000220
+MARSHALL,Oketo Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",40,000230
+MARSHALL,Oketo Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",77,000230
+MARSHALL,Richland Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",21,000240
+MARSHALL,Richland Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",72,000240
+MARSHALL,Rock Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",10,000250
+MARSHALL,Rock Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",56,000250
+MARSHALL,St. Bridget Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",16,000260
+MARSHALL,St. Bridget Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",63,000260
+MARSHALL,Walnut Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",18,000270
+MARSHALL,Walnut Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",43,000270
+MARSHALL,Waterville Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",95,000280
+MARSHALL,Waterville Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",260,000280
+MARSHALL,Wells Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",16,000290
+MARSHALL,Wells Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",48,000290
+MARSHALL,West Vermillion Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",56,000300
+MARSHALL,West Vermillion Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",149,000300
+MARSHALL,Franklin Township C1,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",0,120020
+MARSHALL,Franklin Township C1,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",0,120020
+MARSHALL,Franklin Township C2,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",56,120030
+MARSHALL,Franklin Township C2,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",89,120030
+MARSHALL,Guittard Township C1,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",0,120040
+MARSHALL,Guittard Township C1,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",0,120040
+MARSHALL,Guittard Township C2,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",58,120050
+MARSHALL,Guittard Township C2,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",126,120050
+MARSHALL,Balderson Township,Kansas Senate,1,Democratic,"Lukert, Steve",16,000010
+MARSHALL,Balderson Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",27,000010
+MARSHALL,Bigelow Township,Kansas Senate,1,Democratic,"Lukert, Steve",15,000020
+MARSHALL,Bigelow Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",3,000020
+MARSHALL,Blue Rapids City,Kansas Senate,36,Democratic,"Clark, Marquis",112,000030
+MARSHALL,Blue Rapids City,Kansas Senate,36,Republican,"Bowers, Elaine S.",241,000030
+MARSHALL,Blue Rapids Township,Kansas Senate,36,Democratic,"Clark, Marquis",9,000040
+MARSHALL,Blue Rapids Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000040
+MARSHALL,Center Township,Kansas Senate,1,Democratic,"Lukert, Steve",24,000050
+MARSHALL,Center Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",42,000050
+MARSHALL,Clear Fork Township,Kansas Senate,1,Democratic,"Lukert, Steve",11,000060
+MARSHALL,Clear Fork Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",4,000060
+MARSHALL,Cleveland Township,Kansas Senate,1,Democratic,"Lukert, Steve",35,000070
+MARSHALL,Cleveland Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",23,000070
+MARSHALL,Cottage Hill Township,Kansas Senate,36,Democratic,"Clark, Marquis",16,000080
+MARSHALL,Cottage Hill Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",54,000080
+MARSHALL,East Vermillion Township,Kansas Senate,1,Democratic,"Lukert, Steve",123,000090
+MARSHALL,East Vermillion Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",102,000090
+MARSHALL,Elm Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",26,000100
+MARSHALL,Elm Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",52,000100
+MARSHALL,Herkimer Township,Kansas Senate,36,Democratic,"Clark, Marquis",18,000130
+MARSHALL,Herkimer Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",99,000130
+MARSHALL,Lincoln Township,Kansas Senate,1,Democratic,"Lukert, Steve",33,000140
+MARSHALL,Lincoln Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",46,000140
+MARSHALL,Logan Township,Kansas Senate,36,Democratic,"Clark, Marquis",32,000150
+MARSHALL,Logan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",115,000150
+MARSHALL,Marysville City Ward 1,Kansas Senate,36,Democratic,"Clark, Marquis",138,000160
+MARSHALL,Marysville City Ward 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",280,000160
+MARSHALL,Marysville City Ward 2,Kansas Senate,36,Democratic,"Clark, Marquis",115,00017A
+MARSHALL,Marysville City Ward 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",229,00017A
+MARSHALL,Marysville City Ward 2 Exclave,Kansas Senate,36,Democratic,"Clark, Marquis",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00017B
+MARSHALL,Marysville City Ward 3,Kansas Senate,36,Democratic,"Clark, Marquis",90,00018A
+MARSHALL,Marysville City Ward 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",148,00018A
+MARSHALL,Marysville City Ward 3 Exclave,Kansas Senate,36,Democratic,"Clark, Marquis",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,Kansas Senate,36,Democratic,"Clark, Marquis",95,00019A
+MARSHALL,Marysville City Ward 4 Part A,Kansas Senate,36,Republican,"Bowers, Elaine S.",258,00019A
+MARSHALL,Marysville City Ward 4 Part B,Kansas Senate,36,Democratic,"Clark, Marquis",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,Kansas Senate,36,Democratic,"Clark, Marquis",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00019C
+MARSHALL,Marysville Township,Kansas Senate,36,Democratic,"Clark, Marquis",49,000200
+MARSHALL,Marysville Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",83,000200
+MARSHALL,Murray Township,Kansas Senate,1,Democratic,"Lukert, Steve",158,000210
+MARSHALL,Murray Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",135,000210
+MARSHALL,Noble Township,Kansas Senate,1,Democratic,"Lukert, Steve",46,000220
+MARSHALL,Noble Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",56,000220
+MARSHALL,Oketo Township,Kansas Senate,36,Democratic,"Clark, Marquis",38,000230
+MARSHALL,Oketo Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",71,000230
+MARSHALL,Richland Township,Kansas Senate,1,Democratic,"Lukert, Steve",46,000240
+MARSHALL,Richland Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",45,000240
+MARSHALL,Rock Township,Kansas Senate,1,Democratic,"Lukert, Steve",26,000250
+MARSHALL,Rock Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",42,000250
+MARSHALL,St. Bridget Township,Kansas Senate,1,Democratic,"Lukert, Steve",33,000260
+MARSHALL,St. Bridget Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",46,000260
+MARSHALL,Walnut Township,Kansas Senate,36,Democratic,"Clark, Marquis",17,000270
+MARSHALL,Walnut Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",39,000270
+MARSHALL,Waterville Township,Kansas Senate,36,Democratic,"Clark, Marquis",104,000280
+MARSHALL,Waterville Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",242,000280
+MARSHALL,Wells Township,Kansas Senate,1,Democratic,"Lukert, Steve",40,000290
+MARSHALL,Wells Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",22,000290
+MARSHALL,West Vermillion Township,Kansas Senate,1,Democratic,"Lukert, Steve",127,000300
+MARSHALL,West Vermillion Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",83,000300
+MARSHALL,Franklin Township C1,Kansas Senate,1,Democratic,"Lukert, Steve",0,120020
+MARSHALL,Franklin Township C1,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,120020
+MARSHALL,Franklin Township C2,Kansas Senate,1,Democratic,"Lukert, Steve",70,120030
+MARSHALL,Franklin Township C2,Kansas Senate,1,Republican,"Pyle, Dennis D.",72,120030
+MARSHALL,Guittard Township C1,Kansas Senate,1,Democratic,"Lukert, Steve",0,120040
+MARSHALL,Guittard Township C1,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,120040
+MARSHALL,Guittard Township C2,Kansas Senate,1,Democratic,"Lukert, Steve",90,120050
+MARSHALL,Guittard Township C2,Kansas Senate,1,Republican,"Pyle, Dennis D.",92,120050
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+MARSHALL,Balderson Township,President / Vice President,,Democratic,"Obama, Barack",6,000010
+MARSHALL,Balderson Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+MARSHALL,Balderson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+MARSHALL,Balderson Township,President / Vice President,,Republican,"Romney, Mitt",36,000010
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,Democratic,"Obama, Barack",8,000020
+MARSHALL,Bigelow Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,Republican,"Romney, Mitt",10,000020
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Barnett, Andre",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Bush, Kent W",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Christensen, Will",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Goode, Virgil",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Stein, Jill E",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,Democratic,"Obama, Barack",125,000030
+MARSHALL,Blue Rapids City,President / Vice President,,Libertarian,"Johnson, Gary",8,000030
+MARSHALL,Blue Rapids City,President / Vice President,,Reform,"Baldwin, Chuck",3,000030
+MARSHALL,Blue Rapids City,President / Vice President,,Republican,"Romney, Mitt",249,000030
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,Democratic,"Obama, Barack",11,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,Republican,"Romney, Mitt",19,000040
+MARSHALL,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+MARSHALL,Center Township,President / Vice President,,Democratic,"Obama, Barack",18,000050
+MARSHALL,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+MARSHALL,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+MARSHALL,Center Township,President / Vice President,,Republican,"Romney, Mitt",49,000050
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,Democratic,"Obama, Barack",7,000060
+MARSHALL,Clear Fork Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,Republican,"Romney, Mitt",9,000060
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,Democratic,"Obama, Barack",22,000070
+MARSHALL,Cleveland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,Republican,"Romney, Mitt",37,000070
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,Democratic,"Obama, Barack",18,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,Republican,"Romney, Mitt",55,000080
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,Democratic,"Obama, Barack",74,000090
+MARSHALL,East Vermillion Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000090
+MARSHALL,East Vermillion Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+MARSHALL,East Vermillion Township,President / Vice President,,Republican,"Romney, Mitt",157,000090
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,Democratic,"Obama, Barack",31,000100
+MARSHALL,Elm Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+MARSHALL,Elm Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+MARSHALL,Elm Creek Township,President / Vice President,,Republican,"Romney, Mitt",55,000100
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,Democratic,"Obama, Barack",22,000130
+MARSHALL,Herkimer Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000130
+MARSHALL,Herkimer Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000130
+MARSHALL,Herkimer Township,President / Vice President,,Republican,"Romney, Mitt",98,000130
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",3,000140
+MARSHALL,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000140
+MARSHALL,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+MARSHALL,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",72,000140
+MARSHALL,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+MARSHALL,Logan Township,President / Vice President,,Democratic,"Obama, Barack",37,000150
+MARSHALL,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+MARSHALL,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+MARSHALL,Logan Township,President / Vice President,,Republican,"Romney, Mitt",112,000150
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,Democratic,"Obama, Barack",137,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,Republican,"Romney, Mitt",289,000160
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,Democratic,"Obama, Barack",136,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",9,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",3,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,Republican,"Romney, Mitt",233,00017A
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00017B
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,Democratic,"Obama, Barack",98,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",10,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",3,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,Republican,"Romney, Mitt",140,00018A
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Barnett, Andre",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Bush, Kent W",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Christensen, Will",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Goode, Virgil",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Stein, Jill E",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,Democratic,"Obama, Barack",121,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,Libertarian,"Johnson, Gary",7,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,Reform,"Baldwin, Chuck",2,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,Republican,"Romney, Mitt",254,00019A
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Ayers, Avery L",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Barnett, Andre",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Bush, Kent W",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Christensen, Will",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Duncan, Richard A",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Goode, Virgil",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Knill, Dennis J",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Reed, Jill A.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Rogers, Rick L",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Stein, Jill E",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,Democratic,"Obama, Barack",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,Republican,"Romney, Mitt",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Christensen, Will",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00019C
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+MARSHALL,Marysville Township,President / Vice President,,Democratic,"Obama, Barack",45,000200
+MARSHALL,Marysville Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000200
+MARSHALL,Marysville Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000200
+MARSHALL,Marysville Township,President / Vice President,,Republican,"Romney, Mitt",93,000200
+MARSHALL,Murray Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+MARSHALL,Murray Township,President / Vice President,,Democratic,"Obama, Barack",72,000210
+MARSHALL,Murray Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000210
+MARSHALL,Murray Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000210
+MARSHALL,Murray Township,President / Vice President,,Republican,"Romney, Mitt",218,000210
+MARSHALL,Noble Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+MARSHALL,Noble Township,President / Vice President,,Democratic,"Obama, Barack",30,000220
+MARSHALL,Noble Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+MARSHALL,Noble Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+MARSHALL,Noble Township,President / Vice President,,Republican,"Romney, Mitt",77,000220
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+MARSHALL,Oketo Township,President / Vice President,,Democratic,"Obama, Barack",46,000230
+MARSHALL,Oketo Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+MARSHALL,Oketo Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+MARSHALL,Oketo Township,President / Vice President,,Republican,"Romney, Mitt",72,000230
+MARSHALL,Richland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+MARSHALL,Richland Township,President / Vice President,,Democratic,"Obama, Barack",19,000240
+MARSHALL,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000240
+MARSHALL,Richland Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000240
+MARSHALL,Richland Township,President / Vice President,,Republican,"Romney, Mitt",74,000240
+MARSHALL,Rock Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+MARSHALL,Rock Township,President / Vice President,,Democratic,"Obama, Barack",17,000250
+MARSHALL,Rock Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+MARSHALL,Rock Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000250
+MARSHALL,Rock Township,President / Vice President,,Republican,"Romney, Mitt",53,000250
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Barnett, Andre",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Bush, Kent W",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Christensen, Will",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Goode, Virgil",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Stein, Jill E",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,Democratic,"Obama, Barack",18,000260
+MARSHALL,St. Bridget Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000260
+MARSHALL,St. Bridget Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,Republican,"Romney, Mitt",64,000260
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Barnett, Andre",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Bush, Kent W",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Christensen, Will",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Goode, Virgil",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Stein, Jill E",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+MARSHALL,Walnut Township,President / Vice President,,Democratic,"Obama, Barack",25,000270
+MARSHALL,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000270
+MARSHALL,Walnut Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000270
+MARSHALL,Walnut Township,President / Vice President,,Republican,"Romney, Mitt",35,000270
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Barnett, Andre",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Bush, Kent W",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Christensen, Will",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Goode, Virgil",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Stein, Jill E",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+MARSHALL,Waterville Township,President / Vice President,,Democratic,"Obama, Barack",111,000280
+MARSHALL,Waterville Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000280
+MARSHALL,Waterville Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000280
+MARSHALL,Waterville Township,President / Vice President,,Republican,"Romney, Mitt",249,000280
+MARSHALL,Wells Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Barnett, Andre",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Bush, Kent W",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Christensen, Will",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Goode, Virgil",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Stein, Jill E",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+MARSHALL,Wells Township,President / Vice President,,Democratic,"Obama, Barack",29,000290
+MARSHALL,Wells Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000290
+MARSHALL,Wells Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000290
+MARSHALL,Wells Township,President / Vice President,,Republican,"Romney, Mitt",34,000290
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Barnett, Andre",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Bush, Kent W",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Christensen, Will",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Goode, Virgil",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Stein, Jill E",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,Democratic,"Obama, Barack",70,000300
+MARSHALL,West Vermillion Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000300
+MARSHALL,West Vermillion Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000300
+MARSHALL,West Vermillion Township,President / Vice President,,Republican,"Romney, Mitt",141,000300
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Barnett, Andre",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Bush, Kent W",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Christensen, Will",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Goode, Virgil",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Stein, Jill E",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,Democratic,"Obama, Barack",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,Republican,"Romney, Mitt",0,120020
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Barnett, Andre",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Bush, Kent W",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Christensen, Will",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Goode, Virgil",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Stein, Jill E",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,Democratic,"Obama, Barack",50,120030
+MARSHALL,Franklin Township C2,President / Vice President,,Libertarian,"Johnson, Gary",4,120030
+MARSHALL,Franklin Township C2,President / Vice President,,Reform,"Baldwin, Chuck",2,120030
+MARSHALL,Franklin Township C2,President / Vice President,,Republican,"Romney, Mitt",90,120030
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Barnett, Andre",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Bush, Kent W",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Christensen, Will",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Goode, Virgil",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Stein, Jill E",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,Democratic,"Obama, Barack",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,Libertarian,"Johnson, Gary",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,Reform,"Baldwin, Chuck",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,Republican,"Romney, Mitt",0,120040
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Barnett, Andre",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Bush, Kent W",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Christensen, Will",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Goode, Virgil",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Stein, Jill E",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,Democratic,"Obama, Barack",63,120050
+MARSHALL,Guittard Township C2,President / Vice President,,Libertarian,"Johnson, Gary",1,120050
+MARSHALL,Guittard Township C2,President / Vice President,,Reform,"Baldwin, Chuck",1,120050
+MARSHALL,Guittard Township C2,President / Vice President,,Republican,"Romney, Mitt",121,120050
+MARSHALL,Balderson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000010
+MARSHALL,Bigelow Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",10,000020
+MARSHALL,Bigelow Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000020
+MARSHALL,Bigelow Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",8,000020
+MARSHALL,Blue Rapids City,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",113,000030
+MARSHALL,Blue Rapids City,United States House of Representatives,2,Libertarian,"Hawver, Dennis",21,000030
+MARSHALL,Blue Rapids City,United States House of Representatives,2,Republican,"Jenkins, Lynn",248,000030
+MARSHALL,Blue Rapids Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",7,000040
+MARSHALL,Blue Rapids Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000040
+MARSHALL,Blue Rapids Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",19,000040
+MARSHALL,Center Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",14,000050
+MARSHALL,Center Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000050
+MARSHALL,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",52,000050
+MARSHALL,Clear Fork Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",7,000060
+MARSHALL,Clear Fork Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000060
+MARSHALL,Clear Fork Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",5,000060
+MARSHALL,Cleveland Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",24,000070
+MARSHALL,Cleveland Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000070
+MARSHALL,Cleveland Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",33,000070
+MARSHALL,Cottage Hill Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",12,000080
+MARSHALL,Cottage Hill Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000080
+MARSHALL,Cottage Hill Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,000080
+MARSHALL,East Vermillion Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",70,000090
+MARSHALL,East Vermillion Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000090
+MARSHALL,East Vermillion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",149,000090
+MARSHALL,Elm Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",28,000100
+MARSHALL,Elm Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000100
+MARSHALL,Elm Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",49,000100
+MARSHALL,Herkimer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",100,000130
+MARSHALL,Lincoln Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",9,000140
+MARSHALL,Lincoln Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000140
+MARSHALL,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,000140
+MARSHALL,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",125,000150
+MARSHALL,Marysville City Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",356,000160
+MARSHALL,Marysville City Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",272,00017A
+MARSHALL,Marysville City Ward 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00017B
+MARSHALL,Marysville City Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",195,00018A
+MARSHALL,Marysville City Ward 3 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",294,00019A
+MARSHALL,Marysville City Ward 4 Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00019C
+MARSHALL,Marysville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",101,000200
+MARSHALL,Murray Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",80,000210
+MARSHALL,Murray Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,000210
+MARSHALL,Murray Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",198,000210
+MARSHALL,Noble Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",29,000220
+MARSHALL,Noble Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000220
+MARSHALL,Noble Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",62,000220
+MARSHALL,Oketo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",89,000230
+MARSHALL,Richland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",71,000240
+MARSHALL,Rock Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",12,000250
+MARSHALL,Rock Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000250
+MARSHALL,Rock Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",51,000250
+MARSHALL,St. Bridget Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",57,000260
+MARSHALL,Walnut Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",22,000270
+MARSHALL,Walnut Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000270
+MARSHALL,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",36,000270
+MARSHALL,Waterville Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",99,000280
+MARSHALL,Waterville Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,000280
+MARSHALL,Waterville Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",250,000280
+MARSHALL,Wells Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",26,000290
+MARSHALL,Wells Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000290
+MARSHALL,Wells Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",36,000290
+MARSHALL,West Vermillion Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",78,000300
+MARSHALL,West Vermillion Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000300
+MARSHALL,West Vermillion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",122,000300
+MARSHALL,Franklin Township C1,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,120020
+MARSHALL,Franklin Township C2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",23,120030
+MARSHALL,Franklin Township C2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,120030
+MARSHALL,Franklin Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",38,120030
+MARSHALL,Guittard Township C1,United States House of Representatives,1,Republican,"Huelskamp, Tim",6,120040
+MARSHALL,Guittard Township C2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",68,120050
+MARSHALL,Guittard Township C2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,120050
+MARSHALL,Guittard Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",110,120050

--- a/2012/20121106__ks__general__mcpherson__precinct.csv
+++ b/2012/20121106__ks__general__mcpherson__precinct.csv
@@ -1,0 +1,822 @@
+county,precinct,office,district,party,candidate,votes,vtd
+MCPHERSON,Battle Hill Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",18,000010
+MCPHERSON,Battle Hill Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",36,000010
+MCPHERSON,Bonaville Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",1,000020
+MCPHERSON,Bonaville Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",33,000020
+MCPHERSON,Canton Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",79,000030
+MCPHERSON,Canton Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",281,000030
+MCPHERSON,Castle Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",34,000040
+MCPHERSON,Castle Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",47,000040
+MCPHERSON,Delmore Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",13,000050
+MCPHERSON,Delmore Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",65,000050
+MCPHERSON,Empire Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",107,000060
+MCPHERSON,Empire Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",391,000060
+MCPHERSON,Groveland Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",10,000070
+MCPHERSON,Groveland Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",77,000070
+MCPHERSON,Gypsum Creek Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",18,000080
+MCPHERSON,Gypsum Creek Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",58,000080
+MCPHERSON,Harper Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",15,000090
+MCPHERSON,Harper Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",63,000090
+MCPHERSON,Hayes Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",34,000100
+MCPHERSON,Hayes Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",78,000100
+MCPHERSON,Jackson Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",25,000110
+MCPHERSON,Jackson Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",76,000110
+MCPHERSON,King City Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",57,000120
+MCPHERSON,King City Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",174,000120
+MCPHERSON,Lindsborg Ward 1,Kansas House of Representatives,108,Republican,"Johnson, Steven",304,000130
+MCPHERSON,Lindsborg Ward 2,Kansas House of Representatives,108,Republican,"Johnson, Steven",394,000140
+MCPHERSON,Lindsborg Ward 3,Kansas House of Representatives,108,Republican,"Johnson, Steven",273,000150
+MCPHERSON,Lindsborg Ward 4,Kansas House of Representatives,108,Republican,"Johnson, Steven",222,000160
+MCPHERSON,Little Valley Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",33,000170
+MCPHERSON,Little Valley Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",157,000170
+MCPHERSON,Lone Tree Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",25,000180
+MCPHERSON,Lone Tree Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",67,000180
+MCPHERSON,Marquette Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",102,000190
+MCPHERSON,Marquette Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",242,000190
+MCPHERSON,McPherson Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",68,000200
+MCPHERSON,McPherson Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",211,000200
+MCPHERSON,Meridian Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",104,000290
+MCPHERSON,Mound Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",644,000300
+MCPHERSON,New Gottland Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",34,000310
+MCPHERSON,New Gottland Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",210,000310
+MCPHERSON,Smoky Hill Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",150,000320
+MCPHERSON,South Sharps Creek Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",11,000330
+MCPHERSON,South Sharps Creek Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",34,000330
+MCPHERSON,Spring Valley Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",23,000340
+MCPHERSON,Spring Valley Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",116,000340
+MCPHERSON,Superior Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",147,000350
+MCPHERSON,Superior Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",570,000350
+MCPHERSON,Turkey Creek Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",25,000360
+MCPHERSON,Turkey Creek Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",89,000360
+MCPHERSON,Union Township,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",14,000370
+MCPHERSON,Union Township,Kansas House of Representatives,73,Republican,"Shultz, Clark",71,000370
+MCPHERSON,McPherson Ward 1 Precinct 1,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",726,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,Kansas House of Representatives,73,Republican,"Shultz, Clark",2120,900010
+MCPHERSON,McPherson Ward 2,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",238,900020
+MCPHERSON,McPherson Ward 2,Kansas House of Representatives,73,Republican,"Shultz, Clark",690,900020
+MCPHERSON,McPherson Ward 3 Part A,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",130,900030
+MCPHERSON,McPherson Ward 3 Part A,Kansas House of Representatives,73,Republican,"Shultz, Clark",405,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",284,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Kansas House of Representatives,73,Republican,"Shultz, Clark",825,900040
+MCPHERSON,McPherson Ward 1 Exclave,Kansas House of Representatives,73,Democratic,"Lawson, Pamela J.",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,Kansas House of Representatives,73,Republican,"Shultz, Clark",0,900050
+MCPHERSON,Battle Hill Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",15,000010
+MCPHERSON,Battle Hill Township,Kansas Senate,35,Republican,"Emler, Jay Scott",36,000010
+MCPHERSON,Bonaville Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",13,000020
+MCPHERSON,Bonaville Township,Kansas Senate,35,Republican,"Emler, Jay Scott",21,000020
+MCPHERSON,Canton Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",90,000030
+MCPHERSON,Canton Township,Kansas Senate,35,Republican,"Emler, Jay Scott",266,000030
+MCPHERSON,Castle Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",25,000040
+MCPHERSON,Castle Township,Kansas Senate,35,Republican,"Emler, Jay Scott",56,000040
+MCPHERSON,Delmore Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",18,000050
+MCPHERSON,Delmore Township,Kansas Senate,35,Republican,"Emler, Jay Scott",61,000050
+MCPHERSON,Empire Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",159,000060
+MCPHERSON,Empire Township,Kansas Senate,35,Republican,"Emler, Jay Scott",334,000060
+MCPHERSON,Groveland Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",16,000070
+MCPHERSON,Groveland Township,Kansas Senate,35,Republican,"Emler, Jay Scott",68,000070
+MCPHERSON,Gypsum Creek Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",25,000080
+MCPHERSON,Gypsum Creek Township,Kansas Senate,35,Republican,"Emler, Jay Scott",56,000080
+MCPHERSON,Harper Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",14,000090
+MCPHERSON,Harper Township,Kansas Senate,35,Republican,"Emler, Jay Scott",64,000090
+MCPHERSON,Hayes Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",24,000100
+MCPHERSON,Hayes Township,Kansas Senate,35,Republican,"Emler, Jay Scott",85,000100
+MCPHERSON,Jackson Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",26,000110
+MCPHERSON,Jackson Township,Kansas Senate,35,Republican,"Emler, Jay Scott",72,000110
+MCPHERSON,King City Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",60,000120
+MCPHERSON,King City Township,Kansas Senate,35,Republican,"Emler, Jay Scott",166,000120
+MCPHERSON,Lindsborg Ward 1,Kansas Senate,35,Libertarian,"Bryant, Jesse",67,000130
+MCPHERSON,Lindsborg Ward 1,Kansas Senate,35,Republican,"Emler, Jay Scott",311,000130
+MCPHERSON,Lindsborg Ward 2,Kansas Senate,35,Libertarian,"Bryant, Jesse",76,000140
+MCPHERSON,Lindsborg Ward 2,Kansas Senate,35,Republican,"Emler, Jay Scott",387,000140
+MCPHERSON,Lindsborg Ward 3,Kansas Senate,35,Libertarian,"Bryant, Jesse",75,000150
+MCPHERSON,Lindsborg Ward 3,Kansas Senate,35,Republican,"Emler, Jay Scott",244,000150
+MCPHERSON,Lindsborg Ward 4,Kansas Senate,35,Libertarian,"Bryant, Jesse",61,000160
+MCPHERSON,Lindsborg Ward 4,Kansas Senate,35,Republican,"Emler, Jay Scott",205,000160
+MCPHERSON,Little Valley Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",42,000170
+MCPHERSON,Little Valley Township,Kansas Senate,35,Republican,"Emler, Jay Scott",141,000170
+MCPHERSON,Lone Tree Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",36,000180
+MCPHERSON,Lone Tree Township,Kansas Senate,35,Republican,"Emler, Jay Scott",53,000180
+MCPHERSON,Marquette Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",95,000190
+MCPHERSON,Marquette Township,Kansas Senate,35,Republican,"Emler, Jay Scott",245,000190
+MCPHERSON,McPherson Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",73,000200
+MCPHERSON,McPherson Township,Kansas Senate,35,Republican,"Emler, Jay Scott",200,000200
+MCPHERSON,Meridian Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",34,000290
+MCPHERSON,Meridian Township,Kansas Senate,35,Republican,"Emler, Jay Scott",81,000290
+MCPHERSON,Mound Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",178,000300
+MCPHERSON,Mound Township,Kansas Senate,35,Republican,"Emler, Jay Scott",526,000300
+MCPHERSON,New Gottland Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",44,000310
+MCPHERSON,New Gottland Township,Kansas Senate,35,Republican,"Emler, Jay Scott",199,000310
+MCPHERSON,Smoky Hill Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",27,000320
+MCPHERSON,Smoky Hill Township,Kansas Senate,35,Republican,"Emler, Jay Scott",142,000320
+MCPHERSON,South Sharps Creek Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",7,000330
+MCPHERSON,South Sharps Creek Township,Kansas Senate,35,Republican,"Emler, Jay Scott",37,000330
+MCPHERSON,Spring Valley Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",46,000340
+MCPHERSON,Spring Valley Township,Kansas Senate,35,Republican,"Emler, Jay Scott",96,000340
+MCPHERSON,Superior Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",140,000350
+MCPHERSON,Superior Township,Kansas Senate,35,Republican,"Emler, Jay Scott",572,000350
+MCPHERSON,Turkey Creek Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",23,000360
+MCPHERSON,Turkey Creek Township,Kansas Senate,35,Republican,"Emler, Jay Scott",92,000360
+MCPHERSON,Union Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",19,000370
+MCPHERSON,Union Township,Kansas Senate,35,Republican,"Emler, Jay Scott",65,000370
+MCPHERSON,McPherson Ward 1 Precinct 1,Kansas Senate,35,Libertarian,"Bryant, Jesse",541,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,Kansas Senate,35,Republican,"Emler, Jay Scott",2204,900010
+MCPHERSON,McPherson Ward 2,Kansas Senate,35,Libertarian,"Bryant, Jesse",195,900020
+MCPHERSON,McPherson Ward 2,Kansas Senate,35,Republican,"Emler, Jay Scott",704,900020
+MCPHERSON,McPherson Ward 3 Part A,Kansas Senate,35,Libertarian,"Bryant, Jesse",135,900030
+MCPHERSON,McPherson Ward 3 Part A,Kansas Senate,35,Republican,"Emler, Jay Scott",376,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Kansas Senate,35,Libertarian,"Bryant, Jesse",257,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Kansas Senate,35,Republican,"Emler, Jay Scott",807,900040
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Stein, Jill E",1,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,Democratic,"Obama, Barack",21,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,Republican,"Romney, Mitt",32,000010
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,Democratic,"Obama, Barack",4,000020
+MCPHERSON,Bonaville Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+MCPHERSON,Bonaville Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,Republican,"Romney, Mitt",34,000020
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Stein, Jill E",1,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+MCPHERSON,Canton Township,President / Vice President,,Democratic,"Obama, Barack",70,000030
+MCPHERSON,Canton Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000030
+MCPHERSON,Canton Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+MCPHERSON,Canton Township,President / Vice President,,Republican,"Romney, Mitt",289,000030
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+MCPHERSON,Castle Township,President / Vice President,,Democratic,"Obama, Barack",24,000040
+MCPHERSON,Castle Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+MCPHERSON,Castle Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+MCPHERSON,Castle Township,President / Vice President,,Republican,"Romney, Mitt",55,000040
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,Democratic,"Obama, Barack",12,000050
+MCPHERSON,Delmore Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,Republican,"Romney, Mitt",68,000050
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+MCPHERSON,Empire Township,President / Vice President,,Democratic,"Obama, Barack",94,000060
+MCPHERSON,Empire Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000060
+MCPHERSON,Empire Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000060
+MCPHERSON,Empire Township,President / Vice President,,Republican,"Romney, Mitt",412,000060
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Goode, Virgil",1,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,Democratic,"Obama, Barack",18,000070
+MCPHERSON,Groveland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,Republican,"Romney, Mitt",70,000070
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,Democratic,"Obama, Barack",22,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,Republican,"Romney, Mitt",55,000080
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Stein, Jill E",1,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+MCPHERSON,Harper Township,President / Vice President,,Democratic,"Obama, Barack",16,000090
+MCPHERSON,Harper Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000090
+MCPHERSON,Harper Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+MCPHERSON,Harper Township,President / Vice President,,Republican,"Romney, Mitt",59,000090
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,Democratic,"Obama, Barack",33,000100
+MCPHERSON,Hayes Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+MCPHERSON,Hayes Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,Republican,"Romney, Mitt",81,000100
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,Democratic,"Obama, Barack",32,000110
+MCPHERSON,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+MCPHERSON,Jackson Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000110
+MCPHERSON,Jackson Township,President / Vice President,,Republican,"Romney, Mitt",69,000110
+MCPHERSON,King City Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+MCPHERSON,King City Township,President / Vice President,,Democratic,"Obama, Barack",71,000120
+MCPHERSON,King City Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000120
+MCPHERSON,King City Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+MCPHERSON,King City Township,President / Vice President,,Republican,"Romney, Mitt",159,000120
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Stein, Jill E",1,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,Democratic,"Obama, Barack",162,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",16,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,Republican,"Romney, Mitt",216,000130
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",2,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Goode, Virgil",1,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,Democratic,"Obama, Barack",194,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",13,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,Republican,"Romney, Mitt",276,000140
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,Democratic,"Obama, Barack",105,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",10,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",3,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,Republican,"Romney, Mitt",211,000150
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,Democratic,"Obama, Barack",99,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",9,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",2,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,Republican,"Romney, Mitt",161,000160
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,Democratic,"Obama, Barack",39,000170
+MCPHERSON,Little Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+MCPHERSON,Little Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,Republican,"Romney, Mitt",156,000170
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,Democratic,"Obama, Barack",27,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,Republican,"Romney, Mitt",71,000180
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,Democratic,"Obama, Barack",118,000190
+MCPHERSON,Marquette Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000190
+MCPHERSON,Marquette Township,President / Vice President,,Reform,"Baldwin, Chuck",6,000190
+MCPHERSON,Marquette Township,President / Vice President,,Republican,"Romney, Mitt",226,000190
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,Democratic,"Obama, Barack",72,000200
+MCPHERSON,McPherson Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000200
+MCPHERSON,McPherson Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000200
+MCPHERSON,McPherson Township,President / Vice President,,Republican,"Romney, Mitt",212,000200
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Barnett, Andre",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Bush, Kent W",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Christensen, Will",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Goode, Virgil",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Stein, Jill E",1,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,Democratic,"Obama, Barack",28,000290
+MCPHERSON,Meridian Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000290
+MCPHERSON,Meridian Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,Republican,"Romney, Mitt",87,000290
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Barnett, Andre",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Bush, Kent W",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Christensen, Will",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Goode, Virgil",2,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Stein, Jill E",4,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+MCPHERSON,Mound Township,President / Vice President,,Democratic,"Obama, Barack",248,000300
+MCPHERSON,Mound Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000300
+MCPHERSON,Mound Township,President / Vice President,,Reform,"Baldwin, Chuck",6,000300
+MCPHERSON,Mound Township,President / Vice President,,Republican,"Romney, Mitt",494,000300
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Barnett, Andre",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Bush, Kent W",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Christensen, Will",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Goode, Virgil",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Stein, Jill E",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,Democratic,"Obama, Barack",46,000310
+MCPHERSON,New Gottland Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000310
+MCPHERSON,New Gottland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,Republican,"Romney, Mitt",199,000310
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Barnett, Andre",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Bush, Kent W",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Christensen, Will",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Goode, Virgil",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Stein, Jill E",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,Democratic,"Obama, Barack",43,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,Republican,"Romney, Mitt",126,000320
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,Democratic,"Obama, Barack",8,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,Republican,"Romney, Mitt",37,000330
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,Democratic,"Obama, Barack",24,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,Republican,"Romney, Mitt",115,000340
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Ayers, Avery L",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Barnett, Andre",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Bush, Kent W",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Christensen, Will",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Duncan, Richard A",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Goode, Virgil",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Knill, Dennis J",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Reed, Jill A.",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Rogers, Rick L",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Stein, Jill E",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000350
+MCPHERSON,Superior Township,President / Vice President,,Democratic,"Obama, Barack",143,000350
+MCPHERSON,Superior Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000350
+MCPHERSON,Superior Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000350
+MCPHERSON,Superior Township,President / Vice President,,Republican,"Romney, Mitt",602,000350
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,Democratic,"Obama, Barack",24,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,Republican,"Romney, Mitt",100,000360
+MCPHERSON,Union Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Ayers, Avery L",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Barnett, Andre",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Bush, Kent W",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Christensen, Will",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Duncan, Richard A",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Goode, Virgil",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Knill, Dennis J",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Reed, Jill A.",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Rogers, Rick L",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Stein, Jill E",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000370
+MCPHERSON,Union Township,President / Vice President,,Democratic,"Obama, Barack",19,000370
+MCPHERSON,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000370
+MCPHERSON,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000370
+MCPHERSON,Union Township,President / Vice President,,Republican,"Romney, Mitt",67,000370
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",2,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",1,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",895,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",39,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",13,900010
+MCPHERSON,McPherson Ward 1 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",1988,900010
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Bush, Kent W",1,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Christensen, Will",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,Democratic,"Obama, Barack",276,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",18,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",4,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,Republican,"Romney, Mitt",653,900020
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Barnett, Andre",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Bush, Kent W",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Christensen, Will",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Goode, Virgil",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Stein, Jill E",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,Democratic,"Obama, Barack",147,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,Libertarian,"Johnson, Gary",14,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,Reform,"Baldwin, Chuck",5,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,Republican,"Romney, Mitt",382,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Barnett, Andre",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Bush, Kent W",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Christensen, Will",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Goode, Virgil",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Stein, Jill E",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,Democratic,"Obama, Barack",315,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,Libertarian,"Johnson, Gary",25,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,Reform,"Baldwin, Chuck",10,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,Republican,"Romney, Mitt",783,900040
+MCPHERSON,Battle Hill Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000010
+MCPHERSON,Bonaville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000020
+MCPHERSON,Canton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",317,000030
+MCPHERSON,Castle Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",66,000040
+MCPHERSON,Delmore Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",71,000050
+MCPHERSON,Empire Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",441,000060
+MCPHERSON,Groveland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",72,000070
+MCPHERSON,Gypsum Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",61,000080
+MCPHERSON,Harper Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,000090
+MCPHERSON,Hayes Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",85,000100
+MCPHERSON,Jackson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",81,000110
+MCPHERSON,King City Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",192,000120
+MCPHERSON,Lindsborg Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",284,000130
+MCPHERSON,Lindsborg Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",345,000140
+MCPHERSON,Lindsborg Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",262,000150
+MCPHERSON,Lindsborg Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",199,000160
+MCPHERSON,Little Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",162,000170
+MCPHERSON,Lone Tree Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",77,000180
+MCPHERSON,Marquette Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",279,000190
+MCPHERSON,McPherson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",249,000200
+MCPHERSON,Meridian Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",103,000290
+MCPHERSON,Mound Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",594,000300
+MCPHERSON,New Gottland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",222,000310
+MCPHERSON,Smoky Hill Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",144,000320
+MCPHERSON,South Sharps Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000330
+MCPHERSON,Spring Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",124,000340
+MCPHERSON,Superior Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",660,000350
+MCPHERSON,Turkey Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",104,000360
+MCPHERSON,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",71,000370
+MCPHERSON,McPherson Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",2369,900010
+MCPHERSON,McPherson Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",791,900020
+MCPHERSON,McPherson Ward 3 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",454,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",941,900040
+MCPHERSON,McPherson Ward 1 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900050

--- a/2012/20121106__ks__general__meade__precinct.csv
+++ b/2012/20121106__ks__general__meade__precinct.csv
@@ -1,0 +1,82 @@
+county,precinct,office,district,party,candidate,votes,vtd
+MEADE,Cimarron Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",6,000010
+MEADE,Cimarron Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",31,000010
+MEADE,Crooked Creek Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",4,000020
+MEADE,Crooked Creek Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",39,000020
+MEADE,Fowler Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",30,000030
+MEADE,Fowler Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",217,000030
+MEADE,Logan Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",3,000040
+MEADE,Logan Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",48,000040
+MEADE,Meade Center Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",103,000050
+MEADE,Meade Center Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",700,000050
+MEADE,Mertilla Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",6,000060
+MEADE,Mertilla Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",46,000060
+MEADE,Odee Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",1,000070
+MEADE,Odee Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",24,000070
+MEADE,Sand Creek Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",0,000080
+MEADE,Sand Creek Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",21,000080
+MEADE,West Plains Township,Kansas House of Representatives,115,Democratic,"Gilbert, Marjorie ""Mo""",78,000090
+MEADE,West Plains Township,Kansas House of Representatives,115,Republican,"Ryckman, Ronald",292,000090
+MEADE,Cimarron Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",5,000010
+MEADE,Cimarron Township,Kansas Senate,38,Republican,"Love, Garrett",32,000010
+MEADE,Crooked Creek Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",2,000020
+MEADE,Crooked Creek Township,Kansas Senate,38,Republican,"Love, Garrett",43,000020
+MEADE,Fowler Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",27,000030
+MEADE,Fowler Township,Kansas Senate,38,Republican,"Love, Garrett",228,000030
+MEADE,Logan Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",4,000040
+MEADE,Logan Township,Kansas Senate,38,Republican,"Love, Garrett",48,000040
+MEADE,Meade Center Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",91,000050
+MEADE,Meade Center Township,Kansas Senate,38,Republican,"Love, Garrett",716,000050
+MEADE,Mertilla Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",7,000060
+MEADE,Mertilla Township,Kansas Senate,38,Republican,"Love, Garrett",45,000060
+MEADE,Odee Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",3,000070
+MEADE,Odee Township,Kansas Senate,38,Republican,"Love, Garrett",22,000070
+MEADE,Sand Creek Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",0,000080
+MEADE,Sand Creek Township,Kansas Senate,38,Republican,"Love, Garrett",21,000080
+MEADE,West Plains Township,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",69,000090
+MEADE,West Plains Township,Kansas Senate,38,Republican,"Love, Garrett",305,000090
+MEADE,Cimarron Township,President / Vice President,,Democratic,"Obama, Barack",5,000010
+MEADE,Cimarron Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+MEADE,Cimarron Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+MEADE,Cimarron Township,President / Vice President,,Republican,"Romney, Mitt",32,000010
+MEADE,Crooked Creek Township,President / Vice President,,Democratic,"Obama, Barack",5,000020
+MEADE,Crooked Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,Republican,"Romney, Mitt",41,000020
+MEADE,Fowler Township,President / Vice President,,Democratic,"Obama, Barack",40,000030
+MEADE,Fowler Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+MEADE,Fowler Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+MEADE,Fowler Township,President / Vice President,,Republican,"Romney, Mitt",225,000030
+MEADE,Logan Township,President / Vice President,,Democratic,"Obama, Barack",6,000040
+MEADE,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+MEADE,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+MEADE,Logan Township,President / Vice President,,Republican,"Romney, Mitt",44,000040
+MEADE,Meade Center Township,President / Vice President,,Democratic,"Obama, Barack",120,000050
+MEADE,Meade Center Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000050
+MEADE,Meade Center Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000050
+MEADE,Meade Center Township,President / Vice President,,Republican,"Romney, Mitt",696,000050
+MEADE,Mertilla Township,President / Vice President,,Democratic,"Obama, Barack",3,000060
+MEADE,Mertilla Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+MEADE,Mertilla Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+MEADE,Mertilla Township,President / Vice President,,Republican,"Romney, Mitt",49,000060
+MEADE,Odee Township,President / Vice President,,Democratic,"Obama, Barack",3,000070
+MEADE,Odee Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+MEADE,Odee Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+MEADE,Odee Township,President / Vice President,,Republican,"Romney, Mitt",22,000070
+MEADE,Sand Creek Township,President / Vice President,,Democratic,"Obama, Barack",0,000080
+MEADE,Sand Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+MEADE,Sand Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+MEADE,Sand Creek Township,President / Vice President,,Republican,"Romney, Mitt",21,000080
+MEADE,West Plains Township,President / Vice President,,Democratic,"Obama, Barack",76,000090
+MEADE,West Plains Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000090
+MEADE,West Plains Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000090
+MEADE,West Plains Township,President / Vice President,,Republican,"Romney, Mitt",298,000090
+MEADE,Cimarron Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000010
+MEADE,Crooked Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000020
+MEADE,Fowler Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",215,000030
+MEADE,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000040
+MEADE,Meade Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",688,000050
+MEADE,Mertilla Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",46,000060
+MEADE,Odee Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000070
+MEADE,Sand Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000080
+MEADE,West Plains Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",319,000090

--- a/2012/20121106__ks__general__miami__precinct.csv
+++ b/2012/20121106__ks__general__miami__precinct.csv
@@ -1,0 +1,1607 @@
+county,precinct,office,district,party,candidate,votes,vtd
+MIAMI,East Valley Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",184,000020
+MIAMI,Louisburg Ward 1 Exclave Park,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,00003B
+MIAMI,Louisburg Ward 2 Exclave A,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,00004B
+MIAMI,Louisburg Ward 2 Exclave B,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,00004C
+MIAMI,Miami Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",251,000050
+MIAMI,Mound Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",148,000060
+MIAMI,Mound Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",165,000060
+MIAMI,North Marysville Township Enclave,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",0,00007B
+MIAMI,North Wea Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",305,000080
+MIAMI,Osage Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",235,000090
+MIAMI,Osawatomie Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",157,000100
+MIAMI,Osawatomie Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",172,000100
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,00011B
+MIAMI,Osawatomie Ward 2,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",185,00012A
+MIAMI,Osawatomie Ward 2,Kansas House of Representatives,5,Republican,"Jones, Kevin",182,00012A
+MIAMI,Osawatomie Ward 2 Exclave Lake,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,00012B
+MIAMI,Osawatomie Ward 3,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",263,00013A
+MIAMI,Osawatomie Ward 3,Kansas House of Representatives,5,Republican,"Jones, Kevin",175,00013A
+MIAMI,Osawatomie Ward 3 Exclave A,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave B,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,00013C
+MIAMI,Osawatomie Ward 4,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",109,000140
+MIAMI,Osawatomie Ward 4,Kansas House of Representatives,5,Republican,"Jones, Kevin",125,000140
+MIAMI,Paola Ward 1,Kansas House of Representatives,6,Republican,"Vickrey, Jene",459,00016A
+MIAMI,Paola Ward 1 Exclave,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,00016B
+MIAMI,Paola Ward 2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",303,000170
+MIAMI,Paola Ward 3,Kansas House of Representatives,6,Republican,"Vickrey, Jene",481,00018A
+MIAMI,Paola Ward 3 Exclave A,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,00018B
+MIAMI,Paola Ward 4,Kansas House of Representatives,6,Republican,"Vickrey, Jene",638,00019A
+MIAMI,Paola Ward 4 Exclave,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,00019B
+MIAMI,Richland Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",901,000200
+MIAMI,South Wea Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",689,000220
+MIAMI,Spring Hill City Precinct 01,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",642,00023A
+MIAMI,Spring Hill City Exclave A,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",0,00023B
+MIAMI,Spring Hill City Exclave B,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",168,00023C
+MIAMI,Spring Hill City Exclave C,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",0,00023D
+MIAMI,Stanton Township,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",174,000240
+MIAMI,Stanton Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",253,000240
+MIAMI,Sugar Creek Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",210,000250
+MIAMI,Ten Mile Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",684,000260
+MIAMI,West Middle Creek Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",331,000270
+MIAMI,East Middle Creek Township C2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",115,120020
+MIAMI,East Middle Creek Township C3,Kansas House of Representatives,6,Republican,"Vickrey, Jene",380,120030
+MIAMI,North Marysville Township C2,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",129,120040
+MIAMI,North Marysville Township C3,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",361,120050
+MIAMI,Osawatomie Ward 1 H5,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",146,120060
+MIAMI,Osawatomie Ward 1 H5,Kansas House of Representatives,5,Republican,"Jones, Kevin",104,120060
+MIAMI,Osawatomie Ward 1 H6,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,120070
+MIAMI,South Marysville Township C2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",601,120080
+MIAMI,South Marysville Township C3,Kansas House of Representatives,6,Republican,"Vickrey, Jene",10,120090
+MIAMI,West Valley Township H5,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",66,120100
+MIAMI,West Valley Township H5,Kansas House of Representatives,5,Republican,"Jones, Kevin",70,120100
+MIAMI,West Valley Township H6,Kansas House of Representatives,6,Republican,"Vickrey, Jene",103,120110
+MIAMI,North Paola Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",211,200010
+MIAMI,South Paola Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",142,200020
+MIAMI,Louisburg Ward 1,Kansas House of Representatives,6,Republican,"Vickrey, Jene",486,300010
+MIAMI,Louisburg Ward 2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",1181,300020
+MIAMI,Osawatomie Township Enclave A,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",0,900010
+MIAMI,Osawatomie Township Enclave A,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,900010
+MIAMI,Osawatomie Township Enclave B,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",0,900020
+MIAMI,Osawatomie Township Enclave B,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,900020
+MIAMI,Osawatomie Ward 1 Exclave B,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900030
+MIAMI,Osawatomie Ward 1 Exclave C,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900040
+MIAMI,Osawatomie Ward 1 Exclave D,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900050
+MIAMI,Osawatomie Ward 3 Exclave D,Kansas House of Representatives,5,Democratic,"Feuerborn, Bill",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,900070
+MIAMI,Paola Ward 1 Exclave B,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900080
+MIAMI,South Wea Township Enclave A,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900090
+MIAMI,South Wea Township Enclave B,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900100
+MIAMI,South Wea Township Enclave C,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900110
+MIAMI,West Valley Township Exclave,Kansas House of Representatives,6,Republican,"Vickrey, Jene",192,900120
+MIAMI,North Marysville Township Enclave 2,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",0,900130
+MIAMI,North Paola Township Part 1,Kansas House of Representatives,6,Republican,"Vickrey, Jene",14,900140
+MIAMI,North Paola Township Part 2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",63,900150
+MIAMI,North Paola Township Part 3,Kansas House of Representatives,6,Republican,"Vickrey, Jene",0,900160
+MIAMI,South Paola Township Part 2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",85,900180
+MIAMI,East Valley Township,Kansas Senate,12,Democratic,"Cassells, Denise",48,000020
+MIAMI,East Valley Township,Kansas Senate,12,Republican,"Tyson, Caryn",152,000020
+MIAMI,Louisburg Ward 1 Exclave Park,Kansas Senate,37,Republican,"Apple, Pat",0,00003B
+MIAMI,Louisburg Ward 2 Exclave A,Kansas Senate,37,Republican,"Apple, Pat",0,00004B
+MIAMI,Louisburg Ward 2 Exclave B,Kansas Senate,37,Republican,"Apple, Pat",0,00004C
+MIAMI,Miami Township,Kansas Senate,12,Democratic,"Cassells, Denise",87,000050
+MIAMI,Miami Township,Kansas Senate,12,Republican,"Tyson, Caryn",197,000050
+MIAMI,Mound Township,Kansas Senate,12,Democratic,"Cassells, Denise",123,000060
+MIAMI,Mound Township,Kansas Senate,12,Republican,"Tyson, Caryn",189,000060
+MIAMI,North Marysville Township Enclave,Kansas Senate,37,Republican,"Apple, Pat",0,00007B
+MIAMI,North Wea Township,Kansas Senate,37,Republican,"Apple, Pat",301,000080
+MIAMI,Osage Township,Kansas Senate,12,Democratic,"Cassells, Denise",91,000090
+MIAMI,Osage Township,Kansas Senate,12,Republican,"Tyson, Caryn",181,000090
+MIAMI,Osawatomie Township,Kansas Senate,12,Democratic,"Cassells, Denise",102,000100
+MIAMI,Osawatomie Township,Kansas Senate,12,Republican,"Tyson, Caryn",222,000100
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,Kansas Senate,37,Republican,"Apple, Pat",0,00011B
+MIAMI,Osawatomie Ward 2,Kansas Senate,12,Democratic,"Cassells, Denise",148,00012A
+MIAMI,Osawatomie Ward 2,Kansas Senate,12,Republican,"Tyson, Caryn",213,00012A
+MIAMI,Osawatomie Ward 2 Exclave Lake,Kansas Senate,37,Republican,"Apple, Pat",0,00012B
+MIAMI,Osawatomie Ward 3,Kansas Senate,12,Democratic,"Cassells, Denise",210,00013A
+MIAMI,Osawatomie Ward 3,Kansas Senate,12,Republican,"Tyson, Caryn",220,00013A
+MIAMI,Osawatomie Ward 3 Exclave A,Kansas Senate,12,Democratic,"Cassells, Denise",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,Kansas Senate,12,Republican,"Tyson, Caryn",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave B,Kansas Senate,12,Democratic,"Cassells, Denise",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,Kansas Senate,12,Republican,"Tyson, Caryn",0,00013C
+MIAMI,Osawatomie Ward 4,Kansas Senate,12,Democratic,"Cassells, Denise",92,000140
+MIAMI,Osawatomie Ward 4,Kansas Senate,12,Republican,"Tyson, Caryn",139,000140
+MIAMI,Paola Ward 1,Kansas Senate,37,Republican,"Apple, Pat",480,00016A
+MIAMI,Paola Ward 1 Exclave,Kansas Senate,37,Republican,"Apple, Pat",0,00016B
+MIAMI,Paola Ward 2,Kansas Senate,37,Republican,"Apple, Pat",310,000170
+MIAMI,Paola Ward 3,Kansas Senate,37,Republican,"Apple, Pat",481,00018A
+MIAMI,Paola Ward 3 Exclave A,Kansas Senate,37,Republican,"Apple, Pat",0,00018B
+MIAMI,Paola Ward 4,Kansas Senate,37,Republican,"Apple, Pat",654,00019A
+MIAMI,Paola Ward 4 Exclave,Kansas Senate,37,Republican,"Apple, Pat",0,00019B
+MIAMI,Richland Township,Kansas Senate,37,Republican,"Apple, Pat",900,000200
+MIAMI,South Wea Township,Kansas Senate,37,Republican,"Apple, Pat",696,000220
+MIAMI,Spring Hill City Precinct 01,Kansas Senate,37,Republican,"Apple, Pat",659,00023A
+MIAMI,Spring Hill City Exclave A,Kansas Senate,37,Republican,"Apple, Pat",0,00023B
+MIAMI,Spring Hill City Exclave B,Kansas Senate,37,Republican,"Apple, Pat",174,00023C
+MIAMI,Spring Hill City Exclave C,Kansas Senate,37,Republican,"Apple, Pat",0,00023D
+MIAMI,Stanton Township,Kansas Senate,37,Republican,"Apple, Pat",363,000240
+MIAMI,Sugar Creek Township,Kansas Senate,12,Democratic,"Cassells, Denise",68,000250
+MIAMI,Sugar Creek Township,Kansas Senate,12,Republican,"Tyson, Caryn",167,000250
+MIAMI,Ten Mile Township,Kansas Senate,37,Republican,"Apple, Pat",679,000260
+MIAMI,West Middle Creek Township,Kansas Senate,37,Republican,"Apple, Pat",343,000270
+MIAMI,East Middle Creek Township C2,Kansas Senate,37,Republican,"Apple, Pat",122,120020
+MIAMI,East Middle Creek Township C3,Kansas Senate,37,Republican,"Apple, Pat",392,120030
+MIAMI,North Marysville Township C2,Kansas Senate,37,Republican,"Apple, Pat",132,120040
+MIAMI,North Marysville Township C3,Kansas Senate,37,Republican,"Apple, Pat",371,120050
+MIAMI,Osawatomie Ward 1 H5,Kansas Senate,12,Democratic,"Cassells, Denise",107,120060
+MIAMI,Osawatomie Ward 1 H5,Kansas Senate,12,Republican,"Tyson, Caryn",136,120060
+MIAMI,Osawatomie Ward 1 H6,Kansas Senate,12,Democratic,"Cassells, Denise",0,120070
+MIAMI,Osawatomie Ward 1 H6,Kansas Senate,12,Republican,"Tyson, Caryn",0,120070
+MIAMI,South Marysville Township C2,Kansas Senate,37,Republican,"Apple, Pat",609,120080
+MIAMI,South Marysville Township C3,Kansas Senate,37,Republican,"Apple, Pat",10,120090
+MIAMI,West Valley Township H5,Kansas Senate,37,Republican,"Apple, Pat",121,120100
+MIAMI,West Valley Township H6,Kansas Senate,37,Republican,"Apple, Pat",103,120110
+MIAMI,North Paola Township,Kansas Senate,37,Republican,"Apple, Pat",211,200010
+MIAMI,South Paola Township,Kansas Senate,37,Republican,"Apple, Pat",143,200020
+MIAMI,Louisburg Ward 1,Kansas Senate,37,Republican,"Apple, Pat",503,300010
+MIAMI,Louisburg Ward 2,Kansas Senate,37,Republican,"Apple, Pat",1189,300020
+MIAMI,Osawatomie Township Enclave A,Kansas Senate,12,Democratic,"Cassells, Denise",0,900010
+MIAMI,Osawatomie Township Enclave A,Kansas Senate,12,Republican,"Tyson, Caryn",0,900010
+MIAMI,Osawatomie Township Enclave B,Kansas Senate,12,Democratic,"Cassells, Denise",0,900020
+MIAMI,Osawatomie Township Enclave B,Kansas Senate,12,Republican,"Tyson, Caryn",0,900020
+MIAMI,Osawatomie Ward 1 Exclave B,Kansas Senate,37,Republican,"Apple, Pat",0,900030
+MIAMI,Osawatomie Ward 1 Exclave C,Kansas Senate,12,Democratic,"Cassells, Denise",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,Kansas Senate,12,Republican,"Tyson, Caryn",0,900040
+MIAMI,Osawatomie Ward 1 Exclave D,Kansas Senate,12,Democratic,"Cassells, Denise",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,Kansas Senate,12,Republican,"Tyson, Caryn",0,900050
+MIAMI,Osawatomie Ward 3 Exclave D,Kansas Senate,12,Democratic,"Cassells, Denise",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,Kansas Senate,12,Republican,"Tyson, Caryn",0,900070
+MIAMI,Paola Ward 1 Exclave B,Kansas Senate,37,Republican,"Apple, Pat",0,900080
+MIAMI,South Wea Township Enclave A,Kansas Senate,37,Republican,"Apple, Pat",0,900090
+MIAMI,South Wea Township Enclave B,Kansas Senate,37,Republican,"Apple, Pat",0,900100
+MIAMI,South Wea Township Enclave C,Kansas Senate,37,Republican,"Apple, Pat",0,900110
+MIAMI,West Valley Township Exclave,Kansas Senate,12,Democratic,"Cassells, Denise",55,900120
+MIAMI,West Valley Township Exclave,Kansas Senate,12,Republican,"Tyson, Caryn",152,900120
+MIAMI,North Marysville Township Enclave 2,Kansas Senate,37,Republican,"Apple, Pat",0,900130
+MIAMI,North Paola Township Part 1,Kansas Senate,37,Republican,"Apple, Pat",15,900140
+MIAMI,North Paola Township Part 2,Kansas Senate,37,Republican,"Apple, Pat",67,900150
+MIAMI,North Paola Township Part 3,Kansas Senate,37,Republican,"Apple, Pat",0,900160
+MIAMI,South Paola Township Part 2,Kansas Senate,37,Republican,"Apple, Pat",86,900180
+MIAMI,East Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+MIAMI,East Valley Township,President / Vice President,,Democratic,"Obama, Barack",62,000020
+MIAMI,East Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+MIAMI,East Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+MIAMI,East Valley Township,President / Vice President,,Republican,"Romney, Mitt",150,000020
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Ayers, Avery L",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Barnett, Andre",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Barr, Roseanne C",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Bush, Kent W",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Christensen, Will",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Duncan, Richard A",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Goode, Virgil",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Hoefling, Tom",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Knill, Dennis J",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Reed, Jill A.",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Rogers, Rick L",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Stein, Jill E",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Thorne, Kevin M",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,write - in,"Warner, Gerald L.",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,Democratic,"Obama, Barack",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,Libertarian,"Johnson, Gary",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,Reform,"Baldwin, Chuck",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,President / Vice President,,Republican,"Romney, Mitt",0,00003B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00004B
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Christensen, Will",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,00004C
+MIAMI,Miami Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+MIAMI,Miami Township,President / Vice President,,Democratic,"Obama, Barack",92,000050
+MIAMI,Miami Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000050
+MIAMI,Miami Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000050
+MIAMI,Miami Township,President / Vice President,,Republican,"Romney, Mitt",197,000050
+MIAMI,Mound Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+MIAMI,Mound Township,President / Vice President,,Democratic,"Obama, Barack",113,000060
+MIAMI,Mound Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+MIAMI,Mound Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000060
+MIAMI,Mound Township,President / Vice President,,Republican,"Romney, Mitt",200,000060
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Christensen, Will",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00007B
+MIAMI,North Marysville Township Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00007B
+MIAMI,North Wea Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+MIAMI,North Wea Township,President / Vice President,,Democratic,"Obama, Barack",68,000080
+MIAMI,North Wea Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+MIAMI,North Wea Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+MIAMI,North Wea Township,President / Vice President,,Republican,"Romney, Mitt",264,000080
+MIAMI,Osage Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+MIAMI,Osage Township,President / Vice President,,Democratic,"Obama, Barack",90,000090
+MIAMI,Osage Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000090
+MIAMI,Osage Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+MIAMI,Osage Township,President / Vice President,,Republican,"Romney, Mitt",184,000090
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,Democratic,"Obama, Barack",101,000100
+MIAMI,Osawatomie Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000100
+MIAMI,Osawatomie Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+MIAMI,Osawatomie Township,President / Vice President,,Republican,"Romney, Mitt",230,000100
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Ayers, Avery L",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Barnett, Andre",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Barr, Roseanne C",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Bush, Kent W",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Christensen, Will",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Duncan, Richard A",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Goode, Virgil",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Hoefling, Tom",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Knill, Dennis J",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Reed, Jill A.",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Rogers, Rick L",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Stein, Jill E",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Thorne, Kevin M",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,write - in,"Warner, Gerald L.",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,Democratic,"Obama, Barack",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,Libertarian,"Johnson, Gary",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,Reform,"Baldwin, Chuck",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,President / Vice President,,Republican,"Romney, Mitt",0,00011B
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,Democratic,"Obama, Barack",153,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",3,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,Republican,"Romney, Mitt",217,00012A
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Ayers, Avery L",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Barnett, Andre",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Barr, Roseanne C",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Bush, Kent W",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Christensen, Will",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Duncan, Richard A",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Goode, Virgil",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Hoefling, Tom",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Knill, Dennis J",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Reed, Jill A.",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Rogers, Rick L",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Stein, Jill E",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Thorne, Kevin M",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,write - in,"Warner, Gerald L.",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,Democratic,"Obama, Barack",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,Libertarian,"Johnson, Gary",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,Reform,"Baldwin, Chuck",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,President / Vice President,,Republican,"Romney, Mitt",0,00012B
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,Democratic,"Obama, Barack",226,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",12,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,Republican,"Romney, Mitt",209,00013A
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Christensen, Will",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,00013C
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,Democratic,"Obama, Barack",107,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",3,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,Republican,"Romney, Mitt",133,000140
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Christensen, Will",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,Democratic,"Obama, Barack",216,00016A
+MIAMI,Paola Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",10,00016A
+MIAMI,Paola Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,00016A
+MIAMI,Paola Ward 1,President / Vice President,,Republican,"Romney, Mitt",329,00016A
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00016B
+MIAMI,Paola Ward 1 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00016B
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Stein, Jill E",2,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,Democratic,"Obama, Barack",154,000170
+MIAMI,Paola Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",5,000170
+MIAMI,Paola Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",5,000170
+MIAMI,Paola Ward 2,President / Vice President,,Republican,"Romney, Mitt",189,000170
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,Democratic,"Obama, Barack",237,00018A
+MIAMI,Paola Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",8,00018A
+MIAMI,Paola Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",2,00018A
+MIAMI,Paola Ward 3,President / Vice President,,Republican,"Romney, Mitt",341,00018A
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00018B
+MIAMI,Paola Ward 3 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00018B
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Christensen, Will",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,Democratic,"Obama, Barack",303,00019A
+MIAMI,Paola Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",12,00019A
+MIAMI,Paola Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",5,00019A
+MIAMI,Paola Ward 4,President / Vice President,,Republican,"Romney, Mitt",459,00019A
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00019B
+MIAMI,Paola Ward 4 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00019B
+MIAMI,Richland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Stein, Jill E",2,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+MIAMI,Richland Township,President / Vice President,,Democratic,"Obama, Barack",248,000200
+MIAMI,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",22,000200
+MIAMI,Richland Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000200
+MIAMI,Richland Township,President / Vice President,,Republican,"Romney, Mitt",761,000200
+MIAMI,South Wea Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+MIAMI,South Wea Township,President / Vice President,,Democratic,"Obama, Barack",157,000220
+MIAMI,South Wea Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000220
+MIAMI,South Wea Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000220
+MIAMI,South Wea Township,President / Vice President,,Republican,"Romney, Mitt",586,000220
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,Democratic,"Obama, Barack",236,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",14,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",5,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,Republican,"Romney, Mitt",512,00023A
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00023B
+MIAMI,Spring Hill City Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00023B
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Christensen, Will",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,Democratic,"Obama, Barack",78,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",4,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",1,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,Republican,"Romney, Mitt",131,00023C
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Ayers, Avery L",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Barnett, Andre",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Barr, Roseanne C",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Bush, Kent W",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Christensen, Will",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Duncan, Richard A",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Goode, Virgil",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Knill, Dennis J",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Reed, Jill A.",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Rogers, Rick L",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Stein, Jill E",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Thorne, Kevin M",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Warner, Gerald L.",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,Democratic,"Obama, Barack",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,Reform,"Baldwin, Chuck",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,Republican,"Romney, Mitt",0,00023D
+MIAMI,Stanton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+MIAMI,Stanton Township,President / Vice President,,Democratic,"Obama, Barack",151,000240
+MIAMI,Stanton Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000240
+MIAMI,Stanton Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000240
+MIAMI,Stanton Township,President / Vice President,,Republican,"Romney, Mitt",279,000240
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,Democratic,"Obama, Barack",65,000250
+MIAMI,Sugar Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000250
+MIAMI,Sugar Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,Republican,"Romney, Mitt",172,000250
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Barnett, Andre",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Bush, Kent W",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Christensen, Will",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Goode, Virgil",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Stein, Jill E",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,Democratic,"Obama, Barack",192,000260
+MIAMI,Ten Mile Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000260
+MIAMI,Ten Mile Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000260
+MIAMI,Ten Mile Township,President / Vice President,,Republican,"Romney, Mitt",565,000260
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,Democratic,"Obama, Barack",104,000270
+MIAMI,West Middle Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000270
+MIAMI,West Middle Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000270
+MIAMI,West Middle Creek Township,President / Vice President,,Republican,"Romney, Mitt",264,000270
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Barnett, Andre",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Bush, Kent W",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Christensen, Will",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Goode, Virgil",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Stein, Jill E",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,Democratic,"Obama, Barack",35,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,Libertarian,"Johnson, Gary",3,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,Republican,"Romney, Mitt",98,120020
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Barnett, Andre",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Bush, Kent W",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Christensen, Will",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Goode, Virgil",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Stein, Jill E",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,Democratic,"Obama, Barack",117,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,Libertarian,"Johnson, Gary",2,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,Reform,"Baldwin, Chuck",1,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,Republican,"Romney, Mitt",321,120030
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Barnett, Andre",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Bush, Kent W",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Christensen, Will",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Goode, Virgil",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Stein, Jill E",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,Democratic,"Obama, Barack",21,120040
+MIAMI,North Marysville Township C2,President / Vice President,,Libertarian,"Johnson, Gary",1,120040
+MIAMI,North Marysville Township C2,President / Vice President,,Reform,"Baldwin, Chuck",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,Republican,"Romney, Mitt",130,120040
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Barnett, Andre",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Bush, Kent W",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Christensen, Will",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Goode, Virgil",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Stein, Jill E",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+MIAMI,North Marysville Township C3,President / Vice President,,Democratic,"Obama, Barack",141,120050
+MIAMI,North Marysville Township C3,President / Vice President,,Libertarian,"Johnson, Gary",2,120050
+MIAMI,North Marysville Township C3,President / Vice President,,Reform,"Baldwin, Chuck",4,120050
+MIAMI,North Marysville Township C3,President / Vice President,,Republican,"Romney, Mitt",318,120050
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Ayers, Avery L",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Barnett, Andre",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Barr, Roseanne C",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Bush, Kent W",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Christensen, Will",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Duncan, Richard A",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Goode, Virgil",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Knill, Dennis J",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Reed, Jill A.",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Rogers, Rick L",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Stein, Jill E",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Thorne, Kevin M",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,write - in,"Warner, Gerald L.",0,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,Democratic,"Obama, Barack",126,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,Libertarian,"Johnson, Gary",6,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,Reform,"Baldwin, Chuck",5,120060
+MIAMI,Osawatomie Ward 1 H5,President / Vice President,,Republican,"Romney, Mitt",119,120060
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Ayers, Avery L",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Barnett, Andre",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Barr, Roseanne C",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Bush, Kent W",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Christensen, Will",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Duncan, Richard A",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Goode, Virgil",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Knill, Dennis J",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Reed, Jill A.",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Rogers, Rick L",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Stein, Jill E",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Thorne, Kevin M",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,write - in,"Warner, Gerald L.",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,Democratic,"Obama, Barack",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,Libertarian,"Johnson, Gary",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,Reform,"Baldwin, Chuck",0,120070
+MIAMI,Osawatomie Ward 1 H6,President / Vice President,,Republican,"Romney, Mitt",0,120070
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Ayers, Avery L",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Barnett, Andre",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Barr, Roseanne C",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Bush, Kent W",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Christensen, Will",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Duncan, Richard A",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Goode, Virgil",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Knill, Dennis J",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Reed, Jill A.",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Rogers, Rick L",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Stein, Jill E",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Thorne, Kevin M",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Warner, Gerald L.",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,Democratic,"Obama, Barack",199,120080
+MIAMI,South Marysville Township C2,President / Vice President,,Libertarian,"Johnson, Gary",9,120080
+MIAMI,South Marysville Township C2,President / Vice President,,Reform,"Baldwin, Chuck",4,120080
+MIAMI,South Marysville Township C2,President / Vice President,,Republican,"Romney, Mitt",473,120080
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Ayers, Avery L",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Barnett, Andre",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Barr, Roseanne C",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Bush, Kent W",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Christensen, Will",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Duncan, Richard A",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Goode, Virgil",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Knill, Dennis J",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Reed, Jill A.",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Rogers, Rick L",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Stein, Jill E",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Thorne, Kevin M",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Warner, Gerald L.",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,Democratic,"Obama, Barack",2,120090
+MIAMI,South Marysville Township C3,President / Vice President,,Libertarian,"Johnson, Gary",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,Reform,"Baldwin, Chuck",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,Republican,"Romney, Mitt",11,120090
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Ayers, Avery L",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Barnett, Andre",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Barr, Roseanne C",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Bush, Kent W",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Christensen, Will",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Duncan, Richard A",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Goode, Virgil",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Hoefling, Tom",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Knill, Dennis J",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Reed, Jill A.",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Rogers, Rick L",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Stein, Jill E",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Thorne, Kevin M",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Warner, Gerald L.",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,Democratic,"Obama, Barack",51,120100
+MIAMI,West Valley Township H5,President / Vice President,,Libertarian,"Johnson, Gary",5,120100
+MIAMI,West Valley Township H5,President / Vice President,,Reform,"Baldwin, Chuck",1,120100
+MIAMI,West Valley Township H5,President / Vice President,,Republican,"Romney, Mitt",82,120100
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Ayers, Avery L",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Barnett, Andre",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Barr, Roseanne C",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Bush, Kent W",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Christensen, Will",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Duncan, Richard A",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Goode, Virgil",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Hoefling, Tom",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Knill, Dennis J",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Reed, Jill A.",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Rogers, Rick L",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Stein, Jill E",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Thorne, Kevin M",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Warner, Gerald L.",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,Democratic,"Obama, Barack",39,120110
+MIAMI,West Valley Township H6,President / Vice President,,Libertarian,"Johnson, Gary",1,120110
+MIAMI,West Valley Township H6,President / Vice President,,Reform,"Baldwin, Chuck",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,Republican,"Romney, Mitt",84,120110
+MIAMI,North Paola Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Ayers, Avery L",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Barnett, Andre",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Barr, Roseanne C",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Bush, Kent W",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Christensen, Will",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Duncan, Richard A",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Goode, Virgil",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Hoefling, Tom",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Knill, Dennis J",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Reed, Jill A.",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Rogers, Rick L",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Stein, Jill E",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Thorne, Kevin M",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Warner, Gerald L.",0,200010
+MIAMI,North Paola Township,President / Vice President,,Democratic,"Obama, Barack",81,200010
+MIAMI,North Paola Township,President / Vice President,,Libertarian,"Johnson, Gary",1,200010
+MIAMI,North Paola Township,President / Vice President,,Reform,"Baldwin, Chuck",1,200010
+MIAMI,North Paola Township,President / Vice President,,Republican,"Romney, Mitt",171,200010
+MIAMI,South Paola Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Ayers, Avery L",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Barnett, Andre",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Barr, Roseanne C",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Bush, Kent W",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Christensen, Will",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Duncan, Richard A",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Goode, Virgil",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Hoefling, Tom",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Knill, Dennis J",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Reed, Jill A.",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Rogers, Rick L",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Stein, Jill E",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Thorne, Kevin M",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Warner, Gerald L.",0,200020
+MIAMI,South Paola Township,President / Vice President,,Democratic,"Obama, Barack",49,200020
+MIAMI,South Paola Township,President / Vice President,,Libertarian,"Johnson, Gary",5,200020
+MIAMI,South Paola Township,President / Vice President,,Reform,"Baldwin, Chuck",0,200020
+MIAMI,South Paola Township,President / Vice President,,Republican,"Romney, Mitt",115,200020
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Christensen, Will",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,Democratic,"Obama, Barack",198,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",5,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",3,300010
+MIAMI,Louisburg Ward 1,President / Vice President,,Republican,"Romney, Mitt",379,300010
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Christensen, Will",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,Democratic,"Obama, Barack",389,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",21,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",9,300020
+MIAMI,Louisburg Ward 2,President / Vice President,,Republican,"Romney, Mitt",902,300020
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Barnett, Andre",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Bush, Kent W",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Christensen, Will",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Goode, Virgil",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Stein, Jill E",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,Democratic,"Obama, Barack",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+MIAMI,Osawatomie Township Enclave A,President / Vice President,,Republican,"Romney, Mitt",0,900010
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Barnett, Andre",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Bush, Kent W",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Christensen, Will",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Goode, Virgil",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Stein, Jill E",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,Democratic,"Obama, Barack",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+MIAMI,Osawatomie Township Enclave B,President / Vice President,,Republican,"Romney, Mitt",0,900020
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Christensen, Will",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,900030
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Barnett, Andre",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Bush, Kent W",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Christensen, Will",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Goode, Virgil",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Stein, Jill E",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,Democratic,"Obama, Barack",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,President / Vice President,,Republican,"Romney, Mitt",0,900040
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Ayers, Avery L",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Barnett, Andre",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Barr, Roseanne C",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Bush, Kent W",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Christensen, Will",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Duncan, Richard A",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Goode, Virgil",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Knill, Dennis J",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Reed, Jill A.",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Rogers, Rick L",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Stein, Jill E",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Thorne, Kevin M",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,write - in,"Warner, Gerald L.",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,Democratic,"Obama, Barack",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,Reform,"Baldwin, Chuck",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,President / Vice President,,Republican,"Romney, Mitt",0,900050
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Ayers, Avery L",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Barnett, Andre",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Barr, Roseanne C",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Bush, Kent W",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Christensen, Will",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Duncan, Richard A",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Goode, Virgil",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Hoefling, Tom",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Knill, Dennis J",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Reed, Jill A.",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Rogers, Rick L",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Stein, Jill E",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Thorne, Kevin M",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,write - in,"Warner, Gerald L.",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,Democratic,"Obama, Barack",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,Libertarian,"Johnson, Gary",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,Reform,"Baldwin, Chuck",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,President / Vice President,,Republican,"Romney, Mitt",0,900070
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Christensen, Will",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,900080
+MIAMI,Paola Ward 1 Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,900080
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Ayers, Avery L",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Barnett, Andre",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Bush, Kent W",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Christensen, Will",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Duncan, Richard A",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Goode, Virgil",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Knill, Dennis J",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Reed, Jill A.",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Rogers, Rick L",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Stein, Jill E",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,Democratic,"Obama, Barack",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,900090
+MIAMI,South Wea Township Enclave A,President / Vice President,,Republican,"Romney, Mitt",0,900090
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Ayers, Avery L",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Barnett, Andre",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Bush, Kent W",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Christensen, Will",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Duncan, Richard A",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Goode, Virgil",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Knill, Dennis J",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Reed, Jill A.",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Rogers, Rick L",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Stein, Jill E",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,Democratic,"Obama, Barack",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,900100
+MIAMI,South Wea Township Enclave B,President / Vice President,,Republican,"Romney, Mitt",0,900100
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Ayers, Avery L",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Barnett, Andre",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Barr, Roseanne C",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Bush, Kent W",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Christensen, Will",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Duncan, Richard A",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Goode, Virgil",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Hoefling, Tom",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Knill, Dennis J",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Reed, Jill A.",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Rogers, Rick L",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Stein, Jill E",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Thorne, Kevin M",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,write - in,"Warner, Gerald L.",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,Democratic,"Obama, Barack",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,Reform,"Baldwin, Chuck",0,900110
+MIAMI,South Wea Township Enclave C,President / Vice President,,Republican,"Romney, Mitt",0,900110
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Christensen, Will",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,Democratic,"Obama, Barack",58,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,Libertarian,"Johnson, Gary",4,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,Reform,"Baldwin, Chuck",2,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,Republican,"Romney, Mitt",150,900120
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Christensen, Will",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900130
+MIAMI,North Marysville Township Enclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900130
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Ayers, Avery L",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Barnett, Andre",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Bush, Kent W",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Christensen, Will",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Duncan, Richard A",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Goode, Virgil",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Hoefling, Tom",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Knill, Dennis J",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Reed, Jill A.",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Rogers, Rick L",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Stein, Jill E",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,Democratic,"Obama, Barack",4,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,Republican,"Romney, Mitt",11,900140
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Ayers, Avery L",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Barnett, Andre",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Bush, Kent W",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Christensen, Will",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Duncan, Richard A",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Goode, Virgil",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Knill, Dennis J",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Reed, Jill A.",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Rogers, Rick L",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Stein, Jill E",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,Democratic,"Obama, Barack",15,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,Republican,"Romney, Mitt",59,900150
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Ayers, Avery L",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Barnett, Andre",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Barr, Roseanne C",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Bush, Kent W",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Christensen, Will",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Duncan, Richard A",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Goode, Virgil",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Hoefling, Tom",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Knill, Dennis J",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Reed, Jill A.",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Rogers, Rick L",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Stein, Jill E",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Thorne, Kevin M",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,write - in,"Warner, Gerald L.",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,Democratic,"Obama, Barack",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,Libertarian,"Johnson, Gary",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,Reform,"Baldwin, Chuck",0,900160
+MIAMI,North Paola Township Part 3,President / Vice President,,Republican,"Romney, Mitt",0,900160
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Ayers, Avery L",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Barnett, Andre",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Bush, Kent W",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Christensen, Will",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Duncan, Richard A",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Goode, Virgil",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Knill, Dennis J",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Reed, Jill A.",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Rogers, Rick L",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Stein, Jill E",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,Democratic,"Obama, Barack",34,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,Libertarian,"Johnson, Gary",2,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,Republican,"Romney, Mitt",63,900180
+MIAMI,East Valley Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",40,000020
+MIAMI,East Valley Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000020
+MIAMI,East Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",164,000020
+MIAMI,Louisburg Ward 1 Exclave Park,United States House of Representatives,3,Libertarian,"Balam, Joel",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,United States House of Representatives,3,Republican,"Yoder, Kevin",0,00003B
+MIAMI,Louisburg Ward 2 Exclave A,United States House of Representatives,3,Libertarian,"Balam, Joel",0,00004B
+MIAMI,Louisburg Ward 2 Exclave A,United States House of Representatives,3,Republican,"Yoder, Kevin",0,00004B
+MIAMI,Louisburg Ward 2 Exclave B,United States House of Representatives,3,Libertarian,"Balam, Joel",0,00004C
+MIAMI,Louisburg Ward 2 Exclave B,United States House of Representatives,3,Republican,"Yoder, Kevin",0,00004C
+MIAMI,Miami Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",75,000050
+MIAMI,Miami Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000050
+MIAMI,Miami Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",207,000050
+MIAMI,Mound Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",90,000060
+MIAMI,Mound Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000060
+MIAMI,Mound Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",213,000060
+MIAMI,North Marysville Township Enclave,United States House of Representatives,3,Libertarian,"Balam, Joel",0,00007B
+MIAMI,North Marysville Township Enclave,United States House of Representatives,3,Republican,"Yoder, Kevin",0,00007B
+MIAMI,North Wea Township,United States House of Representatives,3,Libertarian,"Balam, Joel",56,000080
+MIAMI,North Wea Township,United States House of Representatives,3,Republican,"Yoder, Kevin",260,000080
+MIAMI,Osage Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",76,000090
+MIAMI,Osage Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,000090
+MIAMI,Osage Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",185,000090
+MIAMI,Osawatomie Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",84,000100
+MIAMI,Osawatomie Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,000100
+MIAMI,Osawatomie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",225,000100
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00011B
+MIAMI,Osawatomie Ward 1 Exclave A Cemetery,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00011B
+MIAMI,Osawatomie Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",131,00012A
+MIAMI,Osawatomie Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,00012A
+MIAMI,Osawatomie Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",223,00012A
+MIAMI,Osawatomie Ward 2 Exclave Lake,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00012B
+MIAMI,Osawatomie Ward 2 Exclave Lake,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00012B
+MIAMI,Osawatomie Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",181,00013A
+MIAMI,Osawatomie Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",24,00013A
+MIAMI,Osawatomie Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",233,00013A
+MIAMI,Osawatomie Ward 3 Exclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013B
+MIAMI,Osawatomie Ward 3 Exclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00013C
+MIAMI,Osawatomie Ward 3 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013C
+MIAMI,Osawatomie Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",82,000140
+MIAMI,Osawatomie Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000140
+MIAMI,Osawatomie Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",143,000140
+MIAMI,Paola Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",166,00016A
+MIAMI,Paola Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",33,00016A
+MIAMI,Paola Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",346,00016A
+MIAMI,Paola Ward 1 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00016B
+MIAMI,Paola Ward 1 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00016B
+MIAMI,Paola Ward 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00016B
+MIAMI,Paola Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",106,000170
+MIAMI,Paola Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,000170
+MIAMI,Paola Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",224,000170
+MIAMI,Paola Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",186,00018A
+MIAMI,Paola Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",20,00018A
+MIAMI,Paola Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",373,00018A
+MIAMI,Paola Ward 3 Exclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00018B
+MIAMI,Paola Ward 3 Exclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00018B
+MIAMI,Paola Ward 3 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00018B
+MIAMI,Paola Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",226,00019A
+MIAMI,Paola Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",36,00019A
+MIAMI,Paola Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",508,00019A
+MIAMI,Paola Ward 4 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00019B
+MIAMI,Paola Ward 4 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00019B
+MIAMI,Paola Ward 4 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00019B
+MIAMI,Richland Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",204,000200
+MIAMI,Richland Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",46,000200
+MIAMI,Richland Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",770,000200
+MIAMI,South Wea Township,United States House of Representatives,3,Libertarian,"Balam, Joel",126,000220
+MIAMI,South Wea Township,United States House of Representatives,3,Republican,"Yoder, Kevin",597,000220
+MIAMI,Spring Hill City Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",156,00023A
+MIAMI,Spring Hill City Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",557,00023A
+MIAMI,Spring Hill City Exclave A,United States House of Representatives,3,Libertarian,"Balam, Joel",0,00023B
+MIAMI,Spring Hill City Exclave A,United States House of Representatives,3,Republican,"Yoder, Kevin",0,00023B
+MIAMI,Spring Hill City Exclave B,United States House of Representatives,3,Libertarian,"Balam, Joel",42,00023C
+MIAMI,Spring Hill City Exclave B,United States House of Representatives,3,Republican,"Yoder, Kevin",148,00023C
+MIAMI,Spring Hill City Exclave C,United States House of Representatives,3,Libertarian,"Balam, Joel",0,00023D
+MIAMI,Spring Hill City Exclave C,United States House of Representatives,3,Republican,"Yoder, Kevin",0,00023D
+MIAMI,Stanton Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",115,000240
+MIAMI,Stanton Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",21,000240
+MIAMI,Stanton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",295,000240
+MIAMI,Sugar Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",51,000250
+MIAMI,Sugar Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000250
+MIAMI,Sugar Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",177,000250
+MIAMI,Ten Mile Township,United States House of Representatives,3,Libertarian,"Balam, Joel",143,000260
+MIAMI,Ten Mile Township,United States House of Representatives,3,Republican,"Yoder, Kevin",585,000260
+MIAMI,West Middle Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",83,000270
+MIAMI,West Middle Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,000270
+MIAMI,West Middle Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",270,000270
+MIAMI,East Middle Creek Township C2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",30,120020
+MIAMI,East Middle Creek Township C2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,120020
+MIAMI,East Middle Creek Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",98,120020
+MIAMI,East Middle Creek Township C3,United States House of Representatives,3,Libertarian,"Balam, Joel",85,120030
+MIAMI,East Middle Creek Township C3,United States House of Representatives,3,Republican,"Yoder, Kevin",329,120030
+MIAMI,North Marysville Township C2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",14,120040
+MIAMI,North Marysville Township C2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,120040
+MIAMI,North Marysville Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",125,120040
+MIAMI,North Marysville Township C3,United States House of Representatives,3,Libertarian,"Balam, Joel",88,120050
+MIAMI,North Marysville Township C3,United States House of Representatives,3,Republican,"Yoder, Kevin",327,120050
+MIAMI,Osawatomie Ward 1 H5,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",99,120060
+MIAMI,Osawatomie Ward 1 H5,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,120060
+MIAMI,Osawatomie Ward 1 H5,United States House of Representatives,2,Republican,"Jenkins, Lynn",143,120060
+MIAMI,Osawatomie Ward 1 H6,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120070
+MIAMI,Osawatomie Ward 1 H6,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120070
+MIAMI,Osawatomie Ward 1 H6,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120070
+MIAMI,South Marysville Township C2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",146,120080
+MIAMI,South Marysville Township C2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",25,120080
+MIAMI,South Marysville Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",503,120080
+MIAMI,South Marysville Township C3,United States House of Representatives,3,Libertarian,"Balam, Joel",2,120090
+MIAMI,South Marysville Township C3,United States House of Representatives,3,Republican,"Yoder, Kevin",10,120090
+MIAMI,West Valley Township H5,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",43,120100
+MIAMI,West Valley Township H5,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,120100
+MIAMI,West Valley Township H5,United States House of Representatives,2,Republican,"Jenkins, Lynn",85,120100
+MIAMI,West Valley Township H6,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",31,120110
+MIAMI,West Valley Township H6,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,120110
+MIAMI,West Valley Township H6,United States House of Representatives,2,Republican,"Jenkins, Lynn",89,120110
+MIAMI,North Paola Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",61,200010
+MIAMI,North Paola Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,200010
+MIAMI,North Paola Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",177,200010
+MIAMI,South Paola Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",36,200020
+MIAMI,South Paola Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,200020
+MIAMI,South Paola Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",123,200020
+MIAMI,Louisburg Ward 1,United States House of Representatives,3,Libertarian,"Balam, Joel",133,300010
+MIAMI,Louisburg Ward 1,United States House of Representatives,3,Republican,"Yoder, Kevin",391,300010
+MIAMI,Louisburg Ward 2,United States House of Representatives,3,Libertarian,"Balam, Joel",237,300020
+MIAMI,Louisburg Ward 2,United States House of Representatives,3,Republican,"Yoder, Kevin",986,300020
+MIAMI,Osawatomie Township Enclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900010
+MIAMI,Osawatomie Township Enclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900010
+MIAMI,Osawatomie Township Enclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+MIAMI,Osawatomie Township Enclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900020
+MIAMI,Osawatomie Township Enclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900020
+MIAMI,Osawatomie Township Enclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+MIAMI,Osawatomie Ward 1 Exclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+MIAMI,Osawatomie Ward 1 Exclave C,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900040
+MIAMI,Osawatomie Ward 1 Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900040
+MIAMI,Osawatomie Ward 1 Exclave D,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900050
+MIAMI,Osawatomie Ward 1 Exclave D,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900050
+MIAMI,Osawatomie Ward 3 Exclave D,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900070
+MIAMI,Osawatomie Ward 3 Exclave D,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900070
+MIAMI,Paola Ward 1 Exclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900080
+MIAMI,Paola Ward 1 Exclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900080
+MIAMI,Paola Ward 1 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900080
+MIAMI,West Valley Township Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",49,900120
+MIAMI,West Valley Township Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,900120
+MIAMI,West Valley Township Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",156,900120
+MIAMI,North Paola Township Part 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",4,900140
+MIAMI,North Paola Township Part 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900140
+MIAMI,North Paola Township Part 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",11,900140
+MIAMI,North Paola Township Part 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",9,900150
+MIAMI,North Paola Township Part 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,900150
+MIAMI,North Paola Township Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",61,900150
+MIAMI,North Paola Township Part 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900160
+MIAMI,North Paola Township Part 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900160
+MIAMI,North Paola Township Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900160
+MIAMI,South Paola Township Part 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",25,900180
+MIAMI,South Paola Township Part 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,900180
+MIAMI,South Paola Township Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,900180

--- a/2012/20121106__ks__general__mitchell__precinct.csv
+++ b/2012/20121106__ks__general__mitchell__precinct.csv
@@ -1,0 +1,793 @@
+county,precinct,office,district,party,candidate,votes,vtd
+MITCHELL,Asherville Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",48,000010
+MITCHELL,Beloit City Ward 1,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",262,000020
+MITCHELL,Beloit City Ward 2,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",431,000030
+MITCHELL,Beloit City Ward 3,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",451,000040
+MITCHELL,Beloit City Ward 4,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",329,000050
+MITCHELL,Beloit Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",111,00006A
+MITCHELL,Beloit Township Enclave A,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00006B
+MITCHELL,Beloit Township Enclave B,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00006C
+MITCHELL,Beloit Township Enclave C,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00006D
+MITCHELL,Bloomfield Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",32,000070
+MITCHELL,Blue Hill Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",17,000080
+MITCHELL,Carr Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",16,000090
+MITCHELL,Cawker City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000100
+MITCHELL,Cawker Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",218,000110
+MITCHELL,Center Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",13,000120
+MITCHELL,Custer Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",60,000130
+MITCHELL,Eureka Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",15,000140
+MITCHELL,Glen Elder City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000150
+MITCHELL,Glen Elder Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",242,000160
+MITCHELL,Hayes Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",17,000170
+MITCHELL,Hunter City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000180
+MITCHELL,Logan Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",41,000190
+MITCHELL,Lulu Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",39,000200
+MITCHELL,Pittsburg Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",162,000210
+MITCHELL,Plum Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",65,000220
+MITCHELL,Round Springs Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",15,000230
+MITCHELL,Salt Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",10,000240
+MITCHELL,Scottsville City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000250
+MITCHELL,Simpson City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000260
+MITCHELL,Solomon Rapids Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",32,000270
+MITCHELL,Tipton City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000280
+MITCHELL,Turkey Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",51,000290
+MITCHELL,Walnut Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",19,000300
+MITCHELL,Asherville Township,Kansas Senate,36,Democratic,"Clark, Marquis",11,000010
+MITCHELL,Asherville Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",41,000010
+MITCHELL,Beloit City Ward 1,Kansas Senate,36,Democratic,"Clark, Marquis",40,000020
+MITCHELL,Beloit City Ward 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",238,000020
+MITCHELL,Beloit City Ward 2,Kansas Senate,36,Democratic,"Clark, Marquis",100,000030
+MITCHELL,Beloit City Ward 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",368,000030
+MITCHELL,Beloit City Ward 3,Kansas Senate,36,Democratic,"Clark, Marquis",86,000040
+MITCHELL,Beloit City Ward 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",386,000040
+MITCHELL,Beloit City Ward 4,Kansas Senate,36,Democratic,"Clark, Marquis",64,000050
+MITCHELL,Beloit City Ward 4,Kansas Senate,36,Republican,"Bowers, Elaine S.",297,000050
+MITCHELL,Beloit Township,Kansas Senate,36,Democratic,"Clark, Marquis",22,00006A
+MITCHELL,Beloit Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",103,00006A
+MITCHELL,Beloit Township Enclave A,Kansas Senate,36,Democratic,"Clark, Marquis",0,00006B
+MITCHELL,Beloit Township Enclave A,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00006B
+MITCHELL,Beloit Township Enclave B,Kansas Senate,36,Democratic,"Clark, Marquis",0,00006C
+MITCHELL,Beloit Township Enclave B,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00006C
+MITCHELL,Beloit Township Enclave C,Kansas Senate,36,Democratic,"Clark, Marquis",0,00006D
+MITCHELL,Beloit Township Enclave C,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00006D
+MITCHELL,Bloomfield Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000070
+MITCHELL,Bloomfield Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",35,000070
+MITCHELL,Blue Hill Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000080
+MITCHELL,Blue Hill Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000080
+MITCHELL,Carr Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000090
+MITCHELL,Carr Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000090
+MITCHELL,Cawker City,Kansas Senate,36,Democratic,"Clark, Marquis",0,000100
+MITCHELL,Cawker City,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,000100
+MITCHELL,Cawker Township,Kansas Senate,36,Democratic,"Clark, Marquis",46,000110
+MITCHELL,Cawker Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",193,000110
+MITCHELL,Center Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000120
+MITCHELL,Center Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000120
+MITCHELL,Custer Township,Kansas Senate,36,Democratic,"Clark, Marquis",12,000130
+MITCHELL,Custer Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",51,000130
+MITCHELL,Eureka Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000140
+MITCHELL,Eureka Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",14,000140
+MITCHELL,Glen Elder City,Kansas Senate,36,Democratic,"Clark, Marquis",0,000150
+MITCHELL,Glen Elder City,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,000150
+MITCHELL,Glen Elder Township,Kansas Senate,36,Democratic,"Clark, Marquis",44,000160
+MITCHELL,Glen Elder Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",207,000160
+MITCHELL,Hayes Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000170
+MITCHELL,Hayes Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000170
+MITCHELL,Hunter City,Kansas Senate,36,Democratic,"Clark, Marquis",0,000180
+MITCHELL,Hunter City,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,000180
+MITCHELL,Logan Township,Kansas Senate,36,Democratic,"Clark, Marquis",7,000190
+MITCHELL,Logan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",37,000190
+MITCHELL,Lulu Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000200
+MITCHELL,Lulu Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",39,000200
+MITCHELL,Pittsburg Township,Kansas Senate,36,Democratic,"Clark, Marquis",21,000210
+MITCHELL,Pittsburg Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",135,000210
+MITCHELL,Plum Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000220
+MITCHELL,Plum Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",63,000220
+MITCHELL,Round Springs Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000230
+MITCHELL,Round Springs Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000230
+MITCHELL,Salt Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000240
+MITCHELL,Salt Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",10,000240
+MITCHELL,Scottsville City,Kansas Senate,36,Democratic,"Clark, Marquis",0,000250
+MITCHELL,Scottsville City,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,000250
+MITCHELL,Simpson City,Kansas Senate,36,Democratic,"Clark, Marquis",0,000260
+MITCHELL,Simpson City,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,000260
+MITCHELL,Solomon Rapids Township,Kansas Senate,36,Democratic,"Clark, Marquis",7,000270
+MITCHELL,Solomon Rapids Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",29,000270
+MITCHELL,Tipton City,Kansas Senate,36,Democratic,"Clark, Marquis",0,000280
+MITCHELL,Tipton City,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,000280
+MITCHELL,Turkey Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",5,000290
+MITCHELL,Turkey Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",53,000290
+MITCHELL,Walnut Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000300
+MITCHELL,Walnut Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",18,000300
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+MITCHELL,Asherville Township,President / Vice President,,Democratic,"Obama, Barack",10,000010
+MITCHELL,Asherville Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+MITCHELL,Asherville Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+MITCHELL,Asherville Township,President / Vice President,,Republican,"Romney, Mitt",41,000010
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,Democratic,"Obama, Barack",68,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",9,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,Republican,"Romney, Mitt",214,000020
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,Democratic,"Obama, Barack",111,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",6,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,Republican,"Romney, Mitt",359,000030
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,Democratic,"Obama, Barack",110,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",3,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",4,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,Republican,"Romney, Mitt",368,000040
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,Democratic,"Obama, Barack",86,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",5,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,Republican,"Romney, Mitt",276,000050
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Ayers, Avery L",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Barnett, Andre",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Bush, Kent W",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Christensen, Will",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Duncan, Richard A",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Goode, Virgil",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Knill, Dennis J",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Reed, Jill A.",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Rogers, Rick L",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Stein, Jill E",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,Democratic,"Obama, Barack",24,00006A
+MITCHELL,Beloit Township,President / Vice President,,Libertarian,"Johnson, Gary",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,Reform,"Baldwin, Chuck",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,Republican,"Romney, Mitt",108,00006A
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Barnett, Andre",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Bush, Kent W",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Christensen, Will",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Goode, Virgil",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Stein, Jill E",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,Democratic,"Obama, Barack",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,Republican,"Romney, Mitt",0,00006B
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Barnett, Andre",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Bush, Kent W",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Christensen, Will",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Goode, Virgil",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Stein, Jill E",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,Democratic,"Obama, Barack",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,Republican,"Romney, Mitt",0,00006C
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Ayers, Avery L",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Barnett, Andre",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Barr, Roseanne C",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Bush, Kent W",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Christensen, Will",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Duncan, Richard A",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Goode, Virgil",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Knill, Dennis J",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Reed, Jill A.",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Rogers, Rick L",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Stein, Jill E",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Thorne, Kevin M",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Warner, Gerald L.",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,Democratic,"Obama, Barack",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,Reform,"Baldwin, Chuck",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,Republican,"Romney, Mitt",0,00006D
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,Democratic,"Obama, Barack",3,000070
+MITCHELL,Bloomfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+MITCHELL,Bloomfield Township,President / Vice President,,Republican,"Romney, Mitt",35,000070
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,Democratic,"Obama, Barack",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,Republican,"Romney, Mitt",17,000080
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,Democratic,"Obama, Barack",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+MITCHELL,Carr Creek Township,President / Vice President,,Republican,"Romney, Mitt",15,000090
+MITCHELL,Cawker City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Barnett, Andre",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Bush, Kent W",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Christensen, Will",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Goode, Virgil",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Stein, Jill E",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+MITCHELL,Cawker City,President / Vice President,,Democratic,"Obama, Barack",0,000100
+MITCHELL,Cawker City,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+MITCHELL,Cawker City,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+MITCHELL,Cawker City,President / Vice President,,Republican,"Romney, Mitt",0,000100
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+MITCHELL,Cawker Township,President / Vice President,,Democratic,"Obama, Barack",50,000110
+MITCHELL,Cawker Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000110
+MITCHELL,Cawker Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+MITCHELL,Cawker Township,President / Vice President,,Republican,"Romney, Mitt",195,000110
+MITCHELL,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+MITCHELL,Center Township,President / Vice President,,Democratic,"Obama, Barack",1,000120
+MITCHELL,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+MITCHELL,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+MITCHELL,Center Township,President / Vice President,,Republican,"Romney, Mitt",12,000120
+MITCHELL,Custer Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+MITCHELL,Custer Township,President / Vice President,,Democratic,"Obama, Barack",9,000130
+MITCHELL,Custer Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+MITCHELL,Custer Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000130
+MITCHELL,Custer Township,President / Vice President,,Republican,"Romney, Mitt",51,000130
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+MITCHELL,Eureka Township,President / Vice President,,Democratic,"Obama, Barack",4,000140
+MITCHELL,Eureka Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+MITCHELL,Eureka Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+MITCHELL,Eureka Township,President / Vice President,,Republican,"Romney, Mitt",12,000140
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Barnett, Andre",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Bush, Kent W",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Christensen, Will",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Goode, Virgil",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Stein, Jill E",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,Democratic,"Obama, Barack",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,Republican,"Romney, Mitt",0,000150
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,Democratic,"Obama, Barack",44,000160
+MITCHELL,Glen Elder Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+MITCHELL,Glen Elder Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000160
+MITCHELL,Glen Elder Township,President / Vice President,,Republican,"Romney, Mitt",209,000160
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+MITCHELL,Hayes Township,President / Vice President,,Democratic,"Obama, Barack",0,000170
+MITCHELL,Hayes Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+MITCHELL,Hayes Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000170
+MITCHELL,Hayes Township,President / Vice President,,Republican,"Romney, Mitt",16,000170
+MITCHELL,Hunter City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Barnett, Andre",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Bush, Kent W",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Christensen, Will",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Goode, Virgil",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Stein, Jill E",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+MITCHELL,Hunter City,President / Vice President,,Democratic,"Obama, Barack",0,000180
+MITCHELL,Hunter City,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+MITCHELL,Hunter City,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+MITCHELL,Hunter City,President / Vice President,,Republican,"Romney, Mitt",0,000180
+MITCHELL,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+MITCHELL,Logan Township,President / Vice President,,Democratic,"Obama, Barack",12,000190
+MITCHELL,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+MITCHELL,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+MITCHELL,Logan Township,President / Vice President,,Republican,"Romney, Mitt",35,000190
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+MITCHELL,Lulu Township,President / Vice President,,Democratic,"Obama, Barack",2,000200
+MITCHELL,Lulu Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+MITCHELL,Lulu Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+MITCHELL,Lulu Township,President / Vice President,,Republican,"Romney, Mitt",37,000200
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,Democratic,"Obama, Barack",23,000210
+MITCHELL,Pittsburg Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000210
+MITCHELL,Pittsburg Township,President / Vice President,,Republican,"Romney, Mitt",145,000210
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,Democratic,"Obama, Barack",2,000220
+MITCHELL,Plum Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000220
+MITCHELL,Plum Creek Township,President / Vice President,,Republican,"Romney, Mitt",65,000220
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,Democratic,"Obama, Barack",2,000230
+MITCHELL,Round Springs Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,Republican,"Romney, Mitt",14,000230
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,Democratic,"Obama, Barack",2,000240
+MITCHELL,Salt Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000240
+MITCHELL,Salt Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,Republican,"Romney, Mitt",6,000240
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Barnett, Andre",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Bush, Kent W",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Christensen, Will",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Goode, Virgil",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Stein, Jill E",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+MITCHELL,Scottsville City,President / Vice President,,Democratic,"Obama, Barack",0,000250
+MITCHELL,Scottsville City,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+MITCHELL,Scottsville City,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+MITCHELL,Scottsville City,President / Vice President,,Republican,"Romney, Mitt",0,000250
+MITCHELL,Simpson City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Barnett, Andre",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Bush, Kent W",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Christensen, Will",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Goode, Virgil",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Stein, Jill E",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+MITCHELL,Simpson City,President / Vice President,,Democratic,"Obama, Barack",0,000260
+MITCHELL,Simpson City,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+MITCHELL,Simpson City,President / Vice President,,Reform,"Baldwin, Chuck",0,000260
+MITCHELL,Simpson City,President / Vice President,,Republican,"Romney, Mitt",0,000260
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Barnett, Andre",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Bush, Kent W",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Christensen, Will",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Goode, Virgil",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Stein, Jill E",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,Democratic,"Obama, Barack",9,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,Republican,"Romney, Mitt",29,000270
+MITCHELL,Tipton City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Barnett, Andre",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Bush, Kent W",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Christensen, Will",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Goode, Virgil",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Stein, Jill E",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+MITCHELL,Tipton City,President / Vice President,,Democratic,"Obama, Barack",0,000280
+MITCHELL,Tipton City,President / Vice President,,Libertarian,"Johnson, Gary",0,000280
+MITCHELL,Tipton City,President / Vice President,,Reform,"Baldwin, Chuck",0,000280
+MITCHELL,Tipton City,President / Vice President,,Republican,"Romney, Mitt",0,000280
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,Democratic,"Obama, Barack",10,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,Republican,"Romney, Mitt",48,000290
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,Democratic,"Obama, Barack",2,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,Republican,"Romney, Mitt",20,000300
+MITCHELL,Asherville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",46,000010
+MITCHELL,Beloit City Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",243,000020
+MITCHELL,Beloit City Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",409,000030
+MITCHELL,Beloit City Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",423,000040
+MITCHELL,Beloit City Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",304,000050
+MITCHELL,Beloit Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",110,00006A
+MITCHELL,Beloit Township Enclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006B
+MITCHELL,Beloit Township Enclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006C
+MITCHELL,Beloit Township Enclave C,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006D
+MITCHELL,Bloomfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000070
+MITCHELL,Blue Hill Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000080
+MITCHELL,Carr Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000090
+MITCHELL,Cawker City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000100
+MITCHELL,Cawker Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",207,000110
+MITCHELL,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000120
+MITCHELL,Custer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",59,000130
+MITCHELL,Eureka Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000140
+MITCHELL,Glen Elder City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000150
+MITCHELL,Glen Elder Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",234,000160
+MITCHELL,Hayes Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000170
+MITCHELL,Hunter City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000180
+MITCHELL,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000190
+MITCHELL,Lulu Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000200
+MITCHELL,Pittsburg Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",158,000210
+MITCHELL,Plum Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",62,000220
+MITCHELL,Round Springs Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000230
+MITCHELL,Salt Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",10,000240
+MITCHELL,Scottsville City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000250
+MITCHELL,Simpson City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000260
+MITCHELL,Solomon Rapids Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000270
+MITCHELL,Tipton City,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000280
+MITCHELL,Turkey Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,000290
+MITCHELL,Walnut Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000300

--- a/2012/20121106__ks__general__montgomery__precinct.csv
+++ b/2012/20121106__ks__general__montgomery__precinct.csv
@@ -1,0 +1,1818 @@
+county,precinct,office,district,party,candidate,votes,vtd
+MONTGOMERY,Caney City Ward 1,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",54,00001A
+MONTGOMERY,Caney City Ward 1,Kansas House of Representatives,12,Republican,"Peck, Virgil",97,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,Kansas House of Representatives,12,Republican,"Peck, Virgil",1,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",1,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,Kansas House of Representatives,12,Republican,"Peck, Virgil",3,00001C
+MONTGOMERY,Caney City Ward 2,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",30,000020
+MONTGOMERY,Caney City Ward 2,Kansas House of Representatives,12,Republican,"Peck, Virgil",101,000020
+MONTGOMERY,Caney City Ward 3,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",55,000030
+MONTGOMERY,Caney City Ward 3,Kansas House of Representatives,12,Republican,"Peck, Virgil",106,000030
+MONTGOMERY,Caney City Ward 4,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",50,000040
+MONTGOMERY,Caney City Ward 4,Kansas House of Representatives,12,Republican,"Peck, Virgil",149,000040
+MONTGOMERY,Caney Township Havana,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",68,000050
+MONTGOMERY,Caney Township Havana,Kansas House of Representatives,12,Republican,"Peck, Virgil",231,000050
+MONTGOMERY,Caney Township Tyro,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",72,000060
+MONTGOMERY,Caney Township Tyro,Kansas House of Representatives,12,Republican,"Peck, Virgil",262,000060
+MONTGOMERY,Cherokee Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",89,000070
+MONTGOMERY,Cherokee Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",113,000070
+MONTGOMERY,Cherry Township,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",58,000080
+MONTGOMERY,Cherry Township,Kansas House of Representatives,11,Republican,"Kelly, Jim",175,000080
+MONTGOMERY,Cherryvale Ward 1,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",131,000090
+MONTGOMERY,Cherryvale Ward 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",282,000090
+MONTGOMERY,Cherryvale Ward 2,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",100,000100
+MONTGOMERY,Cherryvale Ward 2,Kansas House of Representatives,11,Republican,"Kelly, Jim",217,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",66,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Kansas House of Representatives,11,Republican,"Kelly, Jim",8,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",104,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Kansas House of Representatives,11,Republican,"Kelly, Jim",48,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",119,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Kansas House of Representatives,11,Republican,"Kelly, Jim",68,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",134,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Kansas House of Representatives,11,Republican,"Kelly, Jim",86,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",164,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Kansas House of Representatives,11,Republican,"Kelly, Jim",97,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",69,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Kansas House of Representatives,11,Republican,"Kelly, Jim",28,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",83,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Kansas House of Representatives,11,Republican,"Kelly, Jim",60,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",104,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Kansas House of Representatives,11,Republican,"Kelly, Jim",54,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",35,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Kansas House of Representatives,11,Republican,"Kelly, Jim",16,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",109,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Kansas House of Representatives,11,Republican,"Kelly, Jim",53,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",265,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Kansas House of Representatives,11,Republican,"Kelly, Jim",154,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",248,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Kansas House of Representatives,11,Republican,"Kelly, Jim",186,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",321,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Kansas House of Representatives,11,Republican,"Kelly, Jim",240,000230
+MONTGOMERY,Drum Creek Township,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",57,000240
+MONTGOMERY,Drum Creek Township,Kansas House of Representatives,11,Republican,"Kelly, Jim",229,000240
+MONTGOMERY,Fawn Creek Township Dearing,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",327,000250
+MONTGOMERY,Fawn Creek Township Dearing,Kansas House of Representatives,11,Republican,"Kelly, Jim",361,000250
+MONTGOMERY,Fawn Creek Township Tyro,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",48,000260
+MONTGOMERY,Fawn Creek Township Tyro,Kansas House of Representatives,12,Republican,"Peck, Virgil",145,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",52,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",110,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",93,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,Kansas House of Representatives,11,Republican,"Kelly, Jim",198,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",41,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",78,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",40,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,Kansas House of Representatives,12,Republican,"Peck, Virgil",66,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",75,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",163,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",47,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,Kansas House of Representatives,12,Republican,"Peck, Virgil",69,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Kansas House of Representatives,11,Republican,"Kelly, Jim",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",101,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",198,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",67,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,Kansas House of Representatives,11,Republican,"Kelly, Jim",120,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",59,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,Kansas House of Representatives,12,Republican,"Peck, Virgil",107,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",122,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,Kansas House of Representatives,12,Republican,"Peck, Virgil",184,000360
+MONTGOMERY,Independence Township 2 Part B,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",0,00040B
+MONTGOMERY,Independence Township 2 Part B,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,00040B
+MONTGOMERY,Independence Township 2 Part C,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",10,00040C
+MONTGOMERY,Independence Township 2 Part C,Kansas House of Representatives,11,Republican,"Kelly, Jim",40,00040C
+MONTGOMERY,Liberty Township,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",65,000410
+MONTGOMERY,Liberty Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",173,000410
+MONTGOMERY,Louisburg Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",63,000420
+MONTGOMERY,Louisburg Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",185,000420
+MONTGOMERY,Parker Township 1,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",48,000430
+MONTGOMERY,Parker Township 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",68,000430
+MONTGOMERY,Parker Township 2,Kansas House of Representatives,7,Democratic,"Knewtson, H Dean",154,00044A
+MONTGOMERY,Parker Township 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",234,00044A
+MONTGOMERY,Parker Township 2 Enclave A,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",1,00044B
+MONTGOMERY,Parker Township 2 Enclave A,Kansas House of Representatives,11,Republican,"Kelly, Jim",1,00044B
+MONTGOMERY,Parker Township 2 Enclave B,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,Kansas House of Representatives,11,Republican,"Kelly, Jim",0,00044C
+MONTGOMERY,Rutland Township,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",35,000450
+MONTGOMERY,Rutland Township,Kansas House of Representatives,12,Republican,"Peck, Virgil",135,000450
+MONTGOMERY,West Cherry Township,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",38,000470
+MONTGOMERY,West Cherry Township,Kansas House of Representatives,11,Republican,"Kelly, Jim",100,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",11,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",20,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",130,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Kansas House of Representatives,12,Republican,"Peck, Virgil",250,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",35,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Kansas House of Representatives,11,Republican,"Kelly, Jim",102,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",60,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",247,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Kansas House of Representatives,12,Republican,"Peck, Virgil",8,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",23,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Kansas House of Representatives,12,Republican,"Peck, Virgil",66,120050
+MONTGOMERY,Independence Township 1 H11,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",168,120060
+MONTGOMERY,Independence Township 1 H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",557,120060
+MONTGOMERY,Independence Township 1 H12,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",21,120070
+MONTGOMERY,Independence Township 1 H12,Kansas House of Representatives,12,Republican,"Peck, Virgil",87,120070
+MONTGOMERY,Independence Township 2 Part A H11,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",53,120090
+MONTGOMERY,Independence Township 2 Part A H12,Kansas House of Representatives,12,Republican,"Peck, Virgil",127,120090
+MONTGOMERY,Sycamore Township H11,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",83,120100
+MONTGOMERY,Sycamore Township H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",335,120100
+MONTGOMERY,Sycamore Township H12 A,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",0,12011A
+MONTGOMERY,Sycamore Township H12 A,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,12011A
+MONTGOMERY,Sycamore Township H12 B,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",0,12011B
+MONTGOMERY,Sycamore Township H12 B,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,12011B
+MONTGOMERY,Sycamore Township H12 C,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",0,12011C
+MONTGOMERY,Sycamore Township H12 C,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,12011C
+MONTGOMERY,Sycamore Township H12,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",0,120110
+MONTGOMERY,Sycamore Township H12,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,120110
+MONTGOMERY,Caney City Ward 3 Exclave,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",1,900030
+MONTGOMERY,Caney City Ward 3 Exclave,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,900030
+MONTGOMERY,Parker Township 2 Enclave,Kansas House of Representatives,11,Democratic,"Harbaugh, Darrel",0,900040
+MONTGOMERY,Parker Township 2 Enclave,Kansas House of Representatives,11,Republican,"Kelly, Jim",0,900040
+MONTGOMERY,Independence Township 1 Enclave,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",1,900050
+MONTGOMERY,Independence Township 1 Enclave,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,900050
+MONTGOMERY,Independence Exclave Airport,Kansas House of Representatives,12,Democratic,"Bumgarner, Tina",0,900060
+MONTGOMERY,Independence Exclave Airport,Kansas House of Representatives,12,Republican,"Peck, Virgil",0,900060
+MONTGOMERY,Caney City Ward 1,Kansas Senate,15,Republican,"King, Jeff",133,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,Kansas Senate,15,Republican,"King, Jeff",2,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,Kansas Senate,15,Republican,"King, Jeff",5,00001C
+MONTGOMERY,Caney City Ward 2,Kansas Senate,15,Republican,"King, Jeff",117,000020
+MONTGOMERY,Caney City Ward 3,Kansas Senate,15,Republican,"King, Jeff",151,000030
+MONTGOMERY,Caney City Ward 4,Kansas Senate,15,Republican,"King, Jeff",181,000040
+MONTGOMERY,Caney Township Havana,Kansas Senate,15,Republican,"King, Jeff",268,000050
+MONTGOMERY,Caney Township Tyro,Kansas Senate,15,Republican,"King, Jeff",299,000060
+MONTGOMERY,Cherokee Township,Kansas Senate,15,Republican,"King, Jeff",188,000070
+MONTGOMERY,Cherry Township,Kansas Senate,15,Republican,"King, Jeff",207,000080
+MONTGOMERY,Cherryvale Ward 1,Kansas Senate,15,Republican,"King, Jeff",357,000090
+MONTGOMERY,Cherryvale Ward 2,Kansas Senate,15,Republican,"King, Jeff",278,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Kansas Senate,15,Republican,"King, Jeff",41,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Kansas Senate,15,Republican,"King, Jeff",116,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Kansas Senate,15,Republican,"King, Jeff",152,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Kansas Senate,15,Republican,"King, Jeff",183,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Kansas Senate,15,Republican,"King, Jeff",211,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Kansas Senate,15,Republican,"King, Jeff",75,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Kansas Senate,15,Republican,"King, Jeff",119,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Kansas Senate,15,Republican,"King, Jeff",126,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Kansas Senate,15,Republican,"King, Jeff",37,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Kansas Senate,15,Republican,"King, Jeff",129,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Kansas Senate,15,Republican,"King, Jeff",336,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Kansas Senate,15,Republican,"King, Jeff",353,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Kansas Senate,15,Republican,"King, Jeff",474,000230
+MONTGOMERY,Drum Creek Township,Kansas Senate,15,Republican,"King, Jeff",255,000240
+MONTGOMERY,Fawn Creek Township Dearing,Kansas Senate,15,Republican,"King, Jeff",607,000250
+MONTGOMERY,Fawn Creek Township Tyro,Kansas Senate,15,Republican,"King, Jeff",179,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,Kansas Senate,15,Republican,"King, Jeff",129,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,Kansas Senate,15,Republican,"King, Jeff",249,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,Kansas Senate,15,Republican,"King, Jeff",94,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,Kansas Senate,15,Republican,"King, Jeff",91,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,Kansas Senate,15,Republican,"King, Jeff",202,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,Kansas Senate,15,Republican,"King, Jeff",104,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Kansas Senate,15,Republican,"King, Jeff",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,Kansas Senate,15,Republican,"King, Jeff",247,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,Kansas Senate,15,Republican,"King, Jeff",164,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,Kansas Senate,15,Republican,"King, Jeff",152,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,Kansas Senate,15,Republican,"King, Jeff",266,000360
+MONTGOMERY,Independence Township 2 Part B,Kansas Senate,15,Republican,"King, Jeff",0,00040B
+MONTGOMERY,Independence Township 2 Part C,Kansas Senate,15,Republican,"King, Jeff",45,00040C
+MONTGOMERY,Liberty Township,Kansas Senate,15,Republican,"King, Jeff",217,000410
+MONTGOMERY,Louisburg Township,Kansas Senate,14,Democratic,"Fuson, Eden",46,000420
+MONTGOMERY,Louisburg Township,Kansas Senate,14,Republican,"Knox, Forrest J.",211,000420
+MONTGOMERY,Parker Township 1,Kansas Senate,15,Republican,"King, Jeff",97,000430
+MONTGOMERY,Parker Township 2,Kansas Senate,15,Republican,"King, Jeff",324,00044A
+MONTGOMERY,Parker Township 2 Enclave A,Kansas Senate,15,Republican,"King, Jeff",2,00044B
+MONTGOMERY,Parker Township 2 Enclave B,Kansas Senate,15,Republican,"King, Jeff",0,00044C
+MONTGOMERY,Rutland Township,Kansas Senate,15,Republican,"King, Jeff",148,000450
+MONTGOMERY,West Cherry Township,Kansas Senate,15,Republican,"King, Jeff",119,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Kansas Senate,15,Republican,"King, Jeff",25,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Kansas Senate,15,Republican,"King, Jeff",345,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Kansas Senate,15,Republican,"King, Jeff",121,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Kansas Senate,15,Republican,"King, Jeff",281,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Kansas Senate,15,Republican,"King, Jeff",9,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Kansas Senate,15,Republican,"King, Jeff",78,120050
+MONTGOMERY,Independence Township 1 H11,Kansas Senate,15,Republican,"King, Jeff",646,120060
+MONTGOMERY,Independence Township 1 H12,Kansas Senate,15,Republican,"King, Jeff",95,120070
+MONTGOMERY,Independence Township 2 Part A H11,Kansas Senate,15,Republican,"King, Jeff",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,Kansas Senate,15,Republican,"King, Jeff",159,120090
+MONTGOMERY,Sycamore Township H11,Kansas Senate,15,Republican,"King, Jeff",386,120100
+MONTGOMERY,Sycamore Township H12 A,Kansas Senate,15,Republican,"King, Jeff",0,12011A
+MONTGOMERY,Sycamore Township H12 B,Kansas Senate,15,Republican,"King, Jeff",0,12011B
+MONTGOMERY,Sycamore Township H12 C,Kansas Senate,15,Republican,"King, Jeff",0,12011C
+MONTGOMERY,Sycamore Township H12,Kansas Senate,15,Republican,"King, Jeff",0,120110
+MONTGOMERY,Coffeyville Airport,Kansas Senate,15,Republican,"King, Jeff",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,Kansas Senate,15,Republican,"King, Jeff",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,Kansas Senate,15,Republican,"King, Jeff",0,900030
+MONTGOMERY,Parker Township 2 Enclave,Kansas Senate,15,Republican,"King, Jeff",0,900040
+MONTGOMERY,Independence Township 1 Enclave,Kansas Senate,15,Republican,"King, Jeff",0,900050
+MONTGOMERY,Independence Exclave Airport,Kansas Senate,15,Republican,"King, Jeff",0,900060
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Christensen, Will",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,Democratic,"Obama, Barack",31,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,Republican,"Romney, Mitt",119,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,Democratic,"Obama, Barack",2,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Christensen, Will",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,Democratic,"Obama, Barack",1,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,Republican,"Romney, Mitt",4,00001C
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,Democratic,"Obama, Barack",23,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",3,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,Republican,"Romney, Mitt",104,000020
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,Democratic,"Obama, Barack",31,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,Republican,"Romney, Mitt",131,000030
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,Democratic,"Obama, Barack",30,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,Republican,"Romney, Mitt",168,000040
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Barnett, Andre",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Bush, Kent W",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Christensen, Will",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Goode, Virgil",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Stein, Jill E",1,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,Democratic,"Obama, Barack",41,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,Republican,"Romney, Mitt",259,000050
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Barnett, Andre",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Bush, Kent W",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Christensen, Will",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Goode, Virgil",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Stein, Jill E",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,Democratic,"Obama, Barack",32,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,Libertarian,"Johnson, Gary",2,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,Republican,"Romney, Mitt",301,000060
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,Democratic,"Obama, Barack",52,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,Republican,"Romney, Mitt",148,000070
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,Democratic,"Obama, Barack",46,000080
+MONTGOMERY,Cherry Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000080
+MONTGOMERY,Cherry Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000080
+MONTGOMERY,Cherry Township,President / Vice President,,Republican,"Romney, Mitt",179,000080
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,Democratic,"Obama, Barack",133,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",4,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,Republican,"Romney, Mitt",274,000090
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,Democratic,"Obama, Barack",90,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",4,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,Republican,"Romney, Mitt",219,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",67,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",8,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",76,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",5,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",71,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",74,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",5,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",110,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",79,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",6,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",6,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",128,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,Democratic,"Obama, Barack",102,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",6,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",3,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,Republican,"Romney, Mitt",150,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Barnett, Andre",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Bush, Kent W",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Christensen, Will",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Goode, Virgil",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Stein, Jill E",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,Democratic,"Obama, Barack",44,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,Republican,"Romney, Mitt",53,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Barnett, Andre",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Bush, Kent W",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Christensen, Will",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Goode, Virgil",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Stein, Jill E",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,Democratic,"Obama, Barack",50,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",4,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,Reform,"Baldwin, Chuck",2,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,Republican,"Romney, Mitt",87,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Barnett, Andre",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Bush, Kent W",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Christensen, Will",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Goode, Virgil",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Stein, Jill E",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,Democratic,"Obama, Barack",74,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",2,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,Republican,"Romney, Mitt",81,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Barnett, Andre",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Bush, Kent W",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Christensen, Will",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Goode, Virgil",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Stein, Jill E",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,Democratic,"Obama, Barack",28,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,Republican,"Romney, Mitt",22,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Barnett, Andre",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Bush, Kent W",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Christensen, Will",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Goode, Virgil",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Stein, Jill E",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,Democratic,"Obama, Barack",67,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",5,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,Reform,"Baldwin, Chuck",2,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,Republican,"Romney, Mitt",89,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Barnett, Andre",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Bush, Kent W",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Christensen, Will",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Goode, Virgil",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Stein, Jill E",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,Democratic,"Obama, Barack",156,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",14,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,Reform,"Baldwin, Chuck",2,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,Republican,"Romney, Mitt",253,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Barnett, Andre",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Bush, Kent W",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Christensen, Will",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Goode, Virgil",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Stein, Jill E",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,Democratic,"Obama, Barack",146,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,Libertarian,"Johnson, Gary",4,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,Reform,"Baldwin, Chuck",7,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,Republican,"Romney, Mitt",283,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Barnett, Andre",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Bush, Kent W",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Christensen, Will",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Goode, Virgil",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Stein, Jill E",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,Democratic,"Obama, Barack",188,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,Libertarian,"Johnson, Gary",5,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,Reform,"Baldwin, Chuck",2,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,Republican,"Romney, Mitt",370,000230
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Stein, Jill E",2,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,Democratic,"Obama, Barack",55,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,Republican,"Romney, Mitt",230,000240
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Barnett, Andre",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Bush, Kent W",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Christensen, Will",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Goode, Virgil",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Stein, Jill E",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,Democratic,"Obama, Barack",167,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,Libertarian,"Johnson, Gary",7,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,Reform,"Baldwin, Chuck",4,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,Republican,"Romney, Mitt",515,000250
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Barnett, Andre",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Bush, Kent W",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Christensen, Will",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Goode, Virgil",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Stein, Jill E",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,Democratic,"Obama, Barack",21,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,Reform,"Baldwin, Chuck",1,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,Republican,"Romney, Mitt",171,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",57,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",101,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",85,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",16,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",190,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",37,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",79,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",44,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",4,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",62,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",82,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",156,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",48,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",1,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",70,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,Republican,"Romney, Mitt",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",104,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",3,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",190,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",78,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",13,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",97,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",59,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",113,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",115,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",4,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",192,000360
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Ayers, Avery L",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Barnett, Andre",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Bush, Kent W",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Christensen, Will",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Duncan, Richard A",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Goode, Virgil",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Knill, Dennis J",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Reed, Jill A.",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Rogers, Rick L",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Stein, Jill E",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,Democratic,"Obama, Barack",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,Republican,"Romney, Mitt",0,00040B
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Ayers, Avery L",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Barnett, Andre",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Barr, Roseanne C",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Bush, Kent W",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Christensen, Will",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Duncan, Richard A",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Goode, Virgil",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Hoefling, Tom",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Knill, Dennis J",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Reed, Jill A.",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Rogers, Rick L",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Stein, Jill E",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Thorne, Kevin M",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Warner, Gerald L.",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,Democratic,"Obama, Barack",7,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,Libertarian,"Johnson, Gary",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,Reform,"Baldwin, Chuck",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,Republican,"Romney, Mitt",43,00040C
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",57,000410
+MONTGOMERY,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000410
+MONTGOMERY,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000410
+MONTGOMERY,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",180,000410
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Ayers, Avery L",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Barnett, Andre",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Bush, Kent W",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Christensen, Will",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Duncan, Richard A",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Goode, Virgil",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Hoefling, Tom",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Knill, Dennis J",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Reed, Jill A.",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Rogers, Rick L",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Stein, Jill E",1,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,Democratic,"Obama, Barack",68,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,Republican,"Romney, Mitt",187,000420
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Ayers, Avery L",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Barnett, Andre",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Bush, Kent W",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Christensen, Will",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Duncan, Richard A",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Goode, Virgil",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Hoefling, Tom",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Knill, Dennis J",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Reed, Jill A.",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Rogers, Rick L",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Stein, Jill E",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,Democratic,"Obama, Barack",43,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,Republican,"Romney, Mitt",75,000430
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Ayers, Avery L",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Barnett, Andre",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Bush, Kent W",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Christensen, Will",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Duncan, Richard A",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Goode, Virgil",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Hoefling, Tom",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Knill, Dennis J",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Reed, Jill A.",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Rogers, Rick L",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Stein, Jill E",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,Democratic,"Obama, Barack",129,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,Libertarian,"Johnson, Gary",4,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,Reform,"Baldwin, Chuck",2,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,Republican,"Romney, Mitt",275,00044A
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Barnett, Andre",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Bush, Kent W",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Christensen, Will",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Goode, Virgil",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Stein, Jill E",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,Democratic,"Obama, Barack",1,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,Republican,"Romney, Mitt",1,00044B
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Barnett, Andre",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Bush, Kent W",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Christensen, Will",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Goode, Virgil",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Stein, Jill E",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,Democratic,"Obama, Barack",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,Republican,"Romney, Mitt",0,00044C
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Barnett, Andre",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Bush, Kent W",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Christensen, Will",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Goode, Virgil",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Stein, Jill E",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,Democratic,"Obama, Barack",24,000450
+MONTGOMERY,Rutland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000450
+MONTGOMERY,Rutland Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000450
+MONTGOMERY,Rutland Township,President / Vice President,,Republican,"Romney, Mitt",146,000450
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Ayers, Avery L",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Barnett, Andre",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Bush, Kent W",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Christensen, Will",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Duncan, Richard A",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Goode, Virgil",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Knill, Dennis J",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Reed, Jill A.",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Rogers, Rick L",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Stein, Jill E",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,Democratic,"Obama, Barack",28,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,Republican,"Romney, Mitt",106,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Barnett, Andre",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Bush, Kent W",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Christensen, Will",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Goode, Virgil",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Stein, Jill E",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,Democratic,"Obama, Barack",10,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,Libertarian,"Johnson, Gary",1,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,Reform,"Baldwin, Chuck",1,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,Republican,"Romney, Mitt",19,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Barnett, Andre",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Bush, Kent W",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Christensen, Will",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Goode, Virgil",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Stein, Jill E",1,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,Democratic,"Obama, Barack",107,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,Libertarian,"Johnson, Gary",5,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,Reform,"Baldwin, Chuck",2,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,Republican,"Romney, Mitt",274,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Ayers, Avery L",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Barnett, Andre",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Bush, Kent W",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Christensen, Will",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Duncan, Richard A",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Goode, Virgil",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Hoefling, Tom",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Knill, Dennis J",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Reed, Jill A.",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Rogers, Rick L",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Stein, Jill E",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,Democratic,"Obama, Barack",42,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,Libertarian,"Johnson, Gary",3,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,Republican,"Romney, Mitt",92,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Barnett, Andre",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Bush, Kent W",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Christensen, Will",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Goode, Virgil",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Stein, Jill E",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,Democratic,"Obama, Barack",53,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,Libertarian,"Johnson, Gary",3,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,Reform,"Baldwin, Chuck",1,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,Republican,"Romney, Mitt",251,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Ayers, Avery L",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Barnett, Andre",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Bush, Kent W",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Christensen, Will",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Duncan, Richard A",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Goode, Virgil",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Hoefling, Tom",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Knill, Dennis J",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Reed, Jill A.",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Rogers, Rick L",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Stein, Jill E",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,Democratic,"Obama, Barack",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,Republican,"Romney, Mitt",9,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Barnett, Andre",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Bush, Kent W",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Christensen, Will",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Goode, Virgil",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Stein, Jill E",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,Democratic,"Obama, Barack",12,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,Libertarian,"Johnson, Gary",1,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,Reform,"Baldwin, Chuck",2,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,Republican,"Romney, Mitt",75,120050
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Ayers, Avery L",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Barnett, Andre",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Barr, Roseanne C",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Bush, Kent W",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Christensen, Will",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Duncan, Richard A",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Goode, Virgil",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Knill, Dennis J",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Reed, Jill A.",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Rogers, Rick L",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Stein, Jill E",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Thorne, Kevin M",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Warner, Gerald L.",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,Democratic,"Obama, Barack",158,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,Libertarian,"Johnson, Gary",13,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,Reform,"Baldwin, Chuck",1,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,Republican,"Romney, Mitt",559,120060
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Ayers, Avery L",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Barnett, Andre",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Barr, Roseanne C",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Bush, Kent W",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Christensen, Will",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Duncan, Richard A",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Goode, Virgil",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Knill, Dennis J",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Reed, Jill A.",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Rogers, Rick L",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Stein, Jill E",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Thorne, Kevin M",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Warner, Gerald L.",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,Democratic,"Obama, Barack",12,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,Libertarian,"Johnson, Gary",2,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,Reform,"Baldwin, Chuck",3,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,Republican,"Romney, Mitt",97,120070
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Ayers, Avery L",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Barnett, Andre",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Barr, Roseanne C",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Bush, Kent W",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Christensen, Will",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Duncan, Richard A",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Goode, Virgil",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Knill, Dennis J",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Reed, Jill A.",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Rogers, Rick L",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Stein, Jill E",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Thorne, Kevin M",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Warner, Gerald L.",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,Democratic,"Obama, Barack",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,Libertarian,"Johnson, Gary",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,Reform,"Baldwin, Chuck",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,Republican,"Romney, Mitt",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Ayers, Avery L",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Barnett, Andre",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Barr, Roseanne C",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Bush, Kent W",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Christensen, Will",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Duncan, Richard A",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Goode, Virgil",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Knill, Dennis J",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Reed, Jill A.",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Rogers, Rick L",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Stein, Jill E",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Thorne, Kevin M",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Warner, Gerald L.",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,Democratic,"Obama, Barack",50,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,Libertarian,"Johnson, Gary",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,Reform,"Baldwin, Chuck",1,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,Republican,"Romney, Mitt",130,120090
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Ayers, Avery L",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Barnett, Andre",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Barr, Roseanne C",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Bush, Kent W",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Christensen, Will",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Duncan, Richard A",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Goode, Virgil",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Hoefling, Tom",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Knill, Dennis J",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Reed, Jill A.",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Rogers, Rick L",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Stein, Jill E",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Thorne, Kevin M",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Warner, Gerald L.",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,Democratic,"Obama, Barack",84,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,Libertarian,"Johnson, Gary",3,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,Reform,"Baldwin, Chuck",3,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,Republican,"Romney, Mitt",332,120100
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Ayers, Avery L",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Barnett, Andre",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Bush, Kent W",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Christensen, Will",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Duncan, Richard A",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Goode, Virgil",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Hoefling, Tom",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Knill, Dennis J",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Reed, Jill A.",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Rogers, Rick L",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Stein, Jill E",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,Democratic,"Obama, Barack",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,Republican,"Romney, Mitt",0,12011A
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Ayers, Avery L",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Barnett, Andre",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Barr, Roseanne C",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Bush, Kent W",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Christensen, Will",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Duncan, Richard A",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Goode, Virgil",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Hoefling, Tom",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Knill, Dennis J",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Reed, Jill A.",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Rogers, Rick L",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Stein, Jill E",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Thorne, Kevin M",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Warner, Gerald L.",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,Democratic,"Obama, Barack",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,Libertarian,"Johnson, Gary",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,Reform,"Baldwin, Chuck",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,Republican,"Romney, Mitt",0,12011B
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Ayers, Avery L",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Barnett, Andre",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Barr, Roseanne C",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Bush, Kent W",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Christensen, Will",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Duncan, Richard A",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Goode, Virgil",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Hoefling, Tom",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Knill, Dennis J",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Reed, Jill A.",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Rogers, Rick L",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Stein, Jill E",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Thorne, Kevin M",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Warner, Gerald L.",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,Democratic,"Obama, Barack",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,Libertarian,"Johnson, Gary",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,Reform,"Baldwin, Chuck",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,Republican,"Romney, Mitt",0,12011C
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Ayers, Avery L",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Barnett, Andre",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Barr, Roseanne C",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Bush, Kent W",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Christensen, Will",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Duncan, Richard A",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Goode, Virgil",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Hoefling, Tom",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Knill, Dennis J",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Reed, Jill A.",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Rogers, Rick L",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Stein, Jill E",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Thorne, Kevin M",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Warner, Gerald L.",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,Democratic,"Obama, Barack",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,Libertarian,"Johnson, Gary",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,Reform,"Baldwin, Chuck",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,Republican,"Romney, Mitt",0,120110
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Barnett, Andre",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Bush, Kent W",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Christensen, Will",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Goode, Virgil",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Stein, Jill E",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,Democratic,"Obama, Barack",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,Republican,"Romney, Mitt",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,Republican,"Romney, Mitt",1,900030
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Barnett, Andre",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Bush, Kent W",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Christensen, Will",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Goode, Virgil",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Stein, Jill E",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,Democratic,"Obama, Barack",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,Republican,"Romney, Mitt",0,900040
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Barnett, Andre",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Bush, Kent W",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Christensen, Will",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Goode, Virgil",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Stein, Jill E",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,Democratic,"Obama, Barack",1,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,Republican,"Romney, Mitt",0,900050
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Ayers, Avery L",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Barnett, Andre",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Barr, Roseanne C",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Bush, Kent W",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Christensen, Will",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Duncan, Richard A",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Goode, Virgil",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Knill, Dennis J",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Reed, Jill A.",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Rogers, Rick L",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Stein, Jill E",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Thorne, Kevin M",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Warner, Gerald L.",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,Democratic,"Obama, Barack",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,Reform,"Baldwin, Chuck",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,Republican,"Romney, Mitt",0,900060
+MONTGOMERY,Caney City Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",26,00001A
+MONTGOMERY,Caney City Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,00001A
+MONTGOMERY,Caney City Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",111,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",2,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",1,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",4,00001C
+MONTGOMERY,Caney City Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",23,000020
+MONTGOMERY,Caney City Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000020
+MONTGOMERY,Caney City Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",95,000020
+MONTGOMERY,Caney City Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",30,000030
+MONTGOMERY,Caney City Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000030
+MONTGOMERY,Caney City Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",121,000030
+MONTGOMERY,Caney City Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",31,000040
+MONTGOMERY,Caney City Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000040
+MONTGOMERY,Caney City Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",156,000040
+MONTGOMERY,Caney Township Havana,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",33,000050
+MONTGOMERY,Caney Township Havana,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000050
+MONTGOMERY,Caney Township Havana,United States House of Representatives,2,Republican,"Jenkins, Lynn",253,000050
+MONTGOMERY,Caney Township Tyro,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",32,000060
+MONTGOMERY,Caney Township Tyro,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000060
+MONTGOMERY,Caney Township Tyro,United States House of Representatives,2,Republican,"Jenkins, Lynn",287,000060
+MONTGOMERY,Cherokee Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",43,000070
+MONTGOMERY,Cherokee Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000070
+MONTGOMERY,Cherokee Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",153,000070
+MONTGOMERY,Cherry Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",48,000080
+MONTGOMERY,Cherry Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,000080
+MONTGOMERY,Cherry Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",169,000080
+MONTGOMERY,Cherryvale Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",117,000090
+MONTGOMERY,Cherryvale Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",24,000090
+MONTGOMERY,Cherryvale Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",276,000090
+MONTGOMERY,Cherryvale Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",73,000100
+MONTGOMERY,Cherryvale Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000100
+MONTGOMERY,Cherryvale Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",223,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",61,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",12,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",69,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",76,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",70,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",106,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",73,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",127,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",87,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",159,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",37,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",55,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",45,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",79,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",61,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",82,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",23,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",23,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",54,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",91,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",137,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States House of Representatives,2,Libertarian,"Hawver, Dennis",24,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States House of Representatives,2,Republican,"Jenkins, Lynn",248,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",119,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States House of Representatives,2,Republican,"Jenkins, Lynn",291,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",148,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States House of Representatives,2,Libertarian,"Hawver, Dennis",17,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States House of Representatives,2,Republican,"Jenkins, Lynn",375,000230
+MONTGOMERY,Drum Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",43,000240
+MONTGOMERY,Drum Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000240
+MONTGOMERY,Drum Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",234,000240
+MONTGOMERY,Fawn Creek Township Dearing,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",145,000250
+MONTGOMERY,Fawn Creek Township Dearing,United States House of Representatives,2,Libertarian,"Hawver, Dennis",25,000250
+MONTGOMERY,Fawn Creek Township Dearing,United States House of Representatives,2,Republican,"Jenkins, Lynn",507,000250
+MONTGOMERY,Fawn Creek Township Tyro,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",25,000260
+MONTGOMERY,Fawn Creek Township Tyro,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000260
+MONTGOMERY,Fawn Creek Township Tyro,United States House of Representatives,2,Republican,"Jenkins, Lynn",154,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",48,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",108,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",62,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",207,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",33,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",31,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",68,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",60,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",158,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",37,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",75,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",94,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",189,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",66,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",105,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",45,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",115,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",90,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",205,000360
+MONTGOMERY,Independence Township 2 Part B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00040B
+MONTGOMERY,Independence Township 2 Part B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00040B
+MONTGOMERY,Independence Township 2 Part B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00040B
+MONTGOMERY,Independence Township 2 Part C,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",10,00040C
+MONTGOMERY,Independence Township 2 Part C,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,00040C
+MONTGOMERY,Independence Township 2 Part C,United States House of Representatives,2,Republican,"Jenkins, Lynn",35,00040C
+MONTGOMERY,Liberty Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",47,000410
+MONTGOMERY,Liberty Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000410
+MONTGOMERY,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",183,000410
+MONTGOMERY,Louisburg Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",49,000420
+MONTGOMERY,Louisburg Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",21,000420
+MONTGOMERY,Louisburg Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",188,000420
+MONTGOMERY,Parker Township 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",30,000430
+MONTGOMERY,Parker Township 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000430
+MONTGOMERY,Parker Township 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",85,000430
+MONTGOMERY,Parker Township 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",114,00044A
+MONTGOMERY,Parker Township 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",17,00044A
+MONTGOMERY,Parker Township 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",270,00044A
+MONTGOMERY,Parker Township 2 Enclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",2,00044B
+MONTGOMERY,Parker Township 2 Enclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00044C
+MONTGOMERY,Rutland Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",21,000450
+MONTGOMERY,Rutland Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000450
+MONTGOMERY,Rutland Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",142,000450
+MONTGOMERY,West Cherry Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",26,000470
+MONTGOMERY,West Cherry Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000470
+MONTGOMERY,West Cherry Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",105,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",11,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",20,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",88,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",279,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",30,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",97,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",37,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",256,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",9,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",14,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",72,120050
+MONTGOMERY,Independence Township 1 H11,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",126,120060
+MONTGOMERY,Independence Township 1 H11,United States House of Representatives,2,Libertarian,"Hawver, Dennis",35,120060
+MONTGOMERY,Independence Township 1 H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",551,120060
+MONTGOMERY,Independence Township 1 H12,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",9,120070
+MONTGOMERY,Independence Township 1 H12,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,120070
+MONTGOMERY,Independence Township 1 H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",93,120070
+MONTGOMERY,Independence Township 2 Part A H11,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",38,120090
+MONTGOMERY,Independence Township 2 Part A H12,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,120090
+MONTGOMERY,Independence Township 2 Part A H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",134,120090
+MONTGOMERY,Sycamore Township H11,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",66,120100
+MONTGOMERY,Sycamore Township H11,United States House of Representatives,2,Libertarian,"Hawver, Dennis",19,120100
+MONTGOMERY,Sycamore Township H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",327,120100
+MONTGOMERY,Sycamore Township H12 A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,12011A
+MONTGOMERY,Sycamore Township H12 A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,12011A
+MONTGOMERY,Sycamore Township H12 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12011A
+MONTGOMERY,Sycamore Township H12 B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,12011B
+MONTGOMERY,Sycamore Township H12 B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,12011B
+MONTGOMERY,Sycamore Township H12 B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12011B
+MONTGOMERY,Sycamore Township H12 C,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,12011C
+MONTGOMERY,Sycamore Township H12 C,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,12011C
+MONTGOMERY,Sycamore Township H12 C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12011C
+MONTGOMERY,Sycamore Township H12,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120110
+MONTGOMERY,Sycamore Township H12,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120110
+MONTGOMERY,Sycamore Township H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120110
+MONTGOMERY,Coffeyville Airport,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900010
+MONTGOMERY,Coffeyville Airport,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900010
+MONTGOMERY,Coffeyville Airport,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+MONTGOMERY,Parker Township 2 Enclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900040
+MONTGOMERY,Parker Township 2 Enclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900040
+MONTGOMERY,Parker Township 2 Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900040
+MONTGOMERY,Independence Township 1 Enclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",1,900050
+MONTGOMERY,Independence Township 1 Enclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900050
+MONTGOMERY,Independence Township 1 Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900050
+MONTGOMERY,Independence Exclave Airport,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900060
+MONTGOMERY,Independence Exclave Airport,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900060
+MONTGOMERY,Independence Exclave Airport,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900060

--- a/2012/20121106__ks__general__morris__precinct.csv
+++ b/2012/20121106__ks__general__morris__precinct.csv
@@ -1,0 +1,453 @@
+county,precinct,office,district,party,candidate,votes,vtd
+MORRIS,Council Grove Ward 1,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",212,000010
+MORRIS,Council Grove Ward 2,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",184,000020
+MORRIS,Council Grove Ward 3,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",378,000030
+MORRIS,Herington Ward 1 Exclave A,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,000040
+MORRIS,Herington Ward 1 Exclave B,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,000050
+MORRIS,Highland Township,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",50,000060
+MORRIS,Overland Township,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",34,000070
+MORRIS,Township 1 Precinct 1,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",113,000080
+MORRIS,Township 1 Precinct 2,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",75,000090
+MORRIS,Township 2,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",314,000100
+MORRIS,Township 3,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",179,000110
+MORRIS,Township 4,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",88,000120
+MORRIS,Township 5,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",261,000130
+MORRIS,Township 6,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",38,000140
+MORRIS,Township 7,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",99,000150
+MORRIS,Township 8,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",90,000160
+MORRIS,Township 9,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",123,000170
+MORRIS,Council Grove Ward 3 Exclave,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,900010
+MORRIS,Herington Exclave C Airport,Kansas House of Representatives,68,Republican,"Moxley, Tom J.",0,900020
+MORRIS,Council Grove Ward 1,Kansas Senate,35,Libertarian,"Bryant, Jesse",69,000010
+MORRIS,Council Grove Ward 1,Kansas Senate,35,Republican,"Emler, Jay Scott",156,000010
+MORRIS,Council Grove Ward 2,Kansas Senate,35,Libertarian,"Bryant, Jesse",41,000020
+MORRIS,Council Grove Ward 2,Kansas Senate,35,Republican,"Emler, Jay Scott",135,000020
+MORRIS,Council Grove Ward 3,Kansas Senate,35,Libertarian,"Bryant, Jesse",91,000030
+MORRIS,Council Grove Ward 3,Kansas Senate,35,Republican,"Emler, Jay Scott",280,000030
+MORRIS,Herington Ward 1 Exclave A,Kansas Senate,35,Libertarian,"Bryant, Jesse",0,000040
+MORRIS,Herington Ward 1 Exclave A,Kansas Senate,35,Republican,"Emler, Jay Scott",0,000040
+MORRIS,Herington Ward 1 Exclave B,Kansas Senate,35,Libertarian,"Bryant, Jesse",0,000050
+MORRIS,Herington Ward 1 Exclave B,Kansas Senate,35,Republican,"Emler, Jay Scott",0,000050
+MORRIS,Highland Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",6,000060
+MORRIS,Highland Township,Kansas Senate,35,Republican,"Emler, Jay Scott",41,000060
+MORRIS,Overland Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",5,000070
+MORRIS,Overland Township,Kansas Senate,35,Republican,"Emler, Jay Scott",21,000070
+MORRIS,Township 1 Precinct 1,Kansas Senate,35,Libertarian,"Bryant, Jesse",34,000080
+MORRIS,Township 1 Precinct 1,Kansas Senate,35,Republican,"Emler, Jay Scott",78,000080
+MORRIS,Township 1 Precinct 2,Kansas Senate,35,Libertarian,"Bryant, Jesse",30,000090
+MORRIS,Township 1 Precinct 2,Kansas Senate,35,Republican,"Emler, Jay Scott",50,000090
+MORRIS,Township 2,Kansas Senate,35,Libertarian,"Bryant, Jesse",81,000100
+MORRIS,Township 2,Kansas Senate,35,Republican,"Emler, Jay Scott",247,000100
+MORRIS,Township 3,Kansas Senate,35,Libertarian,"Bryant, Jesse",35,000110
+MORRIS,Township 3,Kansas Senate,35,Republican,"Emler, Jay Scott",145,000110
+MORRIS,Township 4,Kansas Senate,35,Libertarian,"Bryant, Jesse",31,000120
+MORRIS,Township 4,Kansas Senate,35,Republican,"Emler, Jay Scott",70,000120
+MORRIS,Township 5,Kansas Senate,35,Libertarian,"Bryant, Jesse",57,000130
+MORRIS,Township 5,Kansas Senate,35,Republican,"Emler, Jay Scott",207,000130
+MORRIS,Township 6,Kansas Senate,35,Libertarian,"Bryant, Jesse",14,000140
+MORRIS,Township 6,Kansas Senate,35,Republican,"Emler, Jay Scott",35,000140
+MORRIS,Township 7,Kansas Senate,35,Libertarian,"Bryant, Jesse",29,000150
+MORRIS,Township 7,Kansas Senate,35,Republican,"Emler, Jay Scott",80,000150
+MORRIS,Township 8,Kansas Senate,35,Libertarian,"Bryant, Jesse",15,000160
+MORRIS,Township 8,Kansas Senate,35,Republican,"Emler, Jay Scott",82,000160
+MORRIS,Township 9,Kansas Senate,35,Libertarian,"Bryant, Jesse",29,000170
+MORRIS,Township 9,Kansas Senate,35,Republican,"Emler, Jay Scott",97,000170
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,Democratic,"Obama, Barack",93,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,Republican,"Romney, Mitt",145,000010
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,Democratic,"Obama, Barack",72,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,Republican,"Romney, Mitt",133,000020
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,Democratic,"Obama, Barack",131,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",6,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",5,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,Republican,"Romney, Mitt",264,000030
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,000040
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Christensen, Will",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,000050
+MORRIS,Highland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+MORRIS,Highland Township,President / Vice President,,Democratic,"Obama, Barack",10,000060
+MORRIS,Highland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+MORRIS,Highland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+MORRIS,Highland Township,President / Vice President,,Republican,"Romney, Mitt",47,000060
+MORRIS,Overland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+MORRIS,Overland Township,President / Vice President,,Democratic,"Obama, Barack",10,000070
+MORRIS,Overland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+MORRIS,Overland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+MORRIS,Overland Township,President / Vice President,,Republican,"Romney, Mitt",27,000070
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",36,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",94,000080
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",29,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",4,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",4,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",57,000090
+MORRIS,Township 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Barnett, Andre",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Bush, Kent W",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Christensen, Will",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Goode, Virgil",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Stein, Jill E",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+MORRIS,Township 2,President / Vice President,,Democratic,"Obama, Barack",128,000100
+MORRIS,Township 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000100
+MORRIS,Township 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+MORRIS,Township 2,President / Vice President,,Republican,"Romney, Mitt",236,000100
+MORRIS,Township 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Barnett, Andre",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Bush, Kent W",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Christensen, Will",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Goode, Virgil",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Stein, Jill E",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+MORRIS,Township 3,President / Vice President,,Democratic,"Obama, Barack",58,000110
+MORRIS,Township 3,President / Vice President,,Libertarian,"Johnson, Gary",4,000110
+MORRIS,Township 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+MORRIS,Township 3,President / Vice President,,Republican,"Romney, Mitt",140,000110
+MORRIS,Township 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Barnett, Andre",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Bush, Kent W",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Christensen, Will",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Goode, Virgil",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Stein, Jill E",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+MORRIS,Township 4,President / Vice President,,Democratic,"Obama, Barack",14,000120
+MORRIS,Township 4,President / Vice President,,Libertarian,"Johnson, Gary",5,000120
+MORRIS,Township 4,President / Vice President,,Reform,"Baldwin, Chuck",3,000120
+MORRIS,Township 4,President / Vice President,,Republican,"Romney, Mitt",84,000120
+MORRIS,Township 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Barnett, Andre",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Bush, Kent W",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Christensen, Will",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Goode, Virgil",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Stein, Jill E",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+MORRIS,Township 5,President / Vice President,,Democratic,"Obama, Barack",51,000130
+MORRIS,Township 5,President / Vice President,,Libertarian,"Johnson, Gary",6,000130
+MORRIS,Township 5,President / Vice President,,Reform,"Baldwin, Chuck",3,000130
+MORRIS,Township 5,President / Vice President,,Republican,"Romney, Mitt",231,000130
+MORRIS,Township 6,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Barnett, Andre",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Bush, Kent W",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Christensen, Will",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Goode, Virgil",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Stein, Jill E",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+MORRIS,Township 6,President / Vice President,,Democratic,"Obama, Barack",8,000140
+MORRIS,Township 6,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+MORRIS,Township 6,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+MORRIS,Township 6,President / Vice President,,Republican,"Romney, Mitt",42,000140
+MORRIS,Township 7,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Barnett, Andre",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Bush, Kent W",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Christensen, Will",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Goode, Virgil",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Stein, Jill E",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+MORRIS,Township 7,President / Vice President,,Democratic,"Obama, Barack",33,000150
+MORRIS,Township 7,President / Vice President,,Libertarian,"Johnson, Gary",4,000150
+MORRIS,Township 7,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+MORRIS,Township 7,President / Vice President,,Republican,"Romney, Mitt",79,000150
+MORRIS,Township 8,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Barnett, Andre",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Bush, Kent W",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Christensen, Will",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Goode, Virgil",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Stein, Jill E",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+MORRIS,Township 8,President / Vice President,,Democratic,"Obama, Barack",17,000160
+MORRIS,Township 8,President / Vice President,,Libertarian,"Johnson, Gary",4,000160
+MORRIS,Township 8,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+MORRIS,Township 8,President / Vice President,,Republican,"Romney, Mitt",84,000160
+MORRIS,Township 9,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Barnett, Andre",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Bush, Kent W",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Christensen, Will",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Goode, Virgil",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Stein, Jill E",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+MORRIS,Township 9,President / Vice President,,Democratic,"Obama, Barack",28,000170
+MORRIS,Township 9,President / Vice President,,Libertarian,"Johnson, Gary",1,000170
+MORRIS,Township 9,President / Vice President,,Reform,"Baldwin, Chuck",1,000170
+MORRIS,Township 9,President / Vice President,,Republican,"Romney, Mitt",110,000170
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900010
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Barnett, Andre",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Bush, Kent W",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Christensen, Will",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Goode, Virgil",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Stein, Jill E",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,Democratic,"Obama, Barack",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,Republican,"Romney, Mitt",0,900020
+MORRIS,Council Grove Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",195,000010
+MORRIS,Council Grove Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",156,000020
+MORRIS,Council Grove Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",319,000030
+MORRIS,Herington Ward 1 Exclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000040
+MORRIS,Herington Ward 1 Exclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000050
+MORRIS,Highland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000060
+MORRIS,Overland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000070
+MORRIS,Township 1 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",95,000080
+MORRIS,Township 1 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",66,000090
+MORRIS,Township 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",262,000100
+MORRIS,Township 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",161,000110
+MORRIS,Township 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",84,000120
+MORRIS,Township 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",248,000130
+MORRIS,Township 6,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000140
+MORRIS,Township 7,United States House of Representatives,1,Republican,"Huelskamp, Tim",97,000150
+MORRIS,Township 8,United States House of Representatives,1,Republican,"Huelskamp, Tim",90,000160
+MORRIS,Township 9,United States House of Representatives,1,Republican,"Huelskamp, Tim",119,000170
+MORRIS,Council Grove Ward 3 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+MORRIS,Herington Exclave C Airport,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020

--- a/2012/20121106__ks__general__morton__precinct.csv
+++ b/2012/20121106__ks__general__morton__precinct.csv
@@ -1,0 +1,231 @@
+county,precinct,office,district,party,candidate,votes,vtd
+MORTON,Cimarron Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",26,000010
+MORTON,East Richfield,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",32,000020
+MORTON,Elkhart Ward 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",234,000030
+MORTON,Elkhart Ward 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",211,000040
+MORTON,Elkhart Ward 3,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",247,000050
+MORTON,Jones Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",8,000060
+MORTON,Rolla Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",173,000070
+MORTON,Taloga Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",59,000080
+MORTON,West Richfield,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",65,000090
+MORTON,Westola Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",26,000100
+MORTON,Cimarron Township,Kansas Senate,39,Republican,"Powell, Larry R.",23,000010
+MORTON,East Richfield,Kansas Senate,39,Republican,"Powell, Larry R.",25,000020
+MORTON,Elkhart Ward 1,Kansas Senate,39,Republican,"Powell, Larry R.",229,000030
+MORTON,Elkhart Ward 2,Kansas Senate,39,Republican,"Powell, Larry R.",203,000040
+MORTON,Elkhart Ward 3,Kansas Senate,39,Republican,"Powell, Larry R.",242,000050
+MORTON,Jones Township,Kansas Senate,39,Republican,"Powell, Larry R.",8,000060
+MORTON,Rolla Township,Kansas Senate,39,Republican,"Powell, Larry R.",150,000070
+MORTON,Taloga Township,Kansas Senate,39,Republican,"Powell, Larry R.",56,000080
+MORTON,West Richfield,Kansas Senate,39,Republican,"Powell, Larry R.",58,000090
+MORTON,Westola Township,Kansas Senate,39,Republican,"Powell, Larry R.",27,000100
+MORTON,Cimarron Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+MORTON,Cimarron Township,President / Vice President,,Democratic,"Obama, Barack",4,000010
+MORTON,Cimarron Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+MORTON,Cimarron Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+MORTON,Cimarron Township,President / Vice President,,Republican,"Romney, Mitt",26,000010
+MORTON,East Richfield,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Barnett, Andre",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Bush, Kent W",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Christensen, Will",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Goode, Virgil",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Stein, Jill E",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+MORTON,East Richfield,President / Vice President,,Democratic,"Obama, Barack",9,000020
+MORTON,East Richfield,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+MORTON,East Richfield,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+MORTON,East Richfield,President / Vice President,,Republican,"Romney, Mitt",34,000020
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,Democratic,"Obama, Barack",44,000030
+MORTON,Elkhart Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+MORTON,Elkhart Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+MORTON,Elkhart Ward 1,President / Vice President,,Republican,"Romney, Mitt",234,000030
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,Democratic,"Obama, Barack",37,000040
+MORTON,Elkhart Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+MORTON,Elkhart Ward 2,President / Vice President,,Republican,"Romney, Mitt",204,000040
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,Democratic,"Obama, Barack",51,000050
+MORTON,Elkhart Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+MORTON,Elkhart Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,Republican,"Romney, Mitt",242,000050
+MORTON,Jones Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+MORTON,Jones Township,President / Vice President,,Democratic,"Obama, Barack",0,000060
+MORTON,Jones Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+MORTON,Jones Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+MORTON,Jones Township,President / Vice President,,Republican,"Romney, Mitt",8,000060
+MORTON,Rolla Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+MORTON,Rolla Township,President / Vice President,,Democratic,"Obama, Barack",35,000070
+MORTON,Rolla Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+MORTON,Rolla Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000070
+MORTON,Rolla Township,President / Vice President,,Republican,"Romney, Mitt",174,000070
+MORTON,Taloga Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+MORTON,Taloga Township,President / Vice President,,Democratic,"Obama, Barack",2,000080
+MORTON,Taloga Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+MORTON,Taloga Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+MORTON,Taloga Township,President / Vice President,,Republican,"Romney, Mitt",58,000080
+MORTON,West Richfield,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Barnett, Andre",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Bush, Kent W",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Christensen, Will",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Goode, Virgil",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Stein, Jill E",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+MORTON,West Richfield,President / Vice President,,Democratic,"Obama, Barack",2,000090
+MORTON,West Richfield,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+MORTON,West Richfield,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+MORTON,West Richfield,President / Vice President,,Republican,"Romney, Mitt",66,000090
+MORTON,Westola Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+MORTON,Westola Township,President / Vice President,,Democratic,"Obama, Barack",5,000100
+MORTON,Westola Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+MORTON,Westola Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+MORTON,Westola Township,President / Vice President,,Republican,"Romney, Mitt",26,000100
+MORTON,Cimarron Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000010
+MORTON,East Richfield,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000020
+MORTON,Elkhart Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",238,000030
+MORTON,Elkhart Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",214,000040
+MORTON,Elkhart Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",246,000050
+MORTON,Jones Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,000060
+MORTON,Rolla Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",180,000070
+MORTON,Taloga Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",59,000080
+MORTON,West Richfield,United States House of Representatives,1,Republican,"Huelskamp, Tim",67,000090
+MORTON,Westola Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000100

--- a/2012/20121106__ks__general__nemaha__precinct.csv
+++ b/2012/20121106__ks__general__nemaha__precinct.csv
@@ -1,0 +1,1027 @@
+county,precinct,office,district,party,candidate,votes,vtd
+NEMAHA,Adams Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",31,000010
+NEMAHA,Adams Township,Kansas House of Representatives,62,Republican,"Garber, Randy",67,000010
+NEMAHA,Berwick Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",61,000020
+NEMAHA,Berwick Township,Kansas House of Representatives,62,Republican,"Garber, Randy",143,000020
+NEMAHA,Capioma Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",34,000030
+NEMAHA,Capioma Township,Kansas House of Representatives,62,Republican,"Garber, Randy",48,000030
+NEMAHA,Center Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",34,000040
+NEMAHA,Center Township,Kansas House of Representatives,62,Republican,"Garber, Randy",53,000040
+NEMAHA,Centralia,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",70,00005A
+NEMAHA,Centralia,Kansas House of Representatives,62,Republican,"Garber, Randy",85,00005A
+NEMAHA,Centralia Illinois A,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",13,00005B
+NEMAHA,Centralia Illinois A,Kansas House of Representatives,62,Republican,"Garber, Randy",19,00005B
+NEMAHA,Centralia Illinois B,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,00005C
+NEMAHA,Centralia Illinois B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00005C
+NEMAHA,Clear Creek Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",22,000060
+NEMAHA,Clear Creek Township,Kansas House of Representatives,62,Republican,"Garber, Randy",32,000060
+NEMAHA,Gilman Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",41,000070
+NEMAHA,Gilman Township,Kansas House of Representatives,62,Republican,"Garber, Randy",59,000070
+NEMAHA,Granada Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",30,000080
+NEMAHA,Granada Township,Kansas House of Representatives,62,Republican,"Garber, Randy",29,000080
+NEMAHA,Harrison - Goff,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",29,000090
+NEMAHA,Harrison - Goff,Kansas House of Representatives,62,Republican,"Garber, Randy",47,000090
+NEMAHA,Harrison - Kelly,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",17,000100
+NEMAHA,Harrison - Kelly,Kansas House of Representatives,62,Republican,"Garber, Randy",25,000100
+NEMAHA,Home Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",25,000110
+NEMAHA,Home Township,Kansas House of Representatives,62,Republican,"Garber, Randy",41,000110
+NEMAHA,Illinois Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",81,000120
+NEMAHA,Illinois Township,Kansas House of Representatives,62,Republican,"Garber, Randy",109,000120
+NEMAHA,Marion Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",99,000130
+NEMAHA,Marion Township,Kansas House of Representatives,62,Republican,"Garber, Randy",120,000130
+NEMAHA,Mitchell Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",55,000140
+NEMAHA,Mitchell Township,Kansas House of Representatives,62,Republican,"Garber, Randy",95,000140
+NEMAHA,Nemaha Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",10,000150
+NEMAHA,Nemaha Township,Kansas House of Representatives,62,Republican,"Garber, Randy",76,000150
+NEMAHA,Neuchatel Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",17,000160
+NEMAHA,Neuchatel Township,Kansas House of Representatives,62,Republican,"Garber, Randy",41,000160
+NEMAHA,Red Vermillion Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",15,000170
+NEMAHA,Red Vermillion Township,Kansas House of Representatives,62,Republican,"Garber, Randy",36,000170
+NEMAHA,Reilly Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",28,000180
+NEMAHA,Reilly Township,Kansas House of Representatives,62,Republican,"Garber, Randy",41,000180
+NEMAHA,Richmond Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",85,000190
+NEMAHA,Richmond Township,Kansas House of Representatives,62,Republican,"Garber, Randy",187,000190
+NEMAHA,Rock Creek Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",80,00020A
+NEMAHA,Rock Creek Township,Kansas House of Representatives,62,Republican,"Garber, Randy",137,00020A
+NEMAHA,Rock Creek Township Enclave A,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,00020B
+NEMAHA,Rock Creek Township Enclave A,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00020B
+NEMAHA,Rock Creek Township Enclave B,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,00020C
+NEMAHA,Rock Creek Township Enclave B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00020C
+NEMAHA,Sabetha Ward 1,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",145,000210
+NEMAHA,Sabetha Ward 1,Kansas House of Representatives,62,Republican,"Garber, Randy",178,000210
+NEMAHA,Sabetha Ward 2,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",133,000220
+NEMAHA,Sabetha Ward 2,Kansas House of Representatives,62,Republican,"Garber, Randy",169,000220
+NEMAHA,Sabetha Ward,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",134,00023A
+NEMAHA,Sabetha Ward,Kansas House of Representatives,62,Republican,"Garber, Randy",159,00023A
+NEMAHA,Sabetha Ward 3 Enclave,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00023B
+NEMAHA,Sabetha Ward 4,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",71,000240
+NEMAHA,Sabetha Ward 4,Kansas House of Representatives,62,Republican,"Garber, Randy",114,000240
+NEMAHA,Sabetha Ward 5,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,000250
+NEMAHA,Sabetha Ward 5,Kansas House of Representatives,62,Republican,"Garber, Randy",0,000250
+NEMAHA,Seneca Ward 1,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",80,000260
+NEMAHA,Seneca Ward 1,Kansas House of Representatives,62,Republican,"Garber, Randy",170,000260
+NEMAHA,Seneca Ward 2,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",133,000270
+NEMAHA,Seneca Ward 2,Kansas House of Representatives,62,Republican,"Garber, Randy",231,000270
+NEMAHA,Seneca Ward 3,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",159,000280
+NEMAHA,Seneca Ward 3,Kansas House of Representatives,62,Republican,"Garber, Randy",255,000280
+NEMAHA,Washington Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",34,000290
+NEMAHA,Washington Township,Kansas House of Representatives,62,Republican,"Garber, Randy",174,000290
+NEMAHA,Wetmore Township,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",99,000300
+NEMAHA,Wetmore Township,Kansas House of Representatives,62,Republican,"Garber, Randy",80,000300
+NEMAHA,Richmond Township Enclave 1,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,900010
+NEMAHA,Richmond Township Enclave 1,Kansas House of Representatives,62,Republican,"Garber, Randy",0,900010
+NEMAHA,Richland Township Enclave 2,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,900020
+NEMAHA,Richland Township Enclave 2,Kansas House of Representatives,62,Republican,"Garber, Randy",0,900020
+NEMAHA,Sabetha Ward Exclave,Kansas House of Representatives,62,Democratic,"Stones, Dennis R.",0,900030
+NEMAHA,Sabetha Ward Exclave,Kansas House of Representatives,62,Republican,"Garber, Randy",0,900030
+NEMAHA,Adams Township,Kansas Senate,1,Democratic,"Lukert, Steve",50,000010
+NEMAHA,Adams Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",51,000010
+NEMAHA,Berwick Township,Kansas Senate,1,Democratic,"Lukert, Steve",94,000020
+NEMAHA,Berwick Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",109,000020
+NEMAHA,Capioma Township,Kansas Senate,1,Democratic,"Lukert, Steve",45,000030
+NEMAHA,Capioma Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",36,000030
+NEMAHA,Center Township,Kansas Senate,1,Democratic,"Lukert, Steve",64,000040
+NEMAHA,Center Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",31,000040
+NEMAHA,Centralia,Kansas Senate,1,Democratic,"Lukert, Steve",104,00005A
+NEMAHA,Centralia,Kansas Senate,1,Republican,"Pyle, Dennis D.",60,00005A
+NEMAHA,Centralia Illinois A,Kansas Senate,1,Democratic,"Lukert, Steve",21,00005B
+NEMAHA,Centralia Illinois A,Kansas Senate,1,Republican,"Pyle, Dennis D.",11,00005B
+NEMAHA,Centralia Illinois B,Kansas Senate,1,Democratic,"Lukert, Steve",0,00005C
+NEMAHA,Centralia Illinois B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00005C
+NEMAHA,Clear Creek Township,Kansas Senate,1,Democratic,"Lukert, Steve",40,000060
+NEMAHA,Clear Creek Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",18,000060
+NEMAHA,Gilman Township,Kansas Senate,1,Democratic,"Lukert, Steve",52,000070
+NEMAHA,Gilman Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",48,000070
+NEMAHA,Granada Township,Kansas Senate,1,Democratic,"Lukert, Steve",36,000080
+NEMAHA,Granada Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",23,000080
+NEMAHA,Harrison - Goff,Kansas Senate,1,Democratic,"Lukert, Steve",36,000090
+NEMAHA,Harrison - Goff,Kansas Senate,1,Republican,"Pyle, Dennis D.",40,000090
+NEMAHA,Harrison - Kelly,Kansas Senate,1,Democratic,"Lukert, Steve",23,000100
+NEMAHA,Harrison - Kelly,Kansas Senate,1,Republican,"Pyle, Dennis D.",20,000100
+NEMAHA,Home Township,Kansas Senate,1,Democratic,"Lukert, Steve",47,000110
+NEMAHA,Home Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",22,000110
+NEMAHA,Illinois Township,Kansas Senate,1,Democratic,"Lukert, Steve",130,000120
+NEMAHA,Illinois Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",66,000120
+NEMAHA,Marion Township,Kansas Senate,1,Democratic,"Lukert, Steve",184,000130
+NEMAHA,Marion Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",53,000130
+NEMAHA,Mitchell Township,Kansas Senate,1,Democratic,"Lukert, Steve",84,000140
+NEMAHA,Mitchell Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",80,000140
+NEMAHA,Nemaha Township,Kansas Senate,1,Democratic,"Lukert, Steve",32,000150
+NEMAHA,Nemaha Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",58,000150
+NEMAHA,Neuchatel Township,Kansas Senate,1,Democratic,"Lukert, Steve",33,000160
+NEMAHA,Neuchatel Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",30,000160
+NEMAHA,Red Vermillion Township,Kansas Senate,1,Democratic,"Lukert, Steve",26,000170
+NEMAHA,Red Vermillion Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",29,000170
+NEMAHA,Reilly Township,Kansas Senate,1,Democratic,"Lukert, Steve",41,000180
+NEMAHA,Reilly Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",29,000180
+NEMAHA,Richmond Township,Kansas Senate,1,Democratic,"Lukert, Steve",166,000190
+NEMAHA,Richmond Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",124,000190
+NEMAHA,Rock Creek Township,Kansas Senate,1,Democratic,"Lukert, Steve",121,00020A
+NEMAHA,Rock Creek Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",91,00020A
+NEMAHA,Rock Creek Township Enclave A,Kansas Senate,1,Democratic,"Lukert, Steve",0,00020B
+NEMAHA,Rock Creek Township Enclave A,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00020B
+NEMAHA,Rock Creek Township Enclave B,Kansas Senate,1,Democratic,"Lukert, Steve",0,00020C
+NEMAHA,Rock Creek Township Enclave B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00020C
+NEMAHA,Sabetha Ward 1,Kansas Senate,1,Democratic,"Lukert, Steve",207,000210
+NEMAHA,Sabetha Ward 1,Kansas Senate,1,Republican,"Pyle, Dennis D.",113,000210
+NEMAHA,Sabetha Ward 2,Kansas Senate,1,Democratic,"Lukert, Steve",176,000220
+NEMAHA,Sabetha Ward 2,Kansas Senate,1,Republican,"Pyle, Dennis D.",119,000220
+NEMAHA,Sabetha Ward,Kansas Senate,1,Democratic,"Lukert, Steve",186,00023A
+NEMAHA,Sabetha Ward,Kansas Senate,1,Republican,"Pyle, Dennis D.",111,00023A
+NEMAHA,Sabetha Ward 3 Enclave,Kansas Senate,1,Democratic,"Lukert, Steve",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00023B
+NEMAHA,Sabetha Ward 4,Kansas Senate,1,Democratic,"Lukert, Steve",104,000240
+NEMAHA,Sabetha Ward 4,Kansas Senate,1,Republican,"Pyle, Dennis D.",79,000240
+NEMAHA,Sabetha Ward 5,Kansas Senate,1,Democratic,"Lukert, Steve",0,000250
+NEMAHA,Sabetha Ward 5,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,000250
+NEMAHA,Seneca Ward 1,Kansas Senate,1,Democratic,"Lukert, Steve",153,000260
+NEMAHA,Seneca Ward 1,Kansas Senate,1,Republican,"Pyle, Dennis D.",110,000260
+NEMAHA,Seneca Ward 2,Kansas Senate,1,Democratic,"Lukert, Steve",248,000270
+NEMAHA,Seneca Ward 2,Kansas Senate,1,Republican,"Pyle, Dennis D.",136,000270
+NEMAHA,Seneca Ward 3,Kansas Senate,1,Democratic,"Lukert, Steve",256,000280
+NEMAHA,Seneca Ward 3,Kansas Senate,1,Republican,"Pyle, Dennis D.",174,000280
+NEMAHA,Washington Township,Kansas Senate,1,Democratic,"Lukert, Steve",80,000290
+NEMAHA,Washington Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",129,000290
+NEMAHA,Wetmore Township,Kansas Senate,1,Democratic,"Lukert, Steve",101,000300
+NEMAHA,Wetmore Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",81,000300
+NEMAHA,Richmond Township Enclave 1,Kansas Senate,1,Democratic,"Lukert, Steve",0,900010
+NEMAHA,Richmond Township Enclave 1,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,900010
+NEMAHA,Richland Township Enclave 2,Kansas Senate,1,Democratic,"Lukert, Steve",0,900020
+NEMAHA,Richland Township Enclave 2,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,900020
+NEMAHA,Sabetha Ward Exclave,Kansas Senate,1,Democratic,"Lukert, Steve",0,900030
+NEMAHA,Sabetha Ward Exclave,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,900030
+NEMAHA,Adams Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+NEMAHA,Adams Township,President / Vice President,,Democratic,"Obama, Barack",10,000010
+NEMAHA,Adams Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+NEMAHA,Adams Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+NEMAHA,Adams Township,President / Vice President,,Republican,"Romney, Mitt",93,000010
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+NEMAHA,Berwick Township,President / Vice President,,Democratic,"Obama, Barack",19,000020
+NEMAHA,Berwick Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+NEMAHA,Berwick Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000020
+NEMAHA,Berwick Township,President / Vice President,,Republican,"Romney, Mitt",182,000020
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+NEMAHA,Capioma Township,President / Vice President,,Democratic,"Obama, Barack",9,000030
+NEMAHA,Capioma Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+NEMAHA,Capioma Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+NEMAHA,Capioma Township,President / Vice President,,Republican,"Romney, Mitt",70,000030
+NEMAHA,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+NEMAHA,Center Township,President / Vice President,,Democratic,"Obama, Barack",14,000040
+NEMAHA,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+NEMAHA,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+NEMAHA,Center Township,President / Vice President,,Republican,"Romney, Mitt",76,000040
+NEMAHA,Centralia,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Ayers, Avery L",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Barnett, Andre",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Barr, Roseanne C",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Bush, Kent W",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Christensen, Will",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Duncan, Richard A",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Goode, Virgil",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Knill, Dennis J",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Reed, Jill A.",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Rogers, Rick L",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Stein, Jill E",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Thorne, Kevin M",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Warner, Gerald L.",0,00005A
+NEMAHA,Centralia,President / Vice President,,Democratic,"Obama, Barack",44,00005A
+NEMAHA,Centralia,President / Vice President,,Libertarian,"Johnson, Gary",5,00005A
+NEMAHA,Centralia,President / Vice President,,Reform,"Baldwin, Chuck",4,00005A
+NEMAHA,Centralia,President / Vice President,,Republican,"Romney, Mitt",110,00005A
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Ayers, Avery L",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Barnett, Andre",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Barr, Roseanne C",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Bush, Kent W",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Christensen, Will",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Duncan, Richard A",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Goode, Virgil",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Knill, Dennis J",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Reed, Jill A.",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Rogers, Rick L",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Stein, Jill E",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Thorne, Kevin M",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Warner, Gerald L.",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,Democratic,"Obama, Barack",7,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,Reform,"Baldwin, Chuck",1,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,Republican,"Romney, Mitt",25,00005B
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Ayers, Avery L",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Barnett, Andre",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Barr, Roseanne C",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Bush, Kent W",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Christensen, Will",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Duncan, Richard A",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Goode, Virgil",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Hoefling, Tom",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Knill, Dennis J",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Reed, Jill A.",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Rogers, Rick L",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Stein, Jill E",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Thorne, Kevin M",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Warner, Gerald L.",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,Democratic,"Obama, Barack",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,Libertarian,"Johnson, Gary",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,Reform,"Baldwin, Chuck",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,Republican,"Romney, Mitt",0,00005C
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,Democratic,"Obama, Barack",20,000060
+NEMAHA,Clear Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+NEMAHA,Clear Creek Township,President / Vice President,,Republican,"Romney, Mitt",36,000060
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+NEMAHA,Gilman Township,President / Vice President,,Democratic,"Obama, Barack",31,000070
+NEMAHA,Gilman Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+NEMAHA,Gilman Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+NEMAHA,Gilman Township,President / Vice President,,Republican,"Romney, Mitt",70,000070
+NEMAHA,Granada Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+NEMAHA,Granada Township,President / Vice President,,Democratic,"Obama, Barack",14,000080
+NEMAHA,Granada Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+NEMAHA,Granada Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+NEMAHA,Granada Township,President / Vice President,,Republican,"Romney, Mitt",45,000080
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Barnett, Andre",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Bush, Kent W",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Christensen, Will",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Goode, Virgil",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Stein, Jill E",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,Democratic,"Obama, Barack",21,000090
+NEMAHA,Harrison - Goff,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+NEMAHA,Harrison - Goff,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,Republican,"Romney, Mitt",57,000090
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Barnett, Andre",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Bush, Kent W",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Christensen, Will",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Goode, Virgil",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Stein, Jill E",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,Democratic,"Obama, Barack",13,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,Republican,"Romney, Mitt",28,000100
+NEMAHA,Home Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+NEMAHA,Home Township,President / Vice President,,Democratic,"Obama, Barack",14,000110
+NEMAHA,Home Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+NEMAHA,Home Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+NEMAHA,Home Township,President / Vice President,,Republican,"Romney, Mitt",56,000110
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+NEMAHA,Illinois Township,President / Vice President,,Democratic,"Obama, Barack",40,000120
+NEMAHA,Illinois Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000120
+NEMAHA,Illinois Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000120
+NEMAHA,Illinois Township,President / Vice President,,Republican,"Romney, Mitt",152,000120
+NEMAHA,Marion Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+NEMAHA,Marion Township,President / Vice President,,Democratic,"Obama, Barack",43,000130
+NEMAHA,Marion Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000130
+NEMAHA,Marion Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000130
+NEMAHA,Marion Township,President / Vice President,,Republican,"Romney, Mitt",179,000130
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,Democratic,"Obama, Barack",22,000140
+NEMAHA,Mitchell Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000140
+NEMAHA,Mitchell Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,Republican,"Romney, Mitt",136,000140
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,Democratic,"Obama, Barack",5,000150
+NEMAHA,Nemaha Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,Republican,"Romney, Mitt",84,000150
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,Democratic,"Obama, Barack",9,000160
+NEMAHA,Neuchatel Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000160
+NEMAHA,Neuchatel Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000160
+NEMAHA,Neuchatel Township,President / Vice President,,Republican,"Romney, Mitt",50,000160
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,Democratic,"Obama, Barack",14,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,Republican,"Romney, Mitt",41,000170
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+NEMAHA,Reilly Township,President / Vice President,,Democratic,"Obama, Barack",11,000180
+NEMAHA,Reilly Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+NEMAHA,Reilly Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000180
+NEMAHA,Reilly Township,President / Vice President,,Republican,"Romney, Mitt",56,000180
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+NEMAHA,Richmond Township,President / Vice President,,Democratic,"Obama, Barack",39,000190
+NEMAHA,Richmond Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+NEMAHA,Richmond Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000190
+NEMAHA,Richmond Township,President / Vice President,,Republican,"Romney, Mitt",244,000190
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Christensen, Will",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,Democratic,"Obama, Barack",16,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",3,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,Republican,"Romney, Mitt",193,00020A
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Barnett, Andre",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Bush, Kent W",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Christensen, Will",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Goode, Virgil",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Stein, Jill E",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,Democratic,"Obama, Barack",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,Republican,"Romney, Mitt",0,00020B
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Barnett, Andre",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Bush, Kent W",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Christensen, Will",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Goode, Virgil",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Stein, Jill E",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,Democratic,"Obama, Barack",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,Republican,"Romney, Mitt",0,00020C
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,Democratic,"Obama, Barack",69,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,Republican,"Romney, Mitt",240,000210
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,Democratic,"Obama, Barack",64,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",5,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,Republican,"Romney, Mitt",232,000220
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Ayers, Avery L",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Barnett, Andre",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Barr, Roseanne C",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Bush, Kent W",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Christensen, Will",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Duncan, Richard A",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Goode, Virgil",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Hoefling, Tom",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Knill, Dennis J",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Reed, Jill A.",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Rogers, Rick L",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Stein, Jill E",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Thorne, Kevin M",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Warner, Gerald L.",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,Democratic,"Obama, Barack",60,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,Libertarian,"Johnson, Gary",3,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,Reform,"Baldwin, Chuck",2,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,Republican,"Romney, Mitt",235,00023A
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Christensen, Will",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00023B
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,Democratic,"Obama, Barack",35,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",5,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",2,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,Republican,"Romney, Mitt",142,000240
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Barnett, Andre",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Bush, Kent W",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Christensen, Will",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Goode, Virgil",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Stein, Jill E",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,Democratic,"Obama, Barack",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,Republican,"Romney, Mitt",0,000250
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,Democratic,"Obama, Barack",64,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",1,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,Republican,"Romney, Mitt",200,000260
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,Democratic,"Obama, Barack",93,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",4,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,Republican,"Romney, Mitt",292,000270
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,Democratic,"Obama, Barack",115,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",4,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",5,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,Republican,"Romney, Mitt",304,000280
+NEMAHA,Washington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Barnett, Andre",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Bush, Kent W",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Christensen, Will",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Goode, Virgil",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Stein, Jill E",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+NEMAHA,Washington Township,President / Vice President,,Democratic,"Obama, Barack",28,000290
+NEMAHA,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000290
+NEMAHA,Washington Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000290
+NEMAHA,Washington Township,President / Vice President,,Republican,"Romney, Mitt",184,000290
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Barnett, Andre",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Bush, Kent W",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Christensen, Will",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Goode, Virgil",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Stein, Jill E",1,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,Democratic,"Obama, Barack",57,000300
+NEMAHA,Wetmore Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000300
+NEMAHA,Wetmore Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000300
+NEMAHA,Wetmore Township,President / Vice President,,Republican,"Romney, Mitt",118,000300
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Christensen, Will",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900010
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Christensen, Will",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900020
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Christensen, Will",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900030
+NEMAHA,Adams Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",24,000010
+NEMAHA,Adams Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000010
+NEMAHA,Adams Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",76,000010
+NEMAHA,Berwick Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",23,000020
+NEMAHA,Berwick Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000020
+NEMAHA,Berwick Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",171,000020
+NEMAHA,Capioma Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",13,000030
+NEMAHA,Capioma Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000030
+NEMAHA,Capioma Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",67,000030
+NEMAHA,Center Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",16,000040
+NEMAHA,Center Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000040
+NEMAHA,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",68,000040
+NEMAHA,Centralia,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",54,00005A
+NEMAHA,Centralia,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,00005A
+NEMAHA,Centralia,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,00005A
+NEMAHA,Centralia Illinois A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",11,00005B
+NEMAHA,Centralia Illinois A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,00005B
+NEMAHA,Centralia Illinois A,United States House of Representatives,2,Republican,"Jenkins, Lynn",20,00005B
+NEMAHA,Centralia Illinois B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00005C
+NEMAHA,Centralia Illinois B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00005C
+NEMAHA,Centralia Illinois B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005C
+NEMAHA,Clear Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",22,000060
+NEMAHA,Clear Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000060
+NEMAHA,Clear Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",36,000060
+NEMAHA,Gilman Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",24,000070
+NEMAHA,Gilman Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000070
+NEMAHA,Gilman Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",71,000070
+NEMAHA,Granada Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",12,000080
+NEMAHA,Granada Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000080
+NEMAHA,Granada Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",45,000080
+NEMAHA,Harrison - Goff,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",30,000090
+NEMAHA,Harrison - Goff,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000090
+NEMAHA,Harrison - Goff,United States House of Representatives,2,Republican,"Jenkins, Lynn",44,000090
+NEMAHA,Harrison - Kelly,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",13,000100
+NEMAHA,Harrison - Kelly,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000100
+NEMAHA,Harrison - Kelly,United States House of Representatives,2,Republican,"Jenkins, Lynn",28,000100
+NEMAHA,Home Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",9,000110
+NEMAHA,Home Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000110
+NEMAHA,Home Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",53,000110
+NEMAHA,Illinois Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",59,000120
+NEMAHA,Illinois Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000120
+NEMAHA,Illinois Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",126,000120
+NEMAHA,Marion Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",59,000130
+NEMAHA,Marion Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000130
+NEMAHA,Marion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",157,000130
+NEMAHA,Mitchell Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",36,000140
+NEMAHA,Mitchell Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000140
+NEMAHA,Mitchell Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",124,000140
+NEMAHA,Nemaha Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",5,000150
+NEMAHA,Nemaha Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000150
+NEMAHA,Nemaha Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",80,000150
+NEMAHA,Neuchatel Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",15,000160
+NEMAHA,Neuchatel Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000160
+NEMAHA,Neuchatel Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,000160
+NEMAHA,Red Vermillion Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",16,000170
+NEMAHA,Red Vermillion Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000170
+NEMAHA,Red Vermillion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",37,000170
+NEMAHA,Reilly Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",19,000180
+NEMAHA,Reilly Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000180
+NEMAHA,Reilly Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",49,000180
+NEMAHA,Richmond Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",61,000190
+NEMAHA,Richmond Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000190
+NEMAHA,Richmond Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",214,000190
+NEMAHA,Rock Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",25,00020A
+NEMAHA,Rock Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,00020A
+NEMAHA,Rock Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",170,00020A
+NEMAHA,Rock Creek Township Enclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00020B
+NEMAHA,Rock Creek Township Enclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00020B
+NEMAHA,Rock Creek Township Enclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00020B
+NEMAHA,Rock Creek Township Enclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00020C
+NEMAHA,Rock Creek Township Enclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00020C
+NEMAHA,Rock Creek Township Enclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00020C
+NEMAHA,Sabetha Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",83,000210
+NEMAHA,Sabetha Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000210
+NEMAHA,Sabetha Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",219,000210
+NEMAHA,Sabetha Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",68,000220
+NEMAHA,Sabetha Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000220
+NEMAHA,Sabetha Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",217,000220
+NEMAHA,Sabetha Ward,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",62,00023A
+NEMAHA,Sabetha Ward,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,00023A
+NEMAHA,Sabetha Ward,United States House of Representatives,2,Republican,"Jenkins, Lynn",221,00023A
+NEMAHA,Sabetha Ward 3 Enclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00023B
+NEMAHA,Sabetha Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",36,000240
+NEMAHA,Sabetha Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,000240
+NEMAHA,Sabetha Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",130,000240
+NEMAHA,Sabetha Ward 5,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,000250
+NEMAHA,Sabetha Ward 5,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000250
+NEMAHA,Sabetha Ward 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,000250
+NEMAHA,Seneca Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",75,000260
+NEMAHA,Seneca Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000260
+NEMAHA,Seneca Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",178,000260
+NEMAHA,Seneca Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",116,000270
+NEMAHA,Seneca Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,000270
+NEMAHA,Seneca Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",248,000270
+NEMAHA,Seneca Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",126,000280
+NEMAHA,Seneca Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000280
+NEMAHA,Seneca Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",278,000280
+NEMAHA,Washington Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",35,000290
+NEMAHA,Washington Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000290
+NEMAHA,Washington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",168,000290
+NEMAHA,Wetmore Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",54,000300
+NEMAHA,Wetmore Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,000300
+NEMAHA,Wetmore Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",115,000300
+NEMAHA,Richmond Township Enclave 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900010
+NEMAHA,Richmond Township Enclave 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900010
+NEMAHA,Richmond Township Enclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+NEMAHA,Richland Township Enclave 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900020
+NEMAHA,Richland Township Enclave 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900020
+NEMAHA,Richland Township Enclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+NEMAHA,Sabetha Ward Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900030
+NEMAHA,Sabetha Ward Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900030
+NEMAHA,Sabetha Ward Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030

--- a/2012/20121106__ks__general__neosho__precinct.csv
+++ b/2012/20121106__ks__general__neosho__precinct.csv
@@ -1,0 +1,846 @@
+county,precinct,office,district,party,candidate,votes,vtd
+NEOSHO,Big Creek Township,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",70,000010
+NEOSHO,Big Creek Township,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",10,000010
+NEOSHO,Big Creek Township,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",172,000010
+NEOSHO,Canville Township,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",290,00002A
+NEOSHO,Centerville Township,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",100,000030
+NEOSHO,Centerville Township,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",6,000030
+NEOSHO,Centerville Township,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",138,000030
+NEOSHO,Chanute Ward 1,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",82,000040
+NEOSHO,Chanute Ward 2 Precinct 1,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",256,000050
+NEOSHO,Chanute Ward 2 Precinct 2,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",289,000060
+NEOSHO,Chanute Ward 3 Precinct 1,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",462,000070
+NEOSHO,Chanute Ward 3 Precinct 2,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",304,000080
+NEOSHO,Chanute Ward 3 Precinct 3,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",556,000090
+NEOSHO,Chanute Ward 4 Precinct 1,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",336,000100
+NEOSHO,Chanute Ward 4 Precinct 2,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",214,000110
+NEOSHO,Chanute Ward 4 Precinct 3,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",194,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",0,00012C
+NEOSHO,East Erie,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",96,000140
+NEOSHO,East Erie,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",8,000140
+NEOSHO,East Erie,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",156,000140
+NEOSHO,Grant Township,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",77,000150
+NEOSHO,Grant Township,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",7,000150
+NEOSHO,Grant Township,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",93,000150
+NEOSHO,Ladore Township,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",98,000160
+NEOSHO,Ladore Township,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",5,000160
+NEOSHO,Ladore Township,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",71,000160
+NEOSHO,Lincoln Township,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",37,000170
+NEOSHO,Lincoln Township,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",4,000170
+NEOSHO,Lincoln Township,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",51,000170
+NEOSHO,Mission Township,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",160,000180
+NEOSHO,Mission Township,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",3,000180
+NEOSHO,Mission Township,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",234,000180
+NEOSHO,North Tioga Township,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",204,000190
+NEOSHO,Shiloh Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",124,000200
+NEOSHO,South Tioga East Township,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",104,000210
+NEOSHO,South Tioga West Township,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",80,00022A
+NEOSHO,South Tioga West Township Enclave,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",0,00022B
+NEOSHO,South Tioga West Township Enclave B,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",0,00022C
+NEOSHO,South Tioga West Township Enclave C,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",0,00022D
+NEOSHO,Walnut Grove Township,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",61,000230
+NEOSHO,Walnut Grove Township,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",8,000230
+NEOSHO,Walnut Grove Township,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",79,000230
+NEOSHO,West Erie,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",107,000240
+NEOSHO,West Erie,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",10,000240
+NEOSHO,West Erie,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",198,000240
+NEOSHO,Chetopa Township H13,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",249,120020
+NEOSHO,Chetopa Township H2,Kansas House of Representatives,2,Democratic,"Grant, Robert ""Bob""",0,120030
+NEOSHO,Chetopa Township H2,Kansas House of Representatives,2,Libertarian,"Monaghan, Lawrence E.",0,120030
+NEOSHO,Chetopa Township H2,Kansas House of Representatives,2,Republican,"Locke, Jeffrey G. ""Jeff""",0,120030
+NEOSHO,Chetopa Township H9,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",85,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Kansas House of Representatives,9,Republican,"Bideau, Edwin H. III",0,900020
+NEOSHO,Big Creek Township,Kansas Senate,15,Republican,"King, Jeff",219,000010
+NEOSHO,Canville Township,Kansas Senate,15,Republican,"King, Jeff",263,00002A
+NEOSHO,Centerville Township,Kansas Senate,15,Republican,"King, Jeff",198,000030
+NEOSHO,Chanute Ward 1,Kansas Senate,15,Republican,"King, Jeff",79,000040
+NEOSHO,Chanute Ward 2 Precinct 1,Kansas Senate,15,Republican,"King, Jeff",246,000050
+NEOSHO,Chanute Ward 2 Precinct 2,Kansas Senate,15,Republican,"King, Jeff",264,000060
+NEOSHO,Chanute Ward 3 Precinct 1,Kansas Senate,15,Republican,"King, Jeff",421,000070
+NEOSHO,Chanute Ward 3 Precinct 2,Kansas Senate,15,Republican,"King, Jeff",283,000080
+NEOSHO,Chanute Ward 3 Precinct 3,Kansas Senate,15,Republican,"King, Jeff",492,000090
+NEOSHO,Chanute Ward 4 Precinct 1,Kansas Senate,15,Republican,"King, Jeff",304,000100
+NEOSHO,Chanute Ward 4 Precinct 2,Kansas Senate,15,Republican,"King, Jeff",207,000110
+NEOSHO,Chanute Ward 4 Precinct 3,Kansas Senate,15,Republican,"King, Jeff",184,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Kansas Senate,15,Republican,"King, Jeff",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Kansas Senate,15,Republican,"King, Jeff",0,00012C
+NEOSHO,East Erie,Kansas Senate,15,Republican,"King, Jeff",200,000140
+NEOSHO,Grant Township,Kansas Senate,15,Republican,"King, Jeff",136,000150
+NEOSHO,Ladore Township,Kansas Senate,15,Republican,"King, Jeff",142,000160
+NEOSHO,Lincoln Township,Kansas Senate,15,Republican,"King, Jeff",72,000170
+NEOSHO,Mission Township,Kansas Senate,15,Republican,"King, Jeff",313,000180
+NEOSHO,North Tioga Township,Kansas Senate,15,Republican,"King, Jeff",201,000190
+NEOSHO,Shiloh Township,Kansas Senate,15,Republican,"King, Jeff",116,000200
+NEOSHO,South Tioga East Township,Kansas Senate,15,Republican,"King, Jeff",99,000210
+NEOSHO,South Tioga West Township,Kansas Senate,15,Republican,"King, Jeff",78,00022A
+NEOSHO,South Tioga West Township Enclave,Kansas Senate,15,Republican,"King, Jeff",0,00022B
+NEOSHO,South Tioga West Township Enclave B,Kansas Senate,15,Republican,"King, Jeff",0,00022C
+NEOSHO,South Tioga West Township Enclave C,Kansas Senate,15,Republican,"King, Jeff",0,00022D
+NEOSHO,Walnut Grove Township,Kansas Senate,15,Republican,"King, Jeff",125,000230
+NEOSHO,West Erie,Kansas Senate,15,Republican,"King, Jeff",253,000240
+NEOSHO,Chetopa Township H13,Kansas Senate,15,Republican,"King, Jeff",238,120020
+NEOSHO,Chetopa Township H2,Kansas Senate,15,Republican,"King, Jeff",0,120030
+NEOSHO,Chetopa Township H9,Kansas Senate,15,Republican,"King, Jeff",74,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Kansas Senate,15,Republican,"King, Jeff",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Kansas Senate,15,Republican,"King, Jeff",0,900020
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,Democratic,"Obama, Barack",48,000010
+NEOSHO,Big Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000010
+NEOSHO,Big Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000010
+NEOSHO,Big Creek Township,President / Vice President,,Republican,"Romney, Mitt",202,000010
+NEOSHO,Canville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Ayers, Avery L",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Barnett, Andre",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Bush, Kent W",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Christensen, Will",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Duncan, Richard A",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Goode, Virgil",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Hoefling, Tom",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Knill, Dennis J",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Reed, Jill A.",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Rogers, Rick L",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Stein, Jill E",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00002A
+NEOSHO,Canville Township,President / Vice President,,Democratic,"Obama, Barack",94,00002A
+NEOSHO,Canville Township,President / Vice President,,Libertarian,"Johnson, Gary",5,00002A
+NEOSHO,Canville Township,President / Vice President,,Reform,"Baldwin, Chuck",1,00002A
+NEOSHO,Canville Township,President / Vice President,,Republican,"Romney, Mitt",229,00002A
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+NEOSHO,Centerville Township,President / Vice President,,Democratic,"Obama, Barack",87,000030
+NEOSHO,Centerville Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+NEOSHO,Centerville Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+NEOSHO,Centerville Township,President / Vice President,,Republican,"Romney, Mitt",166,000030
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,Democratic,"Obama, Barack",35,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,Republican,"Romney, Mitt",54,000040
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",116,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",7,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",163,000050
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",100,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",5,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",216,000060
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",192,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",10,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",9,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",312,000070
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",110,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",5,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",221,000080
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",188,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",7,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",5,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",420,000090
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",1,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",175,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",6,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",206,000100
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",113,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",8,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",136,000110
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",77,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",4,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",2,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",148,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Christensen, Will",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,00012C
+NEOSHO,East Erie,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Barnett, Andre",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Bush, Kent W",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Christensen, Will",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Goode, Virgil",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Stein, Jill E",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+NEOSHO,East Erie,President / Vice President,,Democratic,"Obama, Barack",107,000140
+NEOSHO,East Erie,President / Vice President,,Libertarian,"Johnson, Gary",7,000140
+NEOSHO,East Erie,President / Vice President,,Reform,"Baldwin, Chuck",4,000140
+NEOSHO,East Erie,President / Vice President,,Republican,"Romney, Mitt",150,000140
+NEOSHO,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+NEOSHO,Grant Township,President / Vice President,,Democratic,"Obama, Barack",62,000150
+NEOSHO,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+NEOSHO,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+NEOSHO,Grant Township,President / Vice President,,Republican,"Romney, Mitt",120,000150
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+NEOSHO,Ladore Township,President / Vice President,,Democratic,"Obama, Barack",82,000160
+NEOSHO,Ladore Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000160
+NEOSHO,Ladore Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000160
+NEOSHO,Ladore Township,President / Vice President,,Republican,"Romney, Mitt",89,000160
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",34,000170
+NEOSHO,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000170
+NEOSHO,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",57,000170
+NEOSHO,Mission Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+NEOSHO,Mission Township,President / Vice President,,Democratic,"Obama, Barack",94,000180
+NEOSHO,Mission Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000180
+NEOSHO,Mission Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000180
+NEOSHO,Mission Township,President / Vice President,,Republican,"Romney, Mitt",301,000180
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,Democratic,"Obama, Barack",57,000190
+NEOSHO,North Tioga Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+NEOSHO,North Tioga Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,Republican,"Romney, Mitt",164,000190
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,Democratic,"Obama, Barack",28,000200
+NEOSHO,Shiloh Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000200
+NEOSHO,Shiloh Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,Republican,"Romney, Mitt",113,000200
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,Democratic,"Obama, Barack",29,000210
+NEOSHO,South Tioga East Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000210
+NEOSHO,South Tioga East Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000210
+NEOSHO,South Tioga East Township,President / Vice President,,Republican,"Romney, Mitt",86,000210
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Ayers, Avery L",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Barnett, Andre",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Bush, Kent W",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Christensen, Will",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Duncan, Richard A",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Goode, Virgil",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Hoefling, Tom",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Knill, Dennis J",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Reed, Jill A.",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Rogers, Rick L",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Stein, Jill E",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,Democratic,"Obama, Barack",22,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,Libertarian,"Johnson, Gary",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,Reform,"Baldwin, Chuck",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,Republican,"Romney, Mitt",65,00022A
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Christensen, Will",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00022B
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Barnett, Andre",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Bush, Kent W",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Christensen, Will",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Goode, Virgil",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Stein, Jill E",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,Democratic,"Obama, Barack",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,Republican,"Romney, Mitt",0,00022C
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Ayers, Avery L",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Barnett, Andre",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Barr, Roseanne C",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Bush, Kent W",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Christensen, Will",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Duncan, Richard A",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Goode, Virgil",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Knill, Dennis J",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Reed, Jill A.",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Rogers, Rick L",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Stein, Jill E",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Thorne, Kevin M",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Warner, Gerald L.",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,Democratic,"Obama, Barack",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,Reform,"Baldwin, Chuck",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,Republican,"Romney, Mitt",0,00022D
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,Democratic,"Obama, Barack",49,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,Republican,"Romney, Mitt",102,000230
+NEOSHO,West Erie,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Barnett, Andre",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Bush, Kent W",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Christensen, Will",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Goode, Virgil",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Stein, Jill E",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+NEOSHO,West Erie,President / Vice President,,Democratic,"Obama, Barack",88,000240
+NEOSHO,West Erie,President / Vice President,,Libertarian,"Johnson, Gary",5,000240
+NEOSHO,West Erie,President / Vice President,,Reform,"Baldwin, Chuck",1,000240
+NEOSHO,West Erie,President / Vice President,,Republican,"Romney, Mitt",234,000240
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Barnett, Andre",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Bush, Kent W",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Christensen, Will",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Goode, Virgil",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Stein, Jill E",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,Democratic,"Obama, Barack",52,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,Libertarian,"Johnson, Gary",3,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,Reform,"Baldwin, Chuck",5,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,Republican,"Romney, Mitt",233,120020
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Barnett, Andre",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Bush, Kent W",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Christensen, Will",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Goode, Virgil",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Stein, Jill E",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,Democratic,"Obama, Barack",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,Republican,"Romney, Mitt",0,120030
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Barnett, Andre",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Bush, Kent W",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Christensen, Will",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Goode, Virgil",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Stein, Jill E",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,Democratic,"Obama, Barack",11,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,Libertarian,"Johnson, Gary",2,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,Reform,"Baldwin, Chuck",1,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,Republican,"Romney, Mitt",85,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900020
+NEOSHO,Big Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",43,000010
+NEOSHO,Big Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000010
+NEOSHO,Big Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",211,000010
+NEOSHO,Canville Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",68,00002A
+NEOSHO,Canville Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",10,00002A
+NEOSHO,Canville Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",243,00002A
+NEOSHO,Centerville Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",76,000030
+NEOSHO,Centerville Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000030
+NEOSHO,Centerville Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",167,000030
+NEOSHO,Chanute Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",26,000040
+NEOSHO,Chanute Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000040
+NEOSHO,Chanute Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",57,000040
+NEOSHO,Chanute Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",79,000050
+NEOSHO,Chanute Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000050
+NEOSHO,Chanute Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",195,000050
+NEOSHO,Chanute Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",79,000060
+NEOSHO,Chanute Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,000060
+NEOSHO,Chanute Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",218,000060
+NEOSHO,Chanute Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",146,000070
+NEOSHO,Chanute Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",33,000070
+NEOSHO,Chanute Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",335,000070
+NEOSHO,Chanute Ward 3 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",85,000080
+NEOSHO,Chanute Ward 3 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",19,000080
+NEOSHO,Chanute Ward 3 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",224,000080
+NEOSHO,Chanute Ward 3 Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",171,000090
+NEOSHO,Chanute Ward 3 Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",16,000090
+NEOSHO,Chanute Ward 3 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",420,000090
+NEOSHO,Chanute Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",119,000100
+NEOSHO,Chanute Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",19,000100
+NEOSHO,Chanute Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",248,000100
+NEOSHO,Chanute Ward 4 Precinct 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",95,000110
+NEOSHO,Chanute Ward 4 Precinct 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000110
+NEOSHO,Chanute Ward 4 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",149,000110
+NEOSHO,Chanute Ward 4 Precinct 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",55,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",163,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00012C
+NEOSHO,East Erie,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",84,000140
+NEOSHO,East Erie,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000140
+NEOSHO,East Erie,United States House of Representatives,2,Republican,"Jenkins, Lynn",167,000140
+NEOSHO,Grant Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",48,000150
+NEOSHO,Grant Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000150
+NEOSHO,Grant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",119,000150
+NEOSHO,Ladore Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",81,000160
+NEOSHO,Ladore Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000160
+NEOSHO,Ladore Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",90,000160
+NEOSHO,Lincoln Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",36,000170
+NEOSHO,Lincoln Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000170
+NEOSHO,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",55,000170
+NEOSHO,Mission Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",112,000180
+NEOSHO,Mission Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000180
+NEOSHO,Mission Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",276,000180
+NEOSHO,North Tioga Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",43,000190
+NEOSHO,North Tioga Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000190
+NEOSHO,North Tioga Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",177,000190
+NEOSHO,Shiloh Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",30,000200
+NEOSHO,Shiloh Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000200
+NEOSHO,Shiloh Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",106,000200
+NEOSHO,South Tioga East Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",23,000210
+NEOSHO,South Tioga East Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000210
+NEOSHO,South Tioga East Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",87,000210
+NEOSHO,South Tioga West Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",14,00022A
+NEOSHO,South Tioga West Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,00022A
+NEOSHO,South Tioga West Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",70,00022A
+NEOSHO,South Tioga West Township Enclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00022B
+NEOSHO,South Tioga West Township Enclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00022B
+NEOSHO,South Tioga West Township Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00022B
+NEOSHO,South Tioga West Township Enclave B,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00022C
+NEOSHO,South Tioga West Township Enclave B,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00022C
+NEOSHO,South Tioga West Township Enclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00022C
+NEOSHO,South Tioga West Township Enclave C,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00022D
+NEOSHO,South Tioga West Township Enclave C,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00022D
+NEOSHO,South Tioga West Township Enclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00022D
+NEOSHO,Walnut Grove Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",39,000230
+NEOSHO,Walnut Grove Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000230
+NEOSHO,Walnut Grove Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,000230
+NEOSHO,West Erie,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",76,000240
+NEOSHO,West Erie,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000240
+NEOSHO,West Erie,United States House of Representatives,2,Republican,"Jenkins, Lynn",236,000240
+NEOSHO,Chetopa Township H13,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",51,120020
+NEOSHO,Chetopa Township H13,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,120020
+NEOSHO,Chetopa Township H13,United States House of Representatives,2,Republican,"Jenkins, Lynn",230,120020
+NEOSHO,Chetopa Township H2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,120030
+NEOSHO,Chetopa Township H2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,120030
+NEOSHO,Chetopa Township H2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120030
+NEOSHO,Chetopa Township H9,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",9,120040
+NEOSHO,Chetopa Township H9,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,120040
+NEOSHO,Chetopa Township H9,United States House of Representatives,2,Republican,"Jenkins, Lynn",85,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020

--- a/2012/20121106__ks__general__ness__precinct.csv
+++ b/2012/20121106__ks__general__ness__precinct.csv
@@ -1,0 +1,265 @@
+county,precinct,office,district,party,candidate,votes,vtd
+NESS,Bazine Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",63,000010
+NESS,Bazine Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",118,000010
+NESS,Eden Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",8,000020
+NESS,Eden Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",32,000020
+NESS,Forrester Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",11,000030
+NESS,Forrester Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",46,000030
+NESS,Franklin Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",10,000040
+NESS,Franklin Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",46,000040
+NESS,Highpoint Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",3,000050
+NESS,Highpoint Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",35,000050
+NESS,Johnson Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",8,000060
+NESS,Johnson Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",29,000060
+NESS,Nevada Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",94,000070
+NESS,Nevada Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",115,000070
+NESS,North Center,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",112,000080
+NESS,North Center,Kansas House of Representatives,117,Republican,"Ewy, John L.",295,000080
+NESS,Ohio Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",28,000090
+NESS,Ohio Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",93,000090
+NESS,South Center,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",61,000100
+NESS,South Center,Kansas House of Representatives,117,Republican,"Ewy, John L.",158,000100
+NESS,Waring Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",17,000110
+NESS,Waring Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",30,000110
+NESS,Bazine Township,Kansas Senate,33,Republican,"Holmes, Mitch",158,000010
+NESS,Eden Township,Kansas Senate,33,Republican,"Holmes, Mitch",37,000020
+NESS,Forrester Township,Kansas Senate,33,Republican,"Holmes, Mitch",47,000030
+NESS,Franklin Township,Kansas Senate,33,Republican,"Holmes, Mitch",50,000040
+NESS,Highpoint Township,Kansas Senate,33,Republican,"Holmes, Mitch",37,000050
+NESS,Johnson Township,Kansas Senate,33,Republican,"Holmes, Mitch",30,000060
+NESS,Nevada Township,Kansas Senate,33,Republican,"Holmes, Mitch",162,000070
+NESS,North Center,Kansas Senate,33,Republican,"Holmes, Mitch",340,000080
+NESS,Ohio Township,Kansas Senate,33,Republican,"Holmes, Mitch",104,000090
+NESS,South Center,Kansas Senate,33,Republican,"Holmes, Mitch",183,000100
+NESS,Waring Township,Kansas Senate,33,Republican,"Holmes, Mitch",44,000110
+NESS,Bazine Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+NESS,Bazine Township,President / Vice President,,Democratic,"Obama, Barack",21,000010
+NESS,Bazine Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+NESS,Bazine Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000010
+NESS,Bazine Township,President / Vice President,,Republican,"Romney, Mitt",164,000010
+NESS,Eden Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+NESS,Eden Township,President / Vice President,,Democratic,"Obama, Barack",3,000020
+NESS,Eden Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+NESS,Eden Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+NESS,Eden Township,President / Vice President,,Republican,"Romney, Mitt",38,000020
+NESS,Forrester Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+NESS,Forrester Township,President / Vice President,,Democratic,"Obama, Barack",4,000030
+NESS,Forrester Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+NESS,Forrester Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+NESS,Forrester Township,President / Vice President,,Republican,"Romney, Mitt",53,000030
+NESS,Franklin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+NESS,Franklin Township,President / Vice President,,Democratic,"Obama, Barack",3,000040
+NESS,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+NESS,Franklin Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+NESS,Franklin Township,President / Vice President,,Republican,"Romney, Mitt",55,000040
+NESS,Highpoint Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+NESS,Highpoint Township,President / Vice President,,Democratic,"Obama, Barack",1,000050
+NESS,Highpoint Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+NESS,Highpoint Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+NESS,Highpoint Township,President / Vice President,,Republican,"Romney, Mitt",39,000050
+NESS,Johnson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+NESS,Johnson Township,President / Vice President,,Democratic,"Obama, Barack",2,000060
+NESS,Johnson Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+NESS,Johnson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+NESS,Johnson Township,President / Vice President,,Republican,"Romney, Mitt",36,000060
+NESS,Nevada Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+NESS,Nevada Township,President / Vice President,,Democratic,"Obama, Barack",44,000070
+NESS,Nevada Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000070
+NESS,Nevada Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000070
+NESS,Nevada Township,President / Vice President,,Republican,"Romney, Mitt",160,000070
+NESS,North Center,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+NESS,North Center,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+NESS,North Center,President / Vice President,,write - in,"Barnett, Andre",0,000080
+NESS,North Center,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+NESS,North Center,President / Vice President,,write - in,"Bush, Kent W",0,000080
+NESS,North Center,President / Vice President,,write - in,"Christensen, Will",0,000080
+NESS,North Center,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+NESS,North Center,President / Vice President,,write - in,"Goode, Virgil",0,000080
+NESS,North Center,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+NESS,North Center,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+NESS,North Center,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+NESS,North Center,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+NESS,North Center,President / Vice President,,write - in,"Stein, Jill E",0,000080
+NESS,North Center,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+NESS,North Center,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+NESS,North Center,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+NESS,North Center,President / Vice President,,Democratic,"Obama, Barack",71,000080
+NESS,North Center,President / Vice President,,Libertarian,"Johnson, Gary",4,000080
+NESS,North Center,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+NESS,North Center,President / Vice President,,Republican,"Romney, Mitt",339,000080
+NESS,Ohio Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+NESS,Ohio Township,President / Vice President,,Democratic,"Obama, Barack",15,000090
+NESS,Ohio Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+NESS,Ohio Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+NESS,Ohio Township,President / Vice President,,Republican,"Romney, Mitt",108,000090
+NESS,South Center,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+NESS,South Center,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+NESS,South Center,President / Vice President,,write - in,"Barnett, Andre",0,000100
+NESS,South Center,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+NESS,South Center,President / Vice President,,write - in,"Bush, Kent W",0,000100
+NESS,South Center,President / Vice President,,write - in,"Christensen, Will",0,000100
+NESS,South Center,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+NESS,South Center,President / Vice President,,write - in,"Goode, Virgil",0,000100
+NESS,South Center,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+NESS,South Center,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+NESS,South Center,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+NESS,South Center,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+NESS,South Center,President / Vice President,,write - in,"Stein, Jill E",0,000100
+NESS,South Center,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+NESS,South Center,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+NESS,South Center,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+NESS,South Center,President / Vice President,,Democratic,"Obama, Barack",50,000100
+NESS,South Center,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+NESS,South Center,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+NESS,South Center,President / Vice President,,Republican,"Romney, Mitt",172,000100
+NESS,Waring Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+NESS,Waring Township,President / Vice President,,Democratic,"Obama, Barack",4,000110
+NESS,Waring Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+NESS,Waring Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+NESS,Waring Township,President / Vice President,,Republican,"Romney, Mitt",45,000110
+NESS,Bazine Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",169,000010
+NESS,Eden Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000020
+NESS,Forrester Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,000030
+NESS,Franklin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",50,000040
+NESS,Highpoint Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000050
+NESS,Johnson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000060
+NESS,Nevada Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",173,000070
+NESS,North Center,United States House of Representatives,1,Republican,"Huelskamp, Tim",353,000080
+NESS,Ohio Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",106,000090
+NESS,South Center,United States House of Representatives,1,Republican,"Huelskamp, Tim",192,000100
+NESS,Waring Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000110

--- a/2012/20121106__ks__general__norton__precinct.csv
+++ b/2012/20121106__ks__general__norton__precinct.csv
@@ -1,0 +1,351 @@
+county,precinct,office,district,party,candidate,votes,vtd
+NORTON,Almena Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",34,000010
+NORTON,Almena Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",188,000010
+NORTON,Center Precinct 1,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",33,000020
+NORTON,Center Precinct 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",231,000020
+NORTON,Center Precinct 2,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",5,000030
+NORTON,Center Precinct 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",59,000030
+NORTON,Harrison Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",0,000040
+NORTON,Harrison Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",0,000040
+NORTON,Highland Precinct 1,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",48,000050
+NORTON,Highland Precinct 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",142,000050
+NORTON,Highland Precinct 2,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",7,000060
+NORTON,Highland Precinct 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",37,000060
+NORTON,Highland Precinct 3,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",1,000070
+NORTON,Highland Precinct 3,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",35,000070
+NORTON,Norton Ward 1,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",68,000080
+NORTON,Norton Ward 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",234,000080
+NORTON,Norton Ward 2,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",65,000090
+NORTON,Norton Ward 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",313,000090
+NORTON,Norton Ward 3,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",85,000100
+NORTON,Norton Ward 3,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",278,000100
+NORTON,Solomon Precinct 1,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",5,000110
+NORTON,Solomon Precinct 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",42,000110
+NORTON,Solomon Precinct 2,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",0,000120
+NORTON,Solomon Precinct 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",11,000120
+NORTON,ADVANCE BALLOTS,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",85,99999
+NORTON,ADVANCE BALLOTS,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",227,99999
+NORTON,ADVANCED,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",5,999998
+NORTON,ADVANCED,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",24,999998
+NORTON,Almena Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",38,000010
+NORTON,Almena Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",187,000010
+NORTON,Center Precinct 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",42,000020
+NORTON,Center Precinct 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",224,000020
+NORTON,Center Precinct 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",9,000030
+NORTON,Center Precinct 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",57,000030
+NORTON,Harrison Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,000040
+NORTON,Harrison Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,000040
+NORTON,Highland Precinct 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",53,000050
+NORTON,Highland Precinct 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",142,000050
+NORTON,Highland Precinct 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",11,000060
+NORTON,Highland Precinct 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",34,000060
+NORTON,Highland Precinct 3,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",7,000070
+NORTON,Highland Precinct 3,Kansas Senate,40,Republican,"Ostmeyer, Ralph",28,000070
+NORTON,Norton Ward 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",72,000080
+NORTON,Norton Ward 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",233,000080
+NORTON,Norton Ward 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",64,000090
+NORTON,Norton Ward 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",316,000090
+NORTON,Norton Ward 3,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",90,000100
+NORTON,Norton Ward 3,Kansas Senate,40,Republican,"Ostmeyer, Ralph",268,000100
+NORTON,Solomon Precinct 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",2,000110
+NORTON,Solomon Precinct 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",42,000110
+NORTON,Solomon Precinct 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",1,000120
+NORTON,Solomon Precinct 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",10,000120
+NORTON,ADVANCE BALLOTS,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",79,99999
+NORTON,ADVANCE BALLOTS,Kansas Senate,40,Republican,"Ostmeyer, Ralph",237,99999
+NORTON,ADVANCED,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",3,999998
+NORTON,ADVANCED,Kansas Senate,40,Republican,"Ostmeyer, Ralph",25,999998
+NORTON,Almena Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+NORTON,Almena Township,President / Vice President,,Democratic,"Obama, Barack",37,000010
+NORTON,Almena Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+NORTON,Almena Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+NORTON,Almena Township,President / Vice President,,Republican,"Romney, Mitt",187,000010
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+NORTON,Center Precinct 1,President / Vice President,,Democratic,"Obama, Barack",36,000020
+NORTON,Center Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",6,000020
+NORTON,Center Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000020
+NORTON,Center Precinct 1,President / Vice President,,Republican,"Romney, Mitt",226,000020
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+NORTON,Center Precinct 2,President / Vice President,,Democratic,"Obama, Barack",9,000030
+NORTON,Center Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+NORTON,Center Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+NORTON,Center Precinct 2,President / Vice President,,Republican,"Romney, Mitt",57,000030
+NORTON,Harrison Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+NORTON,Harrison Township,President / Vice President,,Democratic,"Obama, Barack",0,000040
+NORTON,Harrison Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+NORTON,Harrison Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+NORTON,Harrison Township,President / Vice President,,Republican,"Romney, Mitt",0,000040
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,Democratic,"Obama, Barack",45,000050
+NORTON,Highland Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000050
+NORTON,Highland Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000050
+NORTON,Highland Precinct 1,President / Vice President,,Republican,"Romney, Mitt",148,000050
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,Democratic,"Obama, Barack",3,000060
+NORTON,Highland Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+NORTON,Highland Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+NORTON,Highland Precinct 2,President / Vice President,,Republican,"Romney, Mitt",41,000060
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,Democratic,"Obama, Barack",1,000070
+NORTON,Highland Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+NORTON,Highland Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+NORTON,Highland Precinct 3,President / Vice President,,Republican,"Romney, Mitt",33,000070
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+NORTON,Norton Ward 1,President / Vice President,,Democratic,"Obama, Barack",56,000080
+NORTON,Norton Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",4,000080
+NORTON,Norton Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000080
+NORTON,Norton Ward 1,President / Vice President,,Republican,"Romney, Mitt",249,000080
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+NORTON,Norton Ward 2,President / Vice President,,Democratic,"Obama, Barack",58,000090
+NORTON,Norton Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000090
+NORTON,Norton Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+NORTON,Norton Ward 2,President / Vice President,,Republican,"Romney, Mitt",322,000090
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+NORTON,Norton Ward 3,President / Vice President,,Democratic,"Obama, Barack",66,000100
+NORTON,Norton Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",8,000100
+NORTON,Norton Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",3,000100
+NORTON,Norton Ward 3,President / Vice President,,Republican,"Romney, Mitt",298,000100
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,Democratic,"Obama, Barack",6,000110
+NORTON,Solomon Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,Republican,"Romney, Mitt",42,000110
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,Democratic,"Obama, Barack",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,Republican,"Romney, Mitt",11,000120
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Ayers, Avery L",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Barnett, Andre",1,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Barr, Roseanne C",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Bush, Kent W",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Christensen, Will",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Duncan, Richard A",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Goode, Virgil",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Hoefling, Tom",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Knill, Dennis J",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Reed, Jill A.",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Rogers, Rick L",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Stein, Jill E",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Thorne, Kevin M",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,write - in,"Warner, Gerald L.",0,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,Democratic,"Obama, Barack",76,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,Libertarian,"Johnson, Gary",2,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,Reform,"Baldwin, Chuck",3,99999
+NORTON,ADVANCE BALLOTS,President / Vice President,,Republican,"Romney, Mitt",241,99999
+NORTON,ADVANCED,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Ayers, Avery L",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Barnett, Andre",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Barr, Roseanne C",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Bush, Kent W",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Christensen, Will",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Duncan, Richard A",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Goode, Virgil",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Hoefling, Tom",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Knill, Dennis J",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Reed, Jill A.",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Rogers, Rick L",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Stein, Jill E",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Thorne, Kevin M",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,999998
+NORTON,ADVANCED,President / Vice President,,write - in,"Warner, Gerald L.",0,999998
+NORTON,ADVANCED,President / Vice President,,Democratic,"Obama, Barack",5,999998
+NORTON,ADVANCED,President / Vice President,,Libertarian,"Johnson, Gary",0,999998
+NORTON,ADVANCED,President / Vice President,,Reform,"Baldwin, Chuck",0,999998
+NORTON,ADVANCED,President / Vice President,,Republican,"Romney, Mitt",23,999998
+NORTON,Almena Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",203,000010
+NORTON,Center Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",241,000020
+NORTON,Center Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",60,000030
+NORTON,Harrison Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000040
+NORTON,Highland Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",156,000050
+NORTON,Highland Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",41,000060
+NORTON,Highland Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000070
+NORTON,Norton Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",276,000080
+NORTON,Norton Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",341,000090
+NORTON,Norton Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",303,000100
+NORTON,Solomon Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",41,000110
+NORTON,Solomon Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",9,000120
+NORTON,ADVANCE BALLOTS,United States House of Representatives,1,Republican,"Huelskamp, Tim",269,99999
+NORTON,ADVANCED,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,999998

--- a/2012/20121106__ks__general__osage__precinct.csv
+++ b/2012/20121106__ks__general__osage__precinct.csv
@@ -1,0 +1,757 @@
+county,precinct,office,district,party,candidate,votes,vtd
+OSAGE,Grant Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",44,000007
+OSAGE,Grant Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",87,000007
+OSAGE,Agency Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",66,000010
+OSAGE,Agency Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",102,000010
+OSAGE,Arvonia Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",24,000020
+OSAGE,Arvonia Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",25,000020
+OSAGE,Barclay Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",28,000030
+OSAGE,Barclay Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",50,000030
+OSAGE,Dragoon Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",37,000040
+OSAGE,Dragoon Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",68,000040
+OSAGE,Elk Township,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",370,000050
+OSAGE,Elk Township,Kansas House of Representatives,54,Republican,"Corbet, Ken",521,000050
+OSAGE,Fairfax Township,Kansas House of Representatives,59,Democratic,"Correll, Caleb",101,000060
+OSAGE,Fairfax Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",188,000060
+OSAGE,Lincoln Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",27,000080
+OSAGE,Lincoln Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",33,000080
+OSAGE,Melvern Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",139,000090
+OSAGE,Melvern Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",165,000090
+OSAGE,Michigan Valley Township,Kansas House of Representatives,59,Democratic,"Correll, Caleb",64,000100
+OSAGE,Michigan Valley Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",141,000100
+OSAGE,North Burlingame,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",190,000110
+OSAGE,North Burlingame,Kansas House of Representatives,54,Republican,"Corbet, Ken",215,000110
+OSAGE,North Ridgeway,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",233,000120
+OSAGE,North Ridgeway,Kansas House of Representatives,54,Republican,"Corbet, Ken",265,000120
+OSAGE,North Valleybrook,Kansas House of Representatives,59,Democratic,"Correll, Caleb",136,000130
+OSAGE,North Valleybrook,Kansas House of Representatives,59,Republican,"Finch, Blaine",295,000130
+OSAGE,Olivet Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",41,000140
+OSAGE,Olivet Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",62,000140
+OSAGE,Osage City Ward 1,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",146,000150
+OSAGE,Osage City Ward 1,Kansas House of Representatives,76,Republican,"Mast, Peggy",204,000150
+OSAGE,Osage City Ward 2,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",74,000160
+OSAGE,Osage City Ward 2,Kansas House of Representatives,76,Republican,"Mast, Peggy",94,000160
+OSAGE,Osage City Ward 3,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",115,000170
+OSAGE,Osage City Ward 3,Kansas House of Representatives,76,Republican,"Mast, Peggy",141,000170
+OSAGE,Osage City Ward 4,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",108,000180
+OSAGE,Osage City Ward 4,Kansas House of Representatives,76,Republican,"Mast, Peggy",191,000180
+OSAGE,Scranton Township,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",197,000190
+OSAGE,Scranton Township,Kansas House of Representatives,54,Republican,"Corbet, Ken",275,000190
+OSAGE,South Burlingame,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",142,000200
+OSAGE,South Burlingame,Kansas House of Representatives,54,Republican,"Corbet, Ken",215,000200
+OSAGE,South Ridgeway,Kansas House of Representatives,54,Democratic,"Mah, Ann E.",232,000210
+OSAGE,South Ridgeway,Kansas House of Representatives,54,Republican,"Corbet, Ken",233,000210
+OSAGE,South Valleybrook,Kansas House of Representatives,59,Democratic,"Correll, Caleb",69,000220
+OSAGE,South Valleybrook,Kansas House of Representatives,59,Republican,"Finch, Blaine",121,000220
+OSAGE,Superior Township,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",46,000230
+OSAGE,Superior Township,Kansas House of Representatives,76,Republican,"Mast, Peggy",79,000230
+OSAGE,Vassar Township,Kansas House of Representatives,59,Democratic,"Correll, Caleb",125,000240
+OSAGE,Vassar Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",202,000240
+OSAGE,Superior Township Enclave 1,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",0,900010
+OSAGE,Superior Township Enclave 1,Kansas House of Representatives,76,Republican,"Mast, Peggy",0,900010
+OSAGE,Grant Township Enclave 1,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",0,900020
+OSAGE,Grant Township Enclave 1,Kansas House of Representatives,76,Republican,"Mast, Peggy",0,900020
+OSAGE,Grant Township Enclave 2,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",0,900030
+OSAGE,Grant Township Enclave 2,Kansas House of Representatives,76,Republican,"Mast, Peggy",0,900030
+OSAGE,Osage City Ward 2 Exclave,Kansas House of Representatives,76,Democratic,"Lewis, Janet L.",0,900040
+OSAGE,Osage City Ward 2 Exclave,Kansas House of Representatives,76,Republican,"Mast, Peggy",0,900040
+OSAGE,Grant Township,Kansas Senate,19,Democratic,"Hensley, Anthony",51,000007
+OSAGE,Grant Township,Kansas Senate,19,Republican,"Moore, Casey W.",77,000007
+OSAGE,Agency Township,Kansas Senate,19,Democratic,"Hensley, Anthony",67,000010
+OSAGE,Agency Township,Kansas Senate,19,Republican,"Moore, Casey W.",102,000010
+OSAGE,Arvonia Township,Kansas Senate,19,Democratic,"Hensley, Anthony",22,000020
+OSAGE,Arvonia Township,Kansas Senate,19,Republican,"Moore, Casey W.",26,000020
+OSAGE,Barclay Township,Kansas Senate,19,Democratic,"Hensley, Anthony",30,000030
+OSAGE,Barclay Township,Kansas Senate,19,Republican,"Moore, Casey W.",46,000030
+OSAGE,Dragoon Township,Kansas Senate,19,Democratic,"Hensley, Anthony",48,000040
+OSAGE,Dragoon Township,Kansas Senate,19,Republican,"Moore, Casey W.",60,000040
+OSAGE,Elk Township,Kansas Senate,19,Democratic,"Hensley, Anthony",346,000050
+OSAGE,Elk Township,Kansas Senate,19,Republican,"Moore, Casey W.",551,000050
+OSAGE,Fairfax Township,Kansas Senate,19,Democratic,"Hensley, Anthony",132,000060
+OSAGE,Fairfax Township,Kansas Senate,19,Republican,"Moore, Casey W.",171,000060
+OSAGE,Lincoln Township,Kansas Senate,19,Democratic,"Hensley, Anthony",23,000080
+OSAGE,Lincoln Township,Kansas Senate,19,Republican,"Moore, Casey W.",37,000080
+OSAGE,Melvern Township,Kansas Senate,19,Democratic,"Hensley, Anthony",121,000090
+OSAGE,Melvern Township,Kansas Senate,19,Republican,"Moore, Casey W.",181,000090
+OSAGE,Michigan Valley Township,Kansas Senate,19,Democratic,"Hensley, Anthony",105,000100
+OSAGE,Michigan Valley Township,Kansas Senate,19,Republican,"Moore, Casey W.",112,000100
+OSAGE,North Burlingame,Kansas Senate,19,Democratic,"Hensley, Anthony",197,000110
+OSAGE,North Burlingame,Kansas Senate,19,Republican,"Moore, Casey W.",207,000110
+OSAGE,North Ridgeway,Kansas Senate,19,Democratic,"Hensley, Anthony",240,000120
+OSAGE,North Ridgeway,Kansas Senate,19,Republican,"Moore, Casey W.",263,000120
+OSAGE,North Valleybrook,Kansas Senate,19,Democratic,"Hensley, Anthony",198,000130
+OSAGE,North Valleybrook,Kansas Senate,19,Republican,"Moore, Casey W.",254,000130
+OSAGE,Olivet Township,Kansas Senate,19,Democratic,"Hensley, Anthony",46,000140
+OSAGE,Olivet Township,Kansas Senate,19,Republican,"Moore, Casey W.",59,000140
+OSAGE,Osage City Ward 1,Kansas Senate,19,Democratic,"Hensley, Anthony",171,000150
+OSAGE,Osage City Ward 1,Kansas Senate,19,Republican,"Moore, Casey W.",181,000150
+OSAGE,Osage City Ward 2,Kansas Senate,19,Democratic,"Hensley, Anthony",88,000160
+OSAGE,Osage City Ward 2,Kansas Senate,19,Republican,"Moore, Casey W.",82,000160
+OSAGE,Osage City Ward 3,Kansas Senate,19,Democratic,"Hensley, Anthony",149,000170
+OSAGE,Osage City Ward 3,Kansas Senate,19,Republican,"Moore, Casey W.",113,000170
+OSAGE,Osage City Ward 4,Kansas Senate,19,Democratic,"Hensley, Anthony",153,000180
+OSAGE,Osage City Ward 4,Kansas Senate,19,Republican,"Moore, Casey W.",154,000180
+OSAGE,Scranton Township,Kansas Senate,19,Democratic,"Hensley, Anthony",209,000190
+OSAGE,Scranton Township,Kansas Senate,19,Republican,"Moore, Casey W.",276,000190
+OSAGE,South Burlingame,Kansas Senate,19,Democratic,"Hensley, Anthony",152,000200
+OSAGE,South Burlingame,Kansas Senate,19,Republican,"Moore, Casey W.",206,000200
+OSAGE,South Ridgeway,Kansas Senate,19,Democratic,"Hensley, Anthony",241,000210
+OSAGE,South Ridgeway,Kansas Senate,19,Republican,"Moore, Casey W.",230,000210
+OSAGE,South Valleybrook,Kansas Senate,19,Democratic,"Hensley, Anthony",88,000220
+OSAGE,South Valleybrook,Kansas Senate,19,Republican,"Moore, Casey W.",108,000220
+OSAGE,Superior Township,Kansas Senate,19,Democratic,"Hensley, Anthony",62,000230
+OSAGE,Superior Township,Kansas Senate,19,Republican,"Moore, Casey W.",70,000230
+OSAGE,Vassar Township,Kansas Senate,19,Democratic,"Hensley, Anthony",148,000240
+OSAGE,Vassar Township,Kansas Senate,19,Republican,"Moore, Casey W.",191,000240
+OSAGE,Superior Township Enclave 1,Kansas Senate,19,Democratic,"Hensley, Anthony",0,900010
+OSAGE,Superior Township Enclave 1,Kansas Senate,19,Republican,"Moore, Casey W.",0,900010
+OSAGE,Grant Township Enclave 1,Kansas Senate,19,Democratic,"Hensley, Anthony",0,900020
+OSAGE,Grant Township Enclave 1,Kansas Senate,19,Republican,"Moore, Casey W.",0,900020
+OSAGE,Grant Township Enclave 2,Kansas Senate,19,Democratic,"Hensley, Anthony",0,900030
+OSAGE,Grant Township Enclave 2,Kansas Senate,19,Republican,"Moore, Casey W.",0,900030
+OSAGE,Osage City Ward 2 Exclave,Kansas Senate,19,Democratic,"Hensley, Anthony",0,900040
+OSAGE,Osage City Ward 2 Exclave,Kansas Senate,19,Republican,"Moore, Casey W.",0,900040
+OSAGE,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000007
+OSAGE,Grant Township,President / Vice President,,Democratic,"Obama, Barack",35,000007
+OSAGE,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000007
+OSAGE,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000007
+OSAGE,Grant Township,President / Vice President,,Republican,"Romney, Mitt",96,000007
+OSAGE,Agency Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+OSAGE,Agency Township,President / Vice President,,Democratic,"Obama, Barack",45,000010
+OSAGE,Agency Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000010
+OSAGE,Agency Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000010
+OSAGE,Agency Township,President / Vice President,,Republican,"Romney, Mitt",115,000010
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+OSAGE,Arvonia Township,President / Vice President,,Democratic,"Obama, Barack",17,000020
+OSAGE,Arvonia Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+OSAGE,Arvonia Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+OSAGE,Arvonia Township,President / Vice President,,Republican,"Romney, Mitt",30,000020
+OSAGE,Barclay Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+OSAGE,Barclay Township,President / Vice President,,Democratic,"Obama, Barack",20,000030
+OSAGE,Barclay Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+OSAGE,Barclay Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+OSAGE,Barclay Township,President / Vice President,,Republican,"Romney, Mitt",56,000030
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+OSAGE,Dragoon Township,President / Vice President,,Democratic,"Obama, Barack",28,000040
+OSAGE,Dragoon Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000040
+OSAGE,Dragoon Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+OSAGE,Dragoon Township,President / Vice President,,Republican,"Romney, Mitt",74,000040
+OSAGE,Elk Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+OSAGE,Elk Township,President / Vice President,,Democratic,"Obama, Barack",230,000050
+OSAGE,Elk Township,President / Vice President,,Libertarian,"Johnson, Gary",26,000050
+OSAGE,Elk Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000050
+OSAGE,Elk Township,President / Vice President,,Republican,"Romney, Mitt",648,000050
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+OSAGE,Fairfax Township,President / Vice President,,Democratic,"Obama, Barack",101,000060
+OSAGE,Fairfax Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000060
+OSAGE,Fairfax Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000060
+OSAGE,Fairfax Township,President / Vice President,,Republican,"Romney, Mitt",195,000060
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+OSAGE,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",21,000080
+OSAGE,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+OSAGE,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+OSAGE,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",41,000080
+OSAGE,Melvern Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+OSAGE,Melvern Township,President / Vice President,,Democratic,"Obama, Barack",80,000090
+OSAGE,Melvern Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000090
+OSAGE,Melvern Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000090
+OSAGE,Melvern Township,President / Vice President,,Republican,"Romney, Mitt",214,000090
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,Democratic,"Obama, Barack",82,000100
+OSAGE,Michigan Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000100
+OSAGE,Michigan Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000100
+OSAGE,Michigan Valley Township,President / Vice President,,Republican,"Romney, Mitt",133,000100
+OSAGE,North Burlingame,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Barnett, Andre",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Bush, Kent W",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Christensen, Will",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Goode, Virgil",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Stein, Jill E",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+OSAGE,North Burlingame,President / Vice President,,Democratic,"Obama, Barack",144,000110
+OSAGE,North Burlingame,President / Vice President,,Libertarian,"Johnson, Gary",7,000110
+OSAGE,North Burlingame,President / Vice President,,Reform,"Baldwin, Chuck",5,000110
+OSAGE,North Burlingame,President / Vice President,,Republican,"Romney, Mitt",251,000110
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Barnett, Andre",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Bush, Kent W",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Christensen, Will",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Goode, Virgil",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Stein, Jill E",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+OSAGE,North Ridgeway,President / Vice President,,Democratic,"Obama, Barack",178,000120
+OSAGE,North Ridgeway,President / Vice President,,Libertarian,"Johnson, Gary",12,000120
+OSAGE,North Ridgeway,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+OSAGE,North Ridgeway,President / Vice President,,Republican,"Romney, Mitt",316,000120
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Barnett, Andre",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Bush, Kent W",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Christensen, Will",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Goode, Virgil",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Stein, Jill E",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+OSAGE,North Valleybrook,President / Vice President,,Democratic,"Obama, Barack",150,000130
+OSAGE,North Valleybrook,President / Vice President,,Libertarian,"Johnson, Gary",4,000130
+OSAGE,North Valleybrook,President / Vice President,,Reform,"Baldwin, Chuck",2,000130
+OSAGE,North Valleybrook,President / Vice President,,Republican,"Romney, Mitt",301,000130
+OSAGE,Olivet Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+OSAGE,Olivet Township,President / Vice President,,Democratic,"Obama, Barack",29,000140
+OSAGE,Olivet Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000140
+OSAGE,Olivet Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+OSAGE,Olivet Township,President / Vice President,,Republican,"Romney, Mitt",71,000140
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,Democratic,"Obama, Barack",136,000150
+OSAGE,Osage City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000150
+OSAGE,Osage City Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",4,000150
+OSAGE,Osage City Ward 1,President / Vice President,,Republican,"Romney, Mitt",210,000150
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,Democratic,"Obama, Barack",82,000160
+OSAGE,Osage City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",2,000160
+OSAGE,Osage City Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,Republican,"Romney, Mitt",86,000160
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,Democratic,"Obama, Barack",98,000170
+OSAGE,Osage City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",5,000170
+OSAGE,Osage City Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,Republican,"Romney, Mitt",156,000170
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,Democratic,"Obama, Barack",99,000180
+OSAGE,Osage City Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",7,000180
+OSAGE,Osage City Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",2,000180
+OSAGE,Osage City Ward 4,President / Vice President,,Republican,"Romney, Mitt",204,000180
+OSAGE,Scranton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+OSAGE,Scranton Township,President / Vice President,,Democratic,"Obama, Barack",177,000190
+OSAGE,Scranton Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000190
+OSAGE,Scranton Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000190
+OSAGE,Scranton Township,President / Vice President,,Republican,"Romney, Mitt",291,000190
+OSAGE,South Burlingame,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Barnett, Andre",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Bush, Kent W",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Christensen, Will",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Goode, Virgil",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Stein, Jill E",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+OSAGE,South Burlingame,President / Vice President,,Democratic,"Obama, Barack",105,000200
+OSAGE,South Burlingame,President / Vice President,,Libertarian,"Johnson, Gary",8,000200
+OSAGE,South Burlingame,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+OSAGE,South Burlingame,President / Vice President,,Republican,"Romney, Mitt",246,000200
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Barnett, Andre",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Bush, Kent W",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Christensen, Will",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Goode, Virgil",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Stein, Jill E",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+OSAGE,South Ridgeway,President / Vice President,,Democratic,"Obama, Barack",173,000210
+OSAGE,South Ridgeway,President / Vice President,,Libertarian,"Johnson, Gary",12,000210
+OSAGE,South Ridgeway,President / Vice President,,Reform,"Baldwin, Chuck",6,000210
+OSAGE,South Ridgeway,President / Vice President,,Republican,"Romney, Mitt",282,000210
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Barnett, Andre",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Bush, Kent W",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Christensen, Will",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Goode, Virgil",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Stein, Jill E",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+OSAGE,South Valleybrook,President / Vice President,,Democratic,"Obama, Barack",76,000220
+OSAGE,South Valleybrook,President / Vice President,,Libertarian,"Johnson, Gary",7,000220
+OSAGE,South Valleybrook,President / Vice President,,Reform,"Baldwin, Chuck",2,000220
+OSAGE,South Valleybrook,President / Vice President,,Republican,"Romney, Mitt",113,000220
+OSAGE,Superior Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+OSAGE,Superior Township,President / Vice President,,Democratic,"Obama, Barack",36,000230
+OSAGE,Superior Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000230
+OSAGE,Superior Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000230
+OSAGE,Superior Township,President / Vice President,,Republican,"Romney, Mitt",87,000230
+OSAGE,Vassar Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+OSAGE,Vassar Township,President / Vice President,,Democratic,"Obama, Barack",126,000240
+OSAGE,Vassar Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000240
+OSAGE,Vassar Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000240
+OSAGE,Vassar Township,President / Vice President,,Republican,"Romney, Mitt",211,000240
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Christensen, Will",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900010
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Christensen, Will",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900020
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Christensen, Will",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900030
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900040
+OSAGE,Grant Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",44,000007
+OSAGE,Grant Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000007
+OSAGE,Grant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",85,000007
+OSAGE,Agency Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",47,000010
+OSAGE,Agency Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000010
+OSAGE,Agency Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",115,000010
+OSAGE,Arvonia Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",19,000020
+OSAGE,Arvonia Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000020
+OSAGE,Arvonia Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",27,000020
+OSAGE,Barclay Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",20,000030
+OSAGE,Barclay Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000030
+OSAGE,Barclay Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",55,000030
+OSAGE,Dragoon Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",35,000040
+OSAGE,Dragoon Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000040
+OSAGE,Dragoon Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",62,000040
+OSAGE,Elk Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",262,000050
+OSAGE,Elk Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",46,000050
+OSAGE,Elk Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",595,000050
+OSAGE,Fairfax Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",96,000060
+OSAGE,Fairfax Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",14,000060
+OSAGE,Fairfax Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",199,000060
+OSAGE,Lincoln Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",24,000080
+OSAGE,Lincoln Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000080
+OSAGE,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",33,000080
+OSAGE,Melvern Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",103,000090
+OSAGE,Melvern Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,000090
+OSAGE,Melvern Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",181,000090
+OSAGE,Michigan Valley Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",91,000100
+OSAGE,Michigan Valley Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000100
+OSAGE,Michigan Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",120,000100
+OSAGE,North Burlingame,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",165,000110
+OSAGE,North Burlingame,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000110
+OSAGE,North Burlingame,United States House of Representatives,2,Republican,"Jenkins, Lynn",223,000110
+OSAGE,North Ridgeway,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",187,000120
+OSAGE,North Ridgeway,United States House of Representatives,2,Libertarian,"Hawver, Dennis",41,000120
+OSAGE,North Ridgeway,United States House of Representatives,2,Republican,"Jenkins, Lynn",278,000120
+OSAGE,North Valleybrook,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",171,000130
+OSAGE,North Valleybrook,United States House of Representatives,2,Libertarian,"Hawver, Dennis",22,000130
+OSAGE,North Valleybrook,United States House of Representatives,2,Republican,"Jenkins, Lynn",264,000130
+OSAGE,Olivet Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",36,000140
+OSAGE,Olivet Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000140
+OSAGE,Olivet Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,000140
+OSAGE,Osage City Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",117,000150
+OSAGE,Osage City Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",22,000150
+OSAGE,Osage City Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",214,000150
+OSAGE,Osage City Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",68,000160
+OSAGE,Osage City Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000160
+OSAGE,Osage City Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",95,000160
+OSAGE,Osage City Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",98,000170
+OSAGE,Osage City Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000170
+OSAGE,Osage City Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",154,000170
+OSAGE,Osage City Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",98,000180
+OSAGE,Osage City Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",15,000180
+OSAGE,Osage City Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",197,000180
+OSAGE,Scranton Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",156,000190
+OSAGE,Scranton Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",33,000190
+OSAGE,Scranton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",291,000190
+OSAGE,South Burlingame,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",122,000200
+OSAGE,South Burlingame,United States House of Representatives,2,Libertarian,"Hawver, Dennis",19,000200
+OSAGE,South Burlingame,United States House of Representatives,2,Republican,"Jenkins, Lynn",215,000200
+OSAGE,South Ridgeway,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",189,000210
+OSAGE,South Ridgeway,United States House of Representatives,2,Libertarian,"Hawver, Dennis",26,000210
+OSAGE,South Ridgeway,United States House of Representatives,2,Republican,"Jenkins, Lynn",251,000210
+OSAGE,South Valleybrook,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",73,000220
+OSAGE,South Valleybrook,United States House of Representatives,2,Libertarian,"Hawver, Dennis",18,000220
+OSAGE,South Valleybrook,United States House of Representatives,2,Republican,"Jenkins, Lynn",107,000220
+OSAGE,Superior Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",35,000230
+OSAGE,Superior Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000230
+OSAGE,Superior Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",84,000230
+OSAGE,Vassar Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",131,000240
+OSAGE,Vassar Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",26,000240
+OSAGE,Vassar Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",188,000240
+OSAGE,Superior Township Enclave 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900010
+OSAGE,Superior Township Enclave 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900010
+OSAGE,Superior Township Enclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+OSAGE,Grant Township Enclave 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900020
+OSAGE,Grant Township Enclave 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900020
+OSAGE,Grant Township Enclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+OSAGE,Grant Township Enclave 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900030
+OSAGE,Grant Township Enclave 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900030
+OSAGE,Grant Township Enclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+OSAGE,Osage City Ward 2 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900040
+OSAGE,Osage City Ward 2 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900040
+OSAGE,Osage City Ward 2 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900040

--- a/2012/20121106__ks__general__osborne__precinct.csv
+++ b/2012/20121106__ks__general__osborne__precinct.csv
@@ -1,0 +1,629 @@
+county,precinct,office,district,party,candidate,votes,vtd
+OSBORNE,Bethany Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",59,000010
+OSBORNE,Bloom Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",34,000020
+OSBORNE,Corinth Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",22,000030
+OSBORNE,Covert Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",4,000040
+OSBORNE,Delhi Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",11,000050
+OSBORNE,Grant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",14,000060
+OSBORNE,Hancock Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",12,000070
+OSBORNE,Hawkeye Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",12,000080
+OSBORNE,Independence Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",11,000090
+OSBORNE,Jackson Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",19,000100
+OSBORNE,Kill Creek Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",6,000110
+OSBORNE,Lawrence Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",16,000120
+OSBORNE,Liberty Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",14,000130
+OSBORNE,Mount Ayr Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",29,000140
+OSBORNE,Natoma Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",141,000150
+OSBORNE,Osborne Ward 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",202,000160
+OSBORNE,Osborne Ward 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",246,000170
+OSBORNE,Osborne Ward 3,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",123,000180
+OSBORNE,Penn Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",49,000190
+OSBORNE,Ross 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",365,000200
+OSBORNE,Ross 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",53,000210
+OSBORNE,Round Mound Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",19,000220
+OSBORNE,Sumner Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",64,000230
+OSBORNE,Tilden Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",39,000240
+OSBORNE,Valley Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",8,000250
+OSBORNE,Victor Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",9,000260
+OSBORNE,Winfield Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",11,000270
+OSBORNE,Bethany Township,Kansas Senate,36,Democratic,"Clark, Marquis",19,000010
+OSBORNE,Bethany Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",49,000010
+OSBORNE,Bloom Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000020
+OSBORNE,Bloom Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",34,000020
+OSBORNE,Corinth Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000030
+OSBORNE,Corinth Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",21,000030
+OSBORNE,Covert Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000040
+OSBORNE,Covert Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",4,000040
+OSBORNE,Delhi Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000050
+OSBORNE,Delhi Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",12,000050
+OSBORNE,Grant Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000060
+OSBORNE,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000060
+OSBORNE,Hancock Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000070
+OSBORNE,Hancock Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",12,000070
+OSBORNE,Hawkeye Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000080
+OSBORNE,Hawkeye Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",10,000080
+OSBORNE,Independence Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000090
+OSBORNE,Independence Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",8,000090
+OSBORNE,Jackson Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000100
+OSBORNE,Jackson Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",19,000100
+OSBORNE,Kill Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000110
+OSBORNE,Kill Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",6,000110
+OSBORNE,Lawrence Township,Kansas Senate,36,Democratic,"Clark, Marquis",5,000120
+OSBORNE,Lawrence Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",14,000120
+OSBORNE,Liberty Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000130
+OSBORNE,Liberty Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000130
+OSBORNE,Mount Ayr Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000140
+OSBORNE,Mount Ayr Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",26,000140
+OSBORNE,Natoma Township,Kansas Senate,36,Democratic,"Clark, Marquis",22,000150
+OSBORNE,Natoma Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",124,000150
+OSBORNE,Osborne Ward 1,Kansas Senate,36,Democratic,"Clark, Marquis",34,000160
+OSBORNE,Osborne Ward 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",184,000160
+OSBORNE,Osborne Ward 2,Kansas Senate,36,Democratic,"Clark, Marquis",63,000170
+OSBORNE,Osborne Ward 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",218,000170
+OSBORNE,Osborne Ward 3,Kansas Senate,36,Democratic,"Clark, Marquis",28,000180
+OSBORNE,Osborne Ward 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",107,000180
+OSBORNE,Penn Township,Kansas Senate,36,Democratic,"Clark, Marquis",6,000190
+OSBORNE,Penn Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",42,000190
+OSBORNE,Ross 1,Kansas Senate,36,Democratic,"Clark, Marquis",61,000200
+OSBORNE,Ross 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",341,000200
+OSBORNE,Ross 2,Kansas Senate,36,Democratic,"Clark, Marquis",4,000210
+OSBORNE,Ross 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",52,000210
+OSBORNE,Round Mound Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000220
+OSBORNE,Round Mound Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",19,000220
+OSBORNE,Sumner Township,Kansas Senate,36,Democratic,"Clark, Marquis",13,000230
+OSBORNE,Sumner Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",54,000230
+OSBORNE,Tilden Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000240
+OSBORNE,Tilden Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",37,000240
+OSBORNE,Valley Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000250
+OSBORNE,Valley Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",6,000250
+OSBORNE,Victor Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000260
+OSBORNE,Victor Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",5,000260
+OSBORNE,Winfield Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000270
+OSBORNE,Winfield Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",10,000270
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+OSBORNE,Bethany Township,President / Vice President,,Democratic,"Obama, Barack",14,000010
+OSBORNE,Bethany Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+OSBORNE,Bethany Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+OSBORNE,Bethany Township,President / Vice President,,Republican,"Romney, Mitt",54,000010
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+OSBORNE,Bloom Township,President / Vice President,,Democratic,"Obama, Barack",5,000020
+OSBORNE,Bloom Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+OSBORNE,Bloom Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+OSBORNE,Bloom Township,President / Vice President,,Republican,"Romney, Mitt",33,000020
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+OSBORNE,Corinth Township,President / Vice President,,Democratic,"Obama, Barack",3,000030
+OSBORNE,Corinth Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+OSBORNE,Corinth Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+OSBORNE,Corinth Township,President / Vice President,,Republican,"Romney, Mitt",25,000030
+OSBORNE,Covert Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+OSBORNE,Covert Township,President / Vice President,,Democratic,"Obama, Barack",0,000040
+OSBORNE,Covert Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+OSBORNE,Covert Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+OSBORNE,Covert Township,President / Vice President,,Republican,"Romney, Mitt",4,000040
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+OSBORNE,Delhi Township,President / Vice President,,Democratic,"Obama, Barack",3,000050
+OSBORNE,Delhi Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+OSBORNE,Delhi Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000050
+OSBORNE,Delhi Township,President / Vice President,,Republican,"Romney, Mitt",11,000050
+OSBORNE,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+OSBORNE,Grant Township,President / Vice President,,Democratic,"Obama, Barack",1,000060
+OSBORNE,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+OSBORNE,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+OSBORNE,Grant Township,President / Vice President,,Republican,"Romney, Mitt",14,000060
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+OSBORNE,Hancock Township,President / Vice President,,Democratic,"Obama, Barack",0,000070
+OSBORNE,Hancock Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+OSBORNE,Hancock Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+OSBORNE,Hancock Township,President / Vice President,,Republican,"Romney, Mitt",13,000070
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,Democratic,"Obama, Barack",2,000080
+OSBORNE,Hawkeye Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,Republican,"Romney, Mitt",11,000080
+OSBORNE,Independence Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+OSBORNE,Independence Township,President / Vice President,,Democratic,"Obama, Barack",1,000090
+OSBORNE,Independence Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+OSBORNE,Independence Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+OSBORNE,Independence Township,President / Vice President,,Republican,"Romney, Mitt",13,000090
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+OSBORNE,Jackson Township,President / Vice President,,Democratic,"Obama, Barack",2,000100
+OSBORNE,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+OSBORNE,Jackson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+OSBORNE,Jackson Township,President / Vice President,,Republican,"Romney, Mitt",20,000100
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,Democratic,"Obama, Barack",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,Republican,"Romney, Mitt",6,000110
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,Democratic,"Obama, Barack",6,000120
+OSBORNE,Lawrence Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,Republican,"Romney, Mitt",16,000120
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+OSBORNE,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",4,000130
+OSBORNE,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+OSBORNE,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+OSBORNE,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",11,000130
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,Democratic,"Obama, Barack",1,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,Republican,"Romney, Mitt",31,000140
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+OSBORNE,Natoma Township,President / Vice President,,Democratic,"Obama, Barack",25,000150
+OSBORNE,Natoma Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+OSBORNE,Natoma Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+OSBORNE,Natoma Township,President / Vice President,,Republican,"Romney, Mitt",127,000150
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,Democratic,"Obama, Barack",43,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,Republican,"Romney, Mitt",182,000160
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,Democratic,"Obama, Barack",65,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",4,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,Republican,"Romney, Mitt",237,000170
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,Democratic,"Obama, Barack",33,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,Republican,"Romney, Mitt",116,000180
+OSBORNE,Penn Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+OSBORNE,Penn Township,President / Vice President,,Democratic,"Obama, Barack",8,000190
+OSBORNE,Penn Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+OSBORNE,Penn Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+OSBORNE,Penn Township,President / Vice President,,Republican,"Romney, Mitt",44,000190
+OSBORNE,Ross 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Barnett, Andre",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Bush, Kent W",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Christensen, Will",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Goode, Virgil",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Stein, Jill E",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+OSBORNE,Ross 1,President / Vice President,,Democratic,"Obama, Barack",87,000200
+OSBORNE,Ross 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000200
+OSBORNE,Ross 1,President / Vice President,,Reform,"Baldwin, Chuck",3,000200
+OSBORNE,Ross 1,President / Vice President,,Republican,"Romney, Mitt",336,000200
+OSBORNE,Ross 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Barnett, Andre",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Bush, Kent W",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Christensen, Will",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Goode, Virgil",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Stein, Jill E",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+OSBORNE,Ross 2,President / Vice President,,Democratic,"Obama, Barack",2,000210
+OSBORNE,Ross 2,President / Vice President,,Libertarian,"Johnson, Gary",1,000210
+OSBORNE,Ross 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000210
+OSBORNE,Ross 2,President / Vice President,,Republican,"Romney, Mitt",50,000210
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,Democratic,"Obama, Barack",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,Republican,"Romney, Mitt",20,000220
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+OSBORNE,Sumner Township,President / Vice President,,Democratic,"Obama, Barack",10,000230
+OSBORNE,Sumner Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000230
+OSBORNE,Sumner Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+OSBORNE,Sumner Township,President / Vice President,,Republican,"Romney, Mitt",55,000230
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+OSBORNE,Tilden Township,President / Vice President,,Democratic,"Obama, Barack",2,000240
+OSBORNE,Tilden Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+OSBORNE,Tilden Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000240
+OSBORNE,Tilden Township,President / Vice President,,Republican,"Romney, Mitt",39,000240
+OSBORNE,Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+OSBORNE,Valley Township,President / Vice President,,Democratic,"Obama, Barack",2,000250
+OSBORNE,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+OSBORNE,Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+OSBORNE,Valley Township,President / Vice President,,Republican,"Romney, Mitt",6,000250
+OSBORNE,Victor Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Barnett, Andre",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Bush, Kent W",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Christensen, Will",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Goode, Virgil",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Stein, Jill E",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+OSBORNE,Victor Township,President / Vice President,,Democratic,"Obama, Barack",5,000260
+OSBORNE,Victor Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+OSBORNE,Victor Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000260
+OSBORNE,Victor Township,President / Vice President,,Republican,"Romney, Mitt",5,000260
+OSBORNE,Bethany Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",57,000010
+OSBORNE,Bloom Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000020
+OSBORNE,Corinth Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000030
+OSBORNE,Covert Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,000040
+OSBORNE,Delhi Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000050
+OSBORNE,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000060
+OSBORNE,Hancock Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000070
+OSBORNE,Hawkeye Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000080
+OSBORNE,Independence Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000090
+OSBORNE,Jackson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000100
+OSBORNE,Kill Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",6,000110
+OSBORNE,Lawrence Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000120
+OSBORNE,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000130
+OSBORNE,Mount Ayr Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000140
+OSBORNE,Natoma Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",146,000150
+OSBORNE,Osborne Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",193,000160
+OSBORNE,Osborne Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",243,000170
+OSBORNE,Osborne Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",118,000180
+OSBORNE,Penn Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",46,000190
+OSBORNE,Ross 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",376,000200
+OSBORNE,Ross 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000210
+OSBORNE,Round Mound Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000220
+OSBORNE,Sumner Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",60,000230
+OSBORNE,Tilden Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000240
+OSBORNE,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,000250
+OSBORNE,Victor Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,000260
+OSBORNE,Winfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000270

--- a/2012/20121106__ks__general__ottawa__precinct.csv
+++ b/2012/20121106__ks__general__ottawa__precinct.csv
@@ -1,0 +1,577 @@
+county,precinct,office,district,party,candidate,votes,vtd
+OTTAWA,Bennington Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",521,000010
+OTTAWA,Blaine Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",61,000020
+OTTAWA,Buckeye Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",44,000030
+OTTAWA,Center Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",42,000040
+OTTAWA,Chapman Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",35,000050
+OTTAWA,Concord Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",97,000060
+OTTAWA,Culver Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",93,000070
+OTTAWA,Durham Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",5,000080
+OTTAWA,Fountain Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",56,000090
+OTTAWA,Garfield Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",45,000100
+OTTAWA,Grant Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",44,000110
+OTTAWA,Henry Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",10,000120
+OTTAWA,Lincoln Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",58,000130
+OTTAWA,Logan Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",38,000140
+OTTAWA,Minneapolis Precinct 1,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",298,000150
+OTTAWA,Minneapolis Precinct 2,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",190,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00016B
+OTTAWA,Minneapolis Precinct 3,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",299,000170
+OTTAWA,Morton Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",170,000180
+OTTAWA,Ottawa Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",17,000190
+OTTAWA,Richland Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",114,000200
+OTTAWA,Sheridan Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",192,000210
+OTTAWA,Sherman Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",23,000220
+OTTAWA,Stanton Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",25,000230
+OTTAWA,Bennington Township,Kansas Senate,36,Democratic,"Clark, Marquis",110,000010
+OTTAWA,Bennington Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",485,000010
+OTTAWA,Blaine Township,Kansas Senate,36,Democratic,"Clark, Marquis",9,000020
+OTTAWA,Blaine Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",60,000020
+OTTAWA,Buckeye Township,Kansas Senate,36,Democratic,"Clark, Marquis",6,000030
+OTTAWA,Buckeye Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",40,000030
+OTTAWA,Center Township,Kansas Senate,36,Democratic,"Clark, Marquis",5,000040
+OTTAWA,Center Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",47,000040
+OTTAWA,Chapman Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000050
+OTTAWA,Chapman Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",39,000050
+OTTAWA,Concord Township,Kansas Senate,36,Democratic,"Clark, Marquis",17,000060
+OTTAWA,Concord Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",104,000060
+OTTAWA,Culver Township,Kansas Senate,36,Democratic,"Clark, Marquis",17,000070
+OTTAWA,Culver Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",89,000070
+OTTAWA,Durham Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000080
+OTTAWA,Durham Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",3,000080
+OTTAWA,Fountain Township,Kansas Senate,36,Democratic,"Clark, Marquis",9,000090
+OTTAWA,Fountain Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",61,000090
+OTTAWA,Garfield Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000100
+OTTAWA,Garfield Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",48,000100
+OTTAWA,Grant Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000110
+OTTAWA,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",52,000110
+OTTAWA,Henry Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000120
+OTTAWA,Henry Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",10,000120
+OTTAWA,Lincoln Township,Kansas Senate,36,Democratic,"Clark, Marquis",18,000130
+OTTAWA,Lincoln Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",51,000130
+OTTAWA,Logan Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000140
+OTTAWA,Logan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",40,000140
+OTTAWA,Minneapolis Precinct 1,Kansas Senate,36,Democratic,"Clark, Marquis",32,000150
+OTTAWA,Minneapolis Precinct 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",315,000150
+OTTAWA,Minneapolis Precinct 2,Kansas Senate,36,Democratic,"Clark, Marquis",22,00016A
+OTTAWA,Minneapolis Precinct 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",211,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,Kansas Senate,36,Democratic,"Clark, Marquis",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00016B
+OTTAWA,Minneapolis Precinct 3,Kansas Senate,36,Democratic,"Clark, Marquis",33,000170
+OTTAWA,Minneapolis Precinct 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",326,000170
+OTTAWA,Morton Township,Kansas Senate,36,Democratic,"Clark, Marquis",21,000180
+OTTAWA,Morton Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",168,000180
+OTTAWA,Ottawa Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000190
+OTTAWA,Ottawa Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",17,000190
+OTTAWA,Richland Township,Kansas Senate,36,Democratic,"Clark, Marquis",14,000200
+OTTAWA,Richland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",110,000200
+OTTAWA,Sheridan Township,Kansas Senate,36,Democratic,"Clark, Marquis",35,000210
+OTTAWA,Sheridan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",192,000210
+OTTAWA,Sherman Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000220
+OTTAWA,Sherman Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",25,000220
+OTTAWA,Stanton Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000230
+OTTAWA,Stanton Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",27,000230
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+OTTAWA,Bennington Township,President / Vice President,,Democratic,"Obama, Barack",132,000010
+OTTAWA,Bennington Township,President / Vice President,,Libertarian,"Johnson, Gary",16,000010
+OTTAWA,Bennington Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+OTTAWA,Bennington Township,President / Vice President,,Republican,"Romney, Mitt",460,000010
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+OTTAWA,Blaine Township,President / Vice President,,Democratic,"Obama, Barack",13,000020
+OTTAWA,Blaine Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+OTTAWA,Blaine Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+OTTAWA,Blaine Township,President / Vice President,,Republican,"Romney, Mitt",56,000020
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,Democratic,"Obama, Barack",11,000030
+OTTAWA,Buckeye Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+OTTAWA,Buckeye Township,President / Vice President,,Republican,"Romney, Mitt",33,000030
+OTTAWA,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+OTTAWA,Center Township,President / Vice President,,Democratic,"Obama, Barack",10,000040
+OTTAWA,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+OTTAWA,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+OTTAWA,Center Township,President / Vice President,,Republican,"Romney, Mitt",39,000040
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+OTTAWA,Chapman Township,President / Vice President,,Democratic,"Obama, Barack",3,000050
+OTTAWA,Chapman Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+OTTAWA,Chapman Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+OTTAWA,Chapman Township,President / Vice President,,Republican,"Romney, Mitt",36,000050
+OTTAWA,Concord Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+OTTAWA,Concord Township,President / Vice President,,Democratic,"Obama, Barack",20,000060
+OTTAWA,Concord Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000060
+OTTAWA,Concord Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+OTTAWA,Concord Township,President / Vice President,,Republican,"Romney, Mitt",101,000060
+OTTAWA,Culver Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+OTTAWA,Culver Township,President / Vice President,,Democratic,"Obama, Barack",23,000070
+OTTAWA,Culver Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+OTTAWA,Culver Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+OTTAWA,Culver Township,President / Vice President,,Republican,"Romney, Mitt",83,000070
+OTTAWA,Durham Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+OTTAWA,Durham Township,President / Vice President,,Democratic,"Obama, Barack",3,000080
+OTTAWA,Durham Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+OTTAWA,Durham Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+OTTAWA,Durham Township,President / Vice President,,Republican,"Romney, Mitt",4,000080
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+OTTAWA,Fountain Township,President / Vice President,,Democratic,"Obama, Barack",12,000090
+OTTAWA,Fountain Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+OTTAWA,Fountain Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+OTTAWA,Fountain Township,President / Vice President,,Republican,"Romney, Mitt",58,000090
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+OTTAWA,Garfield Township,President / Vice President,,Democratic,"Obama, Barack",5,000100
+OTTAWA,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+OTTAWA,Garfield Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+OTTAWA,Garfield Township,President / Vice President,,Republican,"Romney, Mitt",45,000100
+OTTAWA,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+OTTAWA,Grant Township,President / Vice President,,Democratic,"Obama, Barack",9,000110
+OTTAWA,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000110
+OTTAWA,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000110
+OTTAWA,Grant Township,President / Vice President,,Republican,"Romney, Mitt",43,000110
+OTTAWA,Henry Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+OTTAWA,Henry Township,President / Vice President,,Democratic,"Obama, Barack",0,000120
+OTTAWA,Henry Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+OTTAWA,Henry Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+OTTAWA,Henry Township,President / Vice President,,Republican,"Romney, Mitt",9,000120
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",25,000130
+OTTAWA,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000130
+OTTAWA,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",45,000130
+OTTAWA,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+OTTAWA,Logan Township,President / Vice President,,Democratic,"Obama, Barack",13,000140
+OTTAWA,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+OTTAWA,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+OTTAWA,Logan Township,President / Vice President,,Republican,"Romney, Mitt",29,000140
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,Democratic,"Obama, Barack",67,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",10,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,Republican,"Romney, Mitt",270,000150
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,Democratic,"Obama, Barack",36,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",8,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,Republican,"Romney, Mitt",192,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00016B
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,Democratic,"Obama, Barack",74,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",5,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",2,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,Republican,"Romney, Mitt",287,000170
+OTTAWA,Morton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+OTTAWA,Morton Township,President / Vice President,,Democratic,"Obama, Barack",31,000180
+OTTAWA,Morton Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000180
+OTTAWA,Morton Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+OTTAWA,Morton Township,President / Vice President,,Republican,"Romney, Mitt",154,000180
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,Democratic,"Obama, Barack",5,000190
+OTTAWA,Ottawa Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,Republican,"Romney, Mitt",16,000190
+OTTAWA,Richland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+OTTAWA,Richland Township,President / Vice President,,Democratic,"Obama, Barack",18,000200
+OTTAWA,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000200
+OTTAWA,Richland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+OTTAWA,Richland Township,President / Vice President,,Republican,"Romney, Mitt",106,000200
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,Democratic,"Obama, Barack",39,000210
+OTTAWA,Sheridan Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000210
+OTTAWA,Sheridan Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000210
+OTTAWA,Sheridan Township,President / Vice President,,Republican,"Romney, Mitt",182,000210
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+OTTAWA,Sherman Township,President / Vice President,,Democratic,"Obama, Barack",3,000220
+OTTAWA,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+OTTAWA,Sherman Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+OTTAWA,Sherman Township,President / Vice President,,Republican,"Romney, Mitt",24,000220
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+OTTAWA,Stanton Township,President / Vice President,,Democratic,"Obama, Barack",6,000230
+OTTAWA,Stanton Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+OTTAWA,Stanton Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+OTTAWA,Stanton Township,President / Vice President,,Republican,"Romney, Mitt",23,000230
+OTTAWA,Bennington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",516,000010
+OTTAWA,Blaine Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",63,000020
+OTTAWA,Buckeye Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000030
+OTTAWA,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000040
+OTTAWA,Chapman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000050
+OTTAWA,Concord Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",104,000060
+OTTAWA,Culver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",96,000070
+OTTAWA,Durham Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,000080
+OTTAWA,Fountain Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",58,000090
+OTTAWA,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000100
+OTTAWA,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000110
+OTTAWA,Henry Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",11,000120
+OTTAWA,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",54,000130
+OTTAWA,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000140
+OTTAWA,Minneapolis Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",313,000150
+OTTAWA,Minneapolis Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",198,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00016B
+OTTAWA,Minneapolis Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",298,000170
+OTTAWA,Morton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",171,000180
+OTTAWA,Ottawa Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000190
+OTTAWA,Richland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",113,000200
+OTTAWA,Sheridan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",194,000210
+OTTAWA,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000220
+OTTAWA,Stanton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000230

--- a/2012/20121106__ks__general__pawnee__precinct.csv
+++ b/2012/20121106__ks__general__pawnee__precinct.csv
@@ -1,0 +1,682 @@
+county,precinct,office,district,party,candidate,votes,vtd
+PAWNEE,Ash Valley Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",20,000010
+PAWNEE,Ash Valley Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",10,000010
+PAWNEE,Conkling Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",4,000030
+PAWNEE,Conkling Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",10,000030
+PAWNEE,Garfield Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",36,000040
+PAWNEE,Garfield Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",65,000040
+PAWNEE,Keysville Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",6,000060
+PAWNEE,Keysville Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",13,000060
+PAWNEE,Larned Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",53,000070
+PAWNEE,Larned Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",75,000070
+PAWNEE,Larned Ward 1,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",130,000080
+PAWNEE,Larned Ward 1,Kansas House of Representatives,117,Republican,"Ewy, John L.",214,000080
+PAWNEE,Larned Ward 2,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",217,000090
+PAWNEE,Larned Ward 2,Kansas House of Representatives,117,Republican,"Ewy, John L.",260,000090
+PAWNEE,Larned Ward 3,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",230,000100
+PAWNEE,Larned Ward 3,Kansas House of Representatives,117,Republican,"Ewy, John L.",257,000100
+PAWNEE,Larned Ward 4,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",134,000110
+PAWNEE,Larned Ward 4,Kansas House of Representatives,117,Republican,"Ewy, John L.",112,000110
+PAWNEE,Lincoln Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",3,000120
+PAWNEE,Lincoln Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",11,000120
+PAWNEE,Logan Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",24,000130
+PAWNEE,Morton Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",16,000140
+PAWNEE,Morton Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",12,000140
+PAWNEE,Orange Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",7,000150
+PAWNEE,Orange Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",14,000150
+PAWNEE,Pawnee Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",17,000160
+PAWNEE,Pawnee Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",19,000160
+PAWNEE,Pleasant Grove Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",31,00017A
+PAWNEE,Pleasant Grove Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",48,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,Kansas House of Representatives,117,Republican,"Ewy, John L.",0,00017B
+PAWNEE,Pleasant Ridge Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",9,000180
+PAWNEE,Pleasant Ridge Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",12,000180
+PAWNEE,Pleasant Valley Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",13,000190
+PAWNEE,Pleasant Valley Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",31,000190
+PAWNEE,River Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",32,000200
+PAWNEE,Santa Fe Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",31,000210
+PAWNEE,Santa Fe Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",35,000210
+PAWNEE,Sawmill Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",6,000220
+PAWNEE,Sawmill Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",8,000220
+PAWNEE,Shiley Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",3,000230
+PAWNEE,Shiley Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",13,000230
+PAWNEE,Valley Center Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",18,000240
+PAWNEE,Walnut Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",18,000250
+PAWNEE,Walnut Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",23,000250
+PAWNEE,Browns Grove Township C1,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",48,120020
+PAWNEE,Browns Grove Township C1,Kansas House of Representatives,117,Republican,"Ewy, John L.",99,120020
+PAWNEE,Browns Grove Township C4,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",0,120030
+PAWNEE,Browns Grove Township C4,Kansas House of Representatives,117,Republican,"Ewy, John L.",2,120030
+PAWNEE,Grant Township C1,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",32,120040
+PAWNEE,Grant Township C1,Kansas House of Representatives,117,Republican,"Ewy, John L.",67,120040
+PAWNEE,Grant Township C4,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",5,120050
+PAWNEE,Grant Township C4,Kansas House of Representatives,117,Republican,"Ewy, John L.",5,120050
+PAWNEE,Ash Valley Township,Kansas Senate,33,Republican,"Holmes, Mitch",20,000010
+PAWNEE,Conkling Township,Kansas Senate,33,Republican,"Holmes, Mitch",13,000030
+PAWNEE,Garfield Township,Kansas Senate,33,Republican,"Holmes, Mitch",93,000040
+PAWNEE,Keysville Township,Kansas Senate,33,Republican,"Holmes, Mitch",14,000060
+PAWNEE,Larned Township,Kansas Senate,33,Republican,"Holmes, Mitch",104,000070
+PAWNEE,Larned Ward 1,Kansas Senate,33,Republican,"Holmes, Mitch",286,000080
+PAWNEE,Larned Ward 2,Kansas Senate,33,Republican,"Holmes, Mitch",387,000090
+PAWNEE,Larned Ward 3,Kansas Senate,33,Republican,"Holmes, Mitch",356,000100
+PAWNEE,Larned Ward 4,Kansas Senate,33,Republican,"Holmes, Mitch",190,000110
+PAWNEE,Lincoln Township,Kansas Senate,33,Republican,"Holmes, Mitch",14,000120
+PAWNEE,Logan Township,Kansas Senate,33,Republican,"Holmes, Mitch",25,000130
+PAWNEE,Morton Township,Kansas Senate,33,Republican,"Holmes, Mitch",21,000140
+PAWNEE,Orange Township,Kansas Senate,33,Republican,"Holmes, Mitch",18,000150
+PAWNEE,Pawnee Township,Kansas Senate,33,Republican,"Holmes, Mitch",22,000160
+PAWNEE,Pleasant Grove Township,Kansas Senate,33,Republican,"Holmes, Mitch",61,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,Kansas Senate,33,Republican,"Holmes, Mitch",0,00017B
+PAWNEE,Pleasant Ridge Township,Kansas Senate,33,Republican,"Holmes, Mitch",17,000180
+PAWNEE,Pleasant Valley Township,Kansas Senate,33,Republican,"Holmes, Mitch",36,000190
+PAWNEE,River Township,Kansas Senate,33,Republican,"Holmes, Mitch",31,000200
+PAWNEE,Santa Fe Township,Kansas Senate,33,Republican,"Holmes, Mitch",52,000210
+PAWNEE,Sawmill Township,Kansas Senate,33,Republican,"Holmes, Mitch",11,000220
+PAWNEE,Shiley Township,Kansas Senate,33,Republican,"Holmes, Mitch",15,000230
+PAWNEE,Valley Center Township,Kansas Senate,33,Republican,"Holmes, Mitch",18,000240
+PAWNEE,Walnut Township,Kansas Senate,33,Republican,"Holmes, Mitch",32,000250
+PAWNEE,Browns Grove Township C1,Kansas Senate,33,Republican,"Holmes, Mitch",124,120020
+PAWNEE,Browns Grove Township C4,Kansas Senate,33,Republican,"Holmes, Mitch",2,120030
+PAWNEE,Grant Township C1,Kansas Senate,33,Republican,"Holmes, Mitch",84,120040
+PAWNEE,Grant Township C4,Kansas Senate,33,Republican,"Holmes, Mitch",9,120050
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,Democratic,"Obama, Barack",15,000010
+PAWNEE,Ash Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,Republican,"Romney, Mitt",15,000010
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+PAWNEE,Conkling Township,President / Vice President,,Democratic,"Obama, Barack",0,000030
+PAWNEE,Conkling Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+PAWNEE,Conkling Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+PAWNEE,Conkling Township,President / Vice President,,Republican,"Romney, Mitt",14,000030
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+PAWNEE,Garfield Township,President / Vice President,,Democratic,"Obama, Barack",16,000040
+PAWNEE,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000040
+PAWNEE,Garfield Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000040
+PAWNEE,Garfield Township,President / Vice President,,Republican,"Romney, Mitt",79,000040
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+PAWNEE,Keysville Township,President / Vice President,,Democratic,"Obama, Barack",7,000060
+PAWNEE,Keysville Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+PAWNEE,Keysville Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+PAWNEE,Keysville Township,President / Vice President,,Republican,"Romney, Mitt",14,000060
+PAWNEE,Larned Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+PAWNEE,Larned Township,President / Vice President,,Democratic,"Obama, Barack",36,000070
+PAWNEE,Larned Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+PAWNEE,Larned Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+PAWNEE,Larned Township,President / Vice President,,Republican,"Romney, Mitt",93,000070
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,Democratic,"Obama, Barack",104,000080
+PAWNEE,Larned Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",6,000080
+PAWNEE,Larned Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,Republican,"Romney, Mitt",245,000080
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,Democratic,"Obama, Barack",149,000090
+PAWNEE,Larned Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000090
+PAWNEE,Larned Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",3,000090
+PAWNEE,Larned Ward 2,President / Vice President,,Republican,"Romney, Mitt",326,000090
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Goode, Virgil",1,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,Democratic,"Obama, Barack",143,000100
+PAWNEE,Larned Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",4,000100
+PAWNEE,Larned Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",3,000100
+PAWNEE,Larned Ward 3,President / Vice President,,Republican,"Romney, Mitt",335,000100
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,Democratic,"Obama, Barack",102,000110
+PAWNEE,Larned Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",5,000110
+PAWNEE,Larned Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,Republican,"Romney, Mitt",145,000110
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",1,000120
+PAWNEE,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",13,000120
+PAWNEE,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+PAWNEE,Logan Township,President / Vice President,,Democratic,"Obama, Barack",1,000130
+PAWNEE,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+PAWNEE,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+PAWNEE,Logan Township,President / Vice President,,Republican,"Romney, Mitt",27,000130
+PAWNEE,Morton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+PAWNEE,Morton Township,President / Vice President,,Democratic,"Obama, Barack",5,000140
+PAWNEE,Morton Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+PAWNEE,Morton Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+PAWNEE,Morton Township,President / Vice President,,Republican,"Romney, Mitt",23,000140
+PAWNEE,Orange Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+PAWNEE,Orange Township,President / Vice President,,Democratic,"Obama, Barack",5,000150
+PAWNEE,Orange Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+PAWNEE,Orange Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+PAWNEE,Orange Township,President / Vice President,,Republican,"Romney, Mitt",17,000150
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,Democratic,"Obama, Barack",11,000160
+PAWNEE,Pawnee Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+PAWNEE,Pawnee Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,Republican,"Romney, Mitt",26,000160
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Ayers, Avery L",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Barnett, Andre",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Bush, Kent W",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Christensen, Will",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Duncan, Richard A",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Goode, Virgil",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Hoefling, Tom",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Knill, Dennis J",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Reed, Jill A.",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Rogers, Rick L",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Stein, Jill E",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,Democratic,"Obama, Barack",23,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,Libertarian,"Johnson, Gary",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,Reform,"Baldwin, Chuck",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,Republican,"Romney, Mitt",56,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Christensen, Will",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00017B
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,Democratic,"Obama, Barack",6,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,Republican,"Romney, Mitt",16,000180
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,Democratic,"Obama, Barack",5,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,Republican,"Romney, Mitt",39,000190
+PAWNEE,River Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+PAWNEE,River Township,President / Vice President,,Democratic,"Obama, Barack",3,000200
+PAWNEE,River Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000200
+PAWNEE,River Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000200
+PAWNEE,River Township,President / Vice President,,Republican,"Romney, Mitt",28,000200
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,Democratic,"Obama, Barack",29,000210
+PAWNEE,Santa Fe Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000210
+PAWNEE,Santa Fe Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000210
+PAWNEE,Santa Fe Township,President / Vice President,,Republican,"Romney, Mitt",37,000210
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,Democratic,"Obama, Barack",2,000220
+PAWNEE,Sawmill Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,Republican,"Romney, Mitt",12,000220
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+PAWNEE,Shiley Township,President / Vice President,,Democratic,"Obama, Barack",0,000230
+PAWNEE,Shiley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+PAWNEE,Shiley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+PAWNEE,Shiley Township,President / Vice President,,Republican,"Romney, Mitt",16,000230
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,Democratic,"Obama, Barack",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,Republican,"Romney, Mitt",17,000240
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+PAWNEE,Walnut Township,President / Vice President,,Democratic,"Obama, Barack",9,000250
+PAWNEE,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000250
+PAWNEE,Walnut Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000250
+PAWNEE,Walnut Township,President / Vice President,,Republican,"Romney, Mitt",28,000250
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Barnett, Andre",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Bush, Kent W",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Christensen, Will",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Goode, Virgil",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Stein, Jill E",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,Democratic,"Obama, Barack",29,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,Libertarian,"Johnson, Gary",1,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,Reform,"Baldwin, Chuck",1,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,Republican,"Romney, Mitt",121,120020
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Barnett, Andre",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Bush, Kent W",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Christensen, Will",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Goode, Virgil",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Stein, Jill E",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,Democratic,"Obama, Barack",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,Republican,"Romney, Mitt",2,120030
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Barnett, Andre",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Bush, Kent W",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Christensen, Will",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Goode, Virgil",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Stein, Jill E",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,Democratic,"Obama, Barack",16,120040
+PAWNEE,Grant Township C1,President / Vice President,,Libertarian,"Johnson, Gary",3,120040
+PAWNEE,Grant Township C1,President / Vice President,,Reform,"Baldwin, Chuck",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,Republican,"Romney, Mitt",83,120040
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Barnett, Andre",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Bush, Kent W",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Christensen, Will",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Goode, Virgil",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Stein, Jill E",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,Democratic,"Obama, Barack",1,120050
+PAWNEE,Grant Township C4,President / Vice President,,Libertarian,"Johnson, Gary",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,Reform,"Baldwin, Chuck",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,Republican,"Romney, Mitt",9,120050
+PAWNEE,Ash Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000010
+PAWNEE,Conkling Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000030
+PAWNEE,Garfield Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",23,000040
+PAWNEE,Garfield Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000040
+PAWNEE,Garfield Township,United States House of Representatives,4,Republican,"Pompeo, Mike",68,000040
+PAWNEE,Keysville Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000060
+PAWNEE,Keysville Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000060
+PAWNEE,Keysville Township,United States House of Representatives,4,Republican,"Pompeo, Mike",15,000060
+PAWNEE,Larned Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",110,000070
+PAWNEE,Larned Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",295,000080
+PAWNEE,Larned Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",412,000090
+PAWNEE,Larned Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",378,000100
+PAWNEE,Larned Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",194,000110
+PAWNEE,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000120
+PAWNEE,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000130
+PAWNEE,Morton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000140
+PAWNEE,Orange Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000150
+PAWNEE,Pawnee Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000160
+PAWNEE,Pleasant Grove Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",63,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00017B
+PAWNEE,Pleasant Ridge Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",11,000180
+PAWNEE,Pleasant Ridge Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000180
+PAWNEE,Pleasant Ridge Township,United States House of Representatives,4,Republican,"Pompeo, Mike",10,000180
+PAWNEE,Pleasant Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000190
+PAWNEE,River Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000200
+PAWNEE,Santa Fe Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",56,000210
+PAWNEE,Sawmill Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",1,000220
+PAWNEE,Sawmill Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000220
+PAWNEE,Sawmill Township,United States House of Representatives,4,Republican,"Pompeo, Mike",10,000220
+PAWNEE,Shiley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000230
+PAWNEE,Valley Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000240
+PAWNEE,Walnut Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000250
+PAWNEE,Browns Grove Township C1,United States House of Representatives,1,Republican,"Huelskamp, Tim",127,120020
+PAWNEE,Browns Grove Township C4,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,120030
+PAWNEE,Browns Grove Township C4,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,120030
+PAWNEE,Browns Grove Township C4,United States House of Representatives,4,Republican,"Pompeo, Mike",2,120030
+PAWNEE,Grant Township C1,United States House of Representatives,1,Republican,"Huelskamp, Tim",88,120040
+PAWNEE,Grant Township C4,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,120050
+PAWNEE,Grant Township C4,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,120050
+PAWNEE,Grant Township C4,United States House of Representatives,4,Republican,"Pompeo, Mike",7,120050

--- a/2012/20121106__ks__general__phillips__precinct.csv
+++ b/2012/20121106__ks__general__phillips__precinct.csv
@@ -1,0 +1,726 @@
+county,precinct,office,district,party,candidate,votes,vtd
+PHILLIPS,Arcade Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",11,000010
+PHILLIPS,Arcade Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",37,000010
+PHILLIPS,Beaver Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",0,000020
+PHILLIPS,Beaver Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",31,000020
+PHILLIPS,Belmont Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",4,000030
+PHILLIPS,Belmont Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",33,000030
+PHILLIPS,Bow Creek Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",2,000040
+PHILLIPS,Bow Creek Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",18,000040
+PHILLIPS,Crystal Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",1,000050
+PHILLIPS,Crystal Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",25,000050
+PHILLIPS,Dayton Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",2,000060
+PHILLIPS,Dayton Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",17,000060
+PHILLIPS,Deer Creek Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",3,000070
+PHILLIPS,Deer Creek Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",32,000070
+PHILLIPS,Freedom Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",4,000080
+PHILLIPS,Freedom Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",41,000080
+PHILLIPS,Glenwood Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",1,000090
+PHILLIPS,Glenwood Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",19,000090
+PHILLIPS,Granite Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",0,000100
+PHILLIPS,Granite Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",16,000100
+PHILLIPS,Greenwood Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",2,000110
+PHILLIPS,Greenwood Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",24,000110
+PHILLIPS,Kirwin Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",17,000120
+PHILLIPS,Kirwin Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",91,000120
+PHILLIPS,Logan Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",46,000130
+PHILLIPS,Logan Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",221,000130
+PHILLIPS,Long Island Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",2,000140
+PHILLIPS,Long Island Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",95,000140
+PHILLIPS,Mound Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",4,000150
+PHILLIPS,Mound Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",53,000150
+PHILLIPS,Phillipsburg City Ward 1,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",101,000160
+PHILLIPS,Phillipsburg City Ward 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",352,000160
+PHILLIPS,Phillipsburg City Ward 2,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",55,000170
+PHILLIPS,Phillipsburg City Ward 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",255,000170
+PHILLIPS,Phillipsburg City Ward 3,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",78,00018A
+PHILLIPS,Phillipsburg City Ward 3,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",261,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",0,00018B
+PHILLIPS,Phillipsburg Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",17,000190
+PHILLIPS,Phillipsburg Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",119,000190
+PHILLIPS,Plainview Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",3,000200
+PHILLIPS,Plainview Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",8,000200
+PHILLIPS,Plum Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",26,000210
+PHILLIPS,Plum Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",139,000210
+PHILLIPS,Prairie View Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",6,000220
+PHILLIPS,Prairie View Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",96,000220
+PHILLIPS,Rushville Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",2,000230
+PHILLIPS,Rushville Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",6,000230
+PHILLIPS,Solomon Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",17,000240
+PHILLIPS,Solomon Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",61,000240
+PHILLIPS,Sumner Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",0,000250
+PHILLIPS,Sumner Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",16,000250
+PHILLIPS,Towanda Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",3,000260
+PHILLIPS,Towanda Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",10,000260
+PHILLIPS,Valley Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",1,000270
+PHILLIPS,Valley Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",10,000270
+PHILLIPS,Walnut Township,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",0,000280
+PHILLIPS,Walnut Township,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",2,000280
+PHILLIPS,Arcade Township,Kansas Senate,36,Democratic,"Clark, Marquis",11,000010
+PHILLIPS,Arcade Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",36,000010
+PHILLIPS,Beaver Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",2,000020
+PHILLIPS,Beaver Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",28,000020
+PHILLIPS,Belmont Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",9,000030
+PHILLIPS,Belmont Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",28,000030
+PHILLIPS,Bow Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000040
+PHILLIPS,Bow Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",18,000040
+PHILLIPS,Crystal Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000050
+PHILLIPS,Crystal Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",22,000050
+PHILLIPS,Dayton Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",2,000060
+PHILLIPS,Dayton Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",16,000060
+PHILLIPS,Deer Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",5,000070
+PHILLIPS,Deer Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",30,000070
+PHILLIPS,Freedom Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000080
+PHILLIPS,Freedom Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",40,000080
+PHILLIPS,Glenwood Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000090
+PHILLIPS,Glenwood Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000090
+PHILLIPS,Granite Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000100
+PHILLIPS,Granite Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",12,000100
+PHILLIPS,Greenwood Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000110
+PHILLIPS,Greenwood Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",23,000110
+PHILLIPS,Kirwin Township,Kansas Senate,36,Democratic,"Clark, Marquis",19,000120
+PHILLIPS,Kirwin Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",82,000120
+PHILLIPS,Logan Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",104,000130
+PHILLIPS,Logan Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",162,000130
+PHILLIPS,Long Island Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",9,000140
+PHILLIPS,Long Island Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",88,000140
+PHILLIPS,Mound Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",9,000150
+PHILLIPS,Mound Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",48,000150
+PHILLIPS,Phillipsburg City Ward 1,Kansas Senate,36,Democratic,"Clark, Marquis",79,000160
+PHILLIPS,Phillipsburg City Ward 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",364,000160
+PHILLIPS,Phillipsburg City Ward 2,Kansas Senate,36,Democratic,"Clark, Marquis",57,000170
+PHILLIPS,Phillipsburg City Ward 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",245,000170
+PHILLIPS,Phillipsburg City Ward 3,Kansas Senate,36,Democratic,"Clark, Marquis",48,00018A
+PHILLIPS,Phillipsburg City Ward 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",283,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Kansas Senate,36,Democratic,"Clark, Marquis",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00018B
+PHILLIPS,Phillipsburg Township,Kansas Senate,36,Democratic,"Clark, Marquis",18,000190
+PHILLIPS,Phillipsburg Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",116,000190
+PHILLIPS,Plainview Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000200
+PHILLIPS,Plainview Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",7,000200
+PHILLIPS,Plum Township,Kansas Senate,36,Democratic,"Clark, Marquis",23,000210
+PHILLIPS,Plum Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",138,000210
+PHILLIPS,Prairie View Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",13,000220
+PHILLIPS,Prairie View Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",89,000220
+PHILLIPS,Rushville Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000230
+PHILLIPS,Rushville Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",8,000230
+PHILLIPS,Solomon Township,Kansas Senate,36,Democratic,"Clark, Marquis",13,000240
+PHILLIPS,Solomon Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",63,000240
+PHILLIPS,Sumner Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000250
+PHILLIPS,Sumner Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000250
+PHILLIPS,Towanda Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",6,000260
+PHILLIPS,Towanda Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",7,000260
+PHILLIPS,Valley Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000270
+PHILLIPS,Valley Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",11,000270
+PHILLIPS,Walnut Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000280
+PHILLIPS,Walnut Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",2,000280
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,Democratic,"Obama, Barack",9,000010
+PHILLIPS,Arcade Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+PHILLIPS,Arcade Township,President / Vice President,,Republican,"Romney, Mitt",39,000010
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,Democratic,"Obama, Barack",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,Republican,"Romney, Mitt",31,000020
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,Democratic,"Obama, Barack",3,000030
+PHILLIPS,Belmont Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,Republican,"Romney, Mitt",36,000030
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,Democratic,"Obama, Barack",3,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,Republican,"Romney, Mitt",17,000040
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,Democratic,"Obama, Barack",1,000050
+PHILLIPS,Crystal Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,Republican,"Romney, Mitt",24,000050
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,Democratic,"Obama, Barack",2,000060
+PHILLIPS,Dayton Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,Republican,"Romney, Mitt",18,000060
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,Democratic,"Obama, Barack",1,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,Republican,"Romney, Mitt",34,000070
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,Democratic,"Obama, Barack",3,000080
+PHILLIPS,Freedom Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+PHILLIPS,Freedom Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,Republican,"Romney, Mitt",42,000080
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Goode, Virgil",1,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,Democratic,"Obama, Barack",2,000090
+PHILLIPS,Glenwood Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+PHILLIPS,Glenwood Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,Republican,"Romney, Mitt",14,000090
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+PHILLIPS,Granite Township,President / Vice President,,Democratic,"Obama, Barack",2,000100
+PHILLIPS,Granite Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+PHILLIPS,Granite Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+PHILLIPS,Granite Township,President / Vice President,,Republican,"Romney, Mitt",14,000100
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,Democratic,"Obama, Barack",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,Republican,"Romney, Mitt",27,000110
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,Democratic,"Obama, Barack",15,000120
+PHILLIPS,Kirwin Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000120
+PHILLIPS,Kirwin Township,President / Vice President,,Republican,"Romney, Mitt",94,000120
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+PHILLIPS,Logan Township,President / Vice President,,Democratic,"Obama, Barack",47,000130
+PHILLIPS,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000130
+PHILLIPS,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+PHILLIPS,Logan Township,President / Vice President,,Republican,"Romney, Mitt",220,000130
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,Democratic,"Obama, Barack",4,000140
+PHILLIPS,Long Island Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,Republican,"Romney, Mitt",95,000140
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+PHILLIPS,Mound Township,President / Vice President,,Democratic,"Obama, Barack",6,000150
+PHILLIPS,Mound Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+PHILLIPS,Mound Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+PHILLIPS,Mound Township,President / Vice President,,Republican,"Romney, Mitt",53,000150
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,Democratic,"Obama, Barack",81,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",3,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,Republican,"Romney, Mitt",371,000160
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,Democratic,"Obama, Barack",61,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",7,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,Republican,"Romney, Mitt",254,000170
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,Democratic,"Obama, Barack",65,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",9,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",4,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,Republican,"Romney, Mitt",268,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00018B
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,Democratic,"Obama, Barack",18,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,Republican,"Romney, Mitt",121,000190
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,Democratic,"Obama, Barack",3,000200
+PHILLIPS,Plainview Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,Republican,"Romney, Mitt",8,000200
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+PHILLIPS,Plum Township,President / Vice President,,Democratic,"Obama, Barack",31,000210
+PHILLIPS,Plum Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000210
+PHILLIPS,Plum Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+PHILLIPS,Plum Township,President / Vice President,,Republican,"Romney, Mitt",144,000210
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,Democratic,"Obama, Barack",8,000220
+PHILLIPS,Prairie View Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,Republican,"Romney, Mitt",97,000220
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,Democratic,"Obama, Barack",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,Republican,"Romney, Mitt",8,000230
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,Democratic,"Obama, Barack",13,000240
+PHILLIPS,Solomon Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000240
+PHILLIPS,Solomon Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,Republican,"Romney, Mitt",65,000240
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,Democratic,"Obama, Barack",1,000250
+PHILLIPS,Sumner Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,Republican,"Romney, Mitt",15,000250
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Barnett, Andre",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Bush, Kent W",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Christensen, Will",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Goode, Virgil",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Stein, Jill E",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,Democratic,"Obama, Barack",1,000260
+PHILLIPS,Towanda Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,Republican,"Romney, Mitt",12,000260
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+PHILLIPS,Valley Township,President / Vice President,,Democratic,"Obama, Barack",2,000270
+PHILLIPS,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000270
+PHILLIPS,Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000270
+PHILLIPS,Valley Township,President / Vice President,,Republican,"Romney, Mitt",12,000270
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Barnett, Andre",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Bush, Kent W",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Christensen, Will",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Goode, Virgil",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Stein, Jill E",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,Democratic,"Obama, Barack",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,Republican,"Romney, Mitt",2,000280
+PHILLIPS,Arcade Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000010
+PHILLIPS,Beaver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000020
+PHILLIPS,Belmont Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000030
+PHILLIPS,Bow Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000040
+PHILLIPS,Crystal Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000050
+PHILLIPS,Dayton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000060
+PHILLIPS,Deer Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000070
+PHILLIPS,Freedom Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000080
+PHILLIPS,Glenwood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000090
+PHILLIPS,Granite Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000100
+PHILLIPS,Greenwood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000110
+PHILLIPS,Kirwin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",90,000120
+PHILLIPS,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",230,000130
+PHILLIPS,Long Island Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",93,000140
+PHILLIPS,Mound Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000150
+PHILLIPS,Phillipsburg City Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",394,000160
+PHILLIPS,Phillipsburg City Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",281,000170
+PHILLIPS,Phillipsburg City Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",315,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00018B
+PHILLIPS,Phillipsburg Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",125,000190
+PHILLIPS,Plainview Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,000200
+PHILLIPS,Plum Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",155,000210
+PHILLIPS,Prairie View Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",92,000220
+PHILLIPS,Rushville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,000230
+PHILLIPS,Solomon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",69,000240
+PHILLIPS,Sumner Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000250
+PHILLIPS,Towanda Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000260
+PHILLIPS,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000270
+PHILLIPS,Walnut Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",2,000280

--- a/2012/20121106__ks__general__pottawatomie__precinct.csv
+++ b/2012/20121106__ks__general__pottawatomie__precinct.csv
@@ -1,0 +1,970 @@
+county,precinct,office,district,party,candidate,votes,vtd
+POTTAWATOMIE,Belvue Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",127,000010
+POTTAWATOMIE,Blue Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",362,000020
+POTTAWATOMIE,Blue Township,Kansas House of Representatives,51,Republican,"Highland, Ron",810,000020
+POTTAWATOMIE,Blue Valley Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",113,000030
+POTTAWATOMIE,Center Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",42,000040
+POTTAWATOMIE,Clear Creek Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",47,000050
+POTTAWATOMIE,Emmett Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",135,000060
+POTTAWATOMIE,Grant Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",95,000070
+POTTAWATOMIE,Green Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",72,000080
+POTTAWATOMIE,Lincoln Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",46,000090
+POTTAWATOMIE,Lone Tree Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",75,000100
+POTTAWATOMIE,Louisville Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",324,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Kansas House of Representatives,66,Republican,"Modesitt, Lee",0,000120
+POTTAWATOMIE,Mill Creek Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",291,000130
+POTTAWATOMIE,Pottawatomie County,Kansas House of Representatives,61,Republican,"Carlson, Richard",202,000140
+POTTAWATOMIE,Rock Creek Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",196,000150
+POTTAWATOMIE,Shannon Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",77,000160
+POTTAWATOMIE,Sherman Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",31,000170
+POTTAWATOMIE,Spring Creek Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",13,000180
+POTTAWATOMIE,St. Clere Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",15,000190
+POTTAWATOMIE,St. Marys East,Kansas House of Representatives,61,Republican,"Carlson, Richard",735,000210
+POTTAWATOMIE,St. Marys West,Kansas House of Representatives,61,Republican,"Carlson, Richard",444,000220
+POTTAWATOMIE,Union Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",74,000230
+POTTAWATOMIE,Vienna Township,Kansas House of Representatives,61,Republican,"Carlson, Richard",44,000240
+POTTAWATOMIE,St. George Township S1,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",6,120020
+POTTAWATOMIE,St. George Township S1,Kansas House of Representatives,51,Republican,"Highland, Ron",4,120020
+POTTAWATOMIE,St. George Township S17,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",317,120030
+POTTAWATOMIE,St. George Township S17,Kansas House of Representatives,51,Republican,"Highland, Ron",866,120030
+POTTAWATOMIE,Wamego East S17,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",0,120040
+POTTAWATOMIE,Wamego East S17,Kansas House of Representatives,51,Republican,"Highland, Ron",0,120040
+POTTAWATOMIE,Wamego East S18,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",136,120050
+POTTAWATOMIE,Wamego East S18,Kansas House of Representatives,51,Republican,"Highland, Ron",269,120050
+POTTAWATOMIE,Wamego Township S1,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",3,120060
+POTTAWATOMIE,Wamego Township S1,Kansas House of Representatives,51,Republican,"Highland, Ron",14,120060
+POTTAWATOMIE,Wamego Township S17,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",74,120070
+POTTAWATOMIE,Wamego Township S17,Kansas House of Representatives,51,Republican,"Highland, Ron",170,120070
+POTTAWATOMIE,Wamego Township S18,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",35,120080
+POTTAWATOMIE,Wamego Township S18,Kansas House of Representatives,51,Republican,"Highland, Ron",95,120080
+POTTAWATOMIE,Wamego West S17,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",117,120090
+POTTAWATOMIE,Wamego West S17,Kansas House of Representatives,51,Republican,"Highland, Ron",335,120090
+POTTAWATOMIE,Wamego West S18,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",220,120100
+POTTAWATOMIE,Wamego West S18,Kansas House of Representatives,51,Republican,"Highland, Ron",423,120100
+POTTAWATOMIE,Wamego West S17 A,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",0,120110
+POTTAWATOMIE,Wamego West S17 A,Kansas House of Representatives,51,Republican,"Highland, Ron",0,120110
+POTTAWATOMIE,Wamego Township Enclave,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",0,900010
+POTTAWATOMIE,Wamego Township Enclave,Kansas House of Representatives,51,Republican,"Highland, Ron",0,900010
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,Kansas House of Representatives,51,Republican,"Highland, Ron",0,900030
+POTTAWATOMIE,Wamego East Enclave,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",0,900040
+POTTAWATOMIE,Wamego East Enclave,Kansas House of Representatives,51,Republican,"Highland, Ron",0,900040
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,Kansas House of Representatives,61,Republican,"Carlson, Richard",12,999994
+POTTAWATOMIE,PROVISIONAL PRECINCT,Kansas House of Representatives,61,Republican,"Carlson, Richard",62,999995
+POTTAWATOMIE,ADVANCE PRECINCT,Kansas House of Representatives,61,Republican,"Carlson, Richard",446,999996
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",3,999997
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,Kansas House of Representatives,51,Republican,"Highland, Ron",18,999997
+POTTAWATOMIE,ADVANCED,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",16,999998
+POTTAWATOMIE,ADVANCED,Kansas House of Representatives,51,Republican,"Highland, Ron",66,999998
+POTTAWATOMIE,PROVISIONAL,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",179,999999
+POTTAWATOMIE,PROVISIONAL,Kansas House of Representatives,51,Republican,"Highland, Ron",398,999999
+POTTAWATOMIE,Belvue Township,Kansas Senate,1,Democratic,"Lukert, Steve",24,000010
+POTTAWATOMIE,Belvue Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",118,000010
+POTTAWATOMIE,Blue Township,Kansas Senate,1,Democratic,"Lukert, Steve",353,000020
+POTTAWATOMIE,Blue Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",826,000020
+POTTAWATOMIE,Blue Valley Township,Kansas Senate,1,Democratic,"Lukert, Steve",63,000030
+POTTAWATOMIE,Blue Valley Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",80,000030
+POTTAWATOMIE,Center Township,Kansas Senate,1,Democratic,"Lukert, Steve",11,000040
+POTTAWATOMIE,Center Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",41,000040
+POTTAWATOMIE,Clear Creek Township,Kansas Senate,1,Democratic,"Lukert, Steve",19,000050
+POTTAWATOMIE,Clear Creek Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",37,000050
+POTTAWATOMIE,Emmett Township,Kansas Senate,1,Democratic,"Lukert, Steve",47,000060
+POTTAWATOMIE,Emmett Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",105,000060
+POTTAWATOMIE,Grant Township,Kansas Senate,1,Democratic,"Lukert, Steve",48,000070
+POTTAWATOMIE,Grant Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",67,000070
+POTTAWATOMIE,Green Township,Kansas Senate,1,Democratic,"Lukert, Steve",28,000080
+POTTAWATOMIE,Green Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",59,000080
+POTTAWATOMIE,Lincoln Township,Kansas Senate,1,Democratic,"Lukert, Steve",16,000090
+POTTAWATOMIE,Lincoln Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",38,000090
+POTTAWATOMIE,Lone Tree Township,Kansas Senate,1,Democratic,"Lukert, Steve",27,000100
+POTTAWATOMIE,Lone Tree Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",62,000100
+POTTAWATOMIE,Louisville Township,Kansas Senate,1,Democratic,"Lukert, Steve",82,000110
+POTTAWATOMIE,Louisville Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",289,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Kansas Senate,1,Democratic,"Lukert, Steve",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,000120
+POTTAWATOMIE,Mill Creek Township,Kansas Senate,1,Democratic,"Lukert, Steve",175,000130
+POTTAWATOMIE,Mill Creek Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",184,000130
+POTTAWATOMIE,Pottawatomie County,Kansas Senate,1,Democratic,"Lukert, Steve",73,000140
+POTTAWATOMIE,Pottawatomie County,Kansas Senate,1,Republican,"Pyle, Dennis D.",170,000140
+POTTAWATOMIE,Rock Creek Township,Kansas Senate,1,Democratic,"Lukert, Steve",104,000150
+POTTAWATOMIE,Rock Creek Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",136,000150
+POTTAWATOMIE,Shannon Township,Kansas Senate,1,Democratic,"Lukert, Steve",25,000160
+POTTAWATOMIE,Shannon Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",70,000160
+POTTAWATOMIE,Sherman Township,Kansas Senate,1,Democratic,"Lukert, Steve",12,000170
+POTTAWATOMIE,Sherman Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",22,000170
+POTTAWATOMIE,Spring Creek Township,Kansas Senate,1,Democratic,"Lukert, Steve",6,000180
+POTTAWATOMIE,Spring Creek Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",8,000180
+POTTAWATOMIE,St. Clere Township,Kansas Senate,1,Democratic,"Lukert, Steve",6,000190
+POTTAWATOMIE,St. Clere Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",13,000190
+POTTAWATOMIE,St. Marys East,Kansas Senate,18,Democratic,"Kelly, Laura",153,000210
+POTTAWATOMIE,St. Marys East,Kansas Senate,18,Republican,"Barta, Dick",674,000210
+POTTAWATOMIE,St. Marys West,Kansas Senate,18,Democratic,"Kelly, Laura",103,000220
+POTTAWATOMIE,St. Marys West,Kansas Senate,18,Republican,"Barta, Dick",404,000220
+POTTAWATOMIE,Union Township,Kansas Senate,1,Democratic,"Lukert, Steve",27,000230
+POTTAWATOMIE,Union Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",60,000230
+POTTAWATOMIE,Vienna Township,Kansas Senate,1,Democratic,"Lukert, Steve",19,000240
+POTTAWATOMIE,Vienna Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",30,000240
+POTTAWATOMIE,St. George Township S1,Kansas Senate,1,Democratic,"Lukert, Steve",5,120020
+POTTAWATOMIE,St. George Township S1,Kansas Senate,1,Republican,"Pyle, Dennis D.",5,120020
+POTTAWATOMIE,St. George Township S17,Kansas Senate,17,Democratic,"Moran, Susan K.",387,120030
+POTTAWATOMIE,St. George Township S17,Kansas Senate,17,Republican,"Longbine, Jeff",796,120030
+POTTAWATOMIE,Wamego East S17,Kansas Senate,17,Democratic,"Moran, Susan K.",0,120040
+POTTAWATOMIE,Wamego East S17,Kansas Senate,17,Republican,"Longbine, Jeff",0,120040
+POTTAWATOMIE,Wamego East S18,Kansas Senate,18,Democratic,"Kelly, Laura",185,120050
+POTTAWATOMIE,Wamego East S18,Kansas Senate,18,Republican,"Barta, Dick",225,120050
+POTTAWATOMIE,Wamego Township S1,Kansas Senate,1,Democratic,"Lukert, Steve",2,120060
+POTTAWATOMIE,Wamego Township S1,Kansas Senate,1,Republican,"Pyle, Dennis D.",15,120060
+POTTAWATOMIE,Wamego Township S17,Kansas Senate,17,Democratic,"Moran, Susan K.",74,120070
+POTTAWATOMIE,Wamego Township S17,Kansas Senate,17,Republican,"Longbine, Jeff",165,120070
+POTTAWATOMIE,Wamego Township S18,Kansas Senate,18,Democratic,"Kelly, Laura",47,120080
+POTTAWATOMIE,Wamego Township S18,Kansas Senate,18,Republican,"Barta, Dick",89,120080
+POTTAWATOMIE,Wamego West S17,Kansas Senate,17,Democratic,"Moran, Susan K.",120,120090
+POTTAWATOMIE,Wamego West S17,Kansas Senate,17,Republican,"Longbine, Jeff",322,120090
+POTTAWATOMIE,Wamego West S18,Kansas Senate,18,Democratic,"Kelly, Laura",284,120100
+POTTAWATOMIE,Wamego West S18,Kansas Senate,18,Republican,"Barta, Dick",381,120100
+POTTAWATOMIE,Wamego West S17 A,Kansas Senate,17,Democratic,"Moran, Susan K.",0,120110
+POTTAWATOMIE,Wamego West S17 A,Kansas Senate,17,Republican,"Longbine, Jeff",0,120110
+POTTAWATOMIE,Wamego Township Enclave,Kansas Senate,17,Democratic,"Moran, Susan K.",0,900010
+POTTAWATOMIE,Wamego Township Enclave,Kansas Senate,17,Republican,"Longbine, Jeff",0,900010
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,Kansas Senate,1,Democratic,"Lukert, Steve",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,900030
+POTTAWATOMIE,Wamego East Enclave,Kansas Senate,18,Democratic,"Kelly, Laura",0,900040
+POTTAWATOMIE,Wamego East Enclave,Kansas Senate,18,Republican,"Barta, Dick",0,900040
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,Kansas Senate,18,Democratic,"Kelly, Laura",2,999991
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,Kansas Senate,18,Republican,"Barta, Dick",12,999991
+POTTAWATOMIE,PROVISIONAL PRECINCT,Kansas Senate,18,Democratic,"Kelly, Laura",12,999992
+POTTAWATOMIE,PROVISIONAL PRECINCT,Kansas Senate,18,Republican,"Barta, Dick",34,999992
+POTTAWATOMIE,ADVANCE PRECINCT,Kansas Senate,18,Democratic,"Kelly, Laura",84,999993
+POTTAWATOMIE,ADVANCE PRECINCT,Kansas Senate,18,Republican,"Barta, Dick",205,999993
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,Kansas Senate,17,Democratic,"Moran, Susan K.",9,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,Kansas Senate,17,Republican,"Longbine, Jeff",26,999994
+POTTAWATOMIE,PROVISIONAL PRECINCT,Kansas Senate,17,Democratic,"Moran, Susan K.",1,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,Kansas Senate,17,Republican,"Longbine, Jeff",3,999995
+POTTAWATOMIE,ADVANCE PRECINCT,Kansas Senate,17,Democratic,"Moran, Susan K.",93,999996
+POTTAWATOMIE,ADVANCE PRECINCT,Kansas Senate,17,Republican,"Longbine, Jeff",188,999996
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,Kansas Senate,1,Democratic,"Lukert, Steve",4,999997
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,Kansas Senate,1,Republican,"Pyle, Dennis D.",10,999997
+POTTAWATOMIE,ADVANCED,Kansas Senate,1,Democratic,"Lukert, Steve",23,999998
+POTTAWATOMIE,ADVANCED,Kansas Senate,1,Republican,"Pyle, Dennis D.",40,999998
+POTTAWATOMIE,PROVISIONAL,Kansas Senate,1,Democratic,"Lukert, Steve",173,999999
+POTTAWATOMIE,PROVISIONAL,Kansas Senate,1,Republican,"Pyle, Dennis D.",360,999999
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,Democratic,"Obama, Barack",23,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,Republican,"Romney, Mitt",120,000010
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,Democratic,"Obama, Barack",341,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,Libertarian,"Johnson, Gary",21,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,Reform,"Baldwin, Chuck",7,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,Republican,"Romney, Mitt",859,000020
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,Democratic,"Obama, Barack",40,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,Republican,"Romney, Mitt",101,000030
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,Democratic,"Obama, Barack",4,000040
+POTTAWATOMIE,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,Republican,"Romney, Mitt",47,000040
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,Democratic,"Obama, Barack",16,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,Republican,"Romney, Mitt",41,000050
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,Democratic,"Obama, Barack",41,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,Republican,"Romney, Mitt",105,000060
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,Democratic,"Obama, Barack",26,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,Republican,"Romney, Mitt",79,000070
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,Democratic,"Obama, Barack",23,000080
+POTTAWATOMIE,Green Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+POTTAWATOMIE,Green Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+POTTAWATOMIE,Green Township,President / Vice President,,Republican,"Romney, Mitt",61,000080
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",15,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",39,000090
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,Democratic,"Obama, Barack",15,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,Republican,"Romney, Mitt",71,000100
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Goode, Virgil",1,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,Democratic,"Obama, Barack",75,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,Republican,"Romney, Mitt",298,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Barnett, Andre",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Bush, Kent W",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Christensen, Will",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Goode, Virgil",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Stein, Jill E",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,Democratic,"Obama, Barack",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,Republican,"Romney, Mitt",0,000120
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,Democratic,"Obama, Barack",115,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",16,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,Republican,"Romney, Mitt",235,000130
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Barnett, Andre",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Bush, Kent W",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Christensen, Will",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Goode, Virgil",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Stein, Jill E",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,Democratic,"Obama, Barack",51,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,Libertarian,"Johnson, Gary",4,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,Republican,"Romney, Mitt",193,000140
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,Democratic,"Obama, Barack",65,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,Republican,"Romney, Mitt",165,000150
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,Democratic,"Obama, Barack",19,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,Republican,"Romney, Mitt",77,000160
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,Democratic,"Obama, Barack",3,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,Republican,"Romney, Mitt",27,000170
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,Democratic,"Obama, Barack",4,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,Republican,"Romney, Mitt",11,000180
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,Democratic,"Obama, Barack",7,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,Republican,"Romney, Mitt",12,000190
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Barnett, Andre",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Bush, Kent W",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Christensen, Will",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Goode, Virgil",8,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Stein, Jill E",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,Democratic,"Obama, Barack",125,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,Libertarian,"Johnson, Gary",14,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,Reform,"Baldwin, Chuck",38,000210
+POTTAWATOMIE,St. Marys East,President / Vice President,,Republican,"Romney, Mitt",621,000210
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Barnett, Andre",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Bush, Kent W",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Christensen, Will",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Goode, Virgil",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Stein, Jill E",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,Democratic,"Obama, Barack",63,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,Libertarian,"Johnson, Gary",13,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,Reform,"Baldwin, Chuck",36,000220
+POTTAWATOMIE,St. Marys West,President / Vice President,,Republican,"Romney, Mitt",379,000220
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,Democratic,"Obama, Barack",24,000230
+POTTAWATOMIE,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+POTTAWATOMIE,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000230
+POTTAWATOMIE,Union Township,President / Vice President,,Republican,"Romney, Mitt",63,000230
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,Democratic,"Obama, Barack",7,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,Republican,"Romney, Mitt",43,000240
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Barnett, Andre",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Bush, Kent W",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Christensen, Will",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Goode, Virgil",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Stein, Jill E",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,Democratic,"Obama, Barack",5,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,Republican,"Romney, Mitt",5,120020
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Barnett, Andre",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Bush, Kent W",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Christensen, Will",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Goode, Virgil",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Stein, Jill E",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,Democratic,"Obama, Barack",305,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,Libertarian,"Johnson, Gary",30,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,Reform,"Baldwin, Chuck",6,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,Republican,"Romney, Mitt",888,120030
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Barnett, Andre",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Bush, Kent W",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Christensen, Will",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Goode, Virgil",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Stein, Jill E",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,Democratic,"Obama, Barack",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,Libertarian,"Johnson, Gary",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,Reform,"Baldwin, Chuck",0,120040
+POTTAWATOMIE,Wamego East S17,President / Vice President,,Republican,"Romney, Mitt",0,120040
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Barnett, Andre",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Bush, Kent W",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Christensen, Will",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Goode, Virgil",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Stein, Jill E",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,Democratic,"Obama, Barack",154,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,Libertarian,"Johnson, Gary",9,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,Reform,"Baldwin, Chuck",2,120050
+POTTAWATOMIE,Wamego East S18,President / Vice President,,Republican,"Romney, Mitt",257,120050
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Ayers, Avery L",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Barnett, Andre",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Barr, Roseanne C",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Bush, Kent W",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Christensen, Will",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Duncan, Richard A",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Goode, Virgil",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Knill, Dennis J",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Reed, Jill A.",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Rogers, Rick L",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Stein, Jill E",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Thorne, Kevin M",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Warner, Gerald L.",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,Democratic,"Obama, Barack",4,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,Libertarian,"Johnson, Gary",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,Reform,"Baldwin, Chuck",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,Republican,"Romney, Mitt",13,120060
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Ayers, Avery L",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Barnett, Andre",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Barr, Roseanne C",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Bush, Kent W",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Christensen, Will",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Duncan, Richard A",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Goode, Virgil",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Knill, Dennis J",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Reed, Jill A.",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Rogers, Rick L",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Stein, Jill E",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Thorne, Kevin M",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Warner, Gerald L.",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,Democratic,"Obama, Barack",62,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,Libertarian,"Johnson, Gary",3,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,Reform,"Baldwin, Chuck",1,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,Republican,"Romney, Mitt",180,120070
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Ayers, Avery L",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Barnett, Andre",1,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Barr, Roseanne C",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Bush, Kent W",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Christensen, Will",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Duncan, Richard A",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Goode, Virgil",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Knill, Dennis J",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Reed, Jill A.",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Rogers, Rick L",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Stein, Jill E",1,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Thorne, Kevin M",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Warner, Gerald L.",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,Democratic,"Obama, Barack",32,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,Libertarian,"Johnson, Gary",1,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,Reform,"Baldwin, Chuck",1,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,Republican,"Romney, Mitt",106,120080
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Ayers, Avery L",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Barnett, Andre",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Barr, Roseanne C",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Bush, Kent W",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Christensen, Will",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Duncan, Richard A",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Goode, Virgil",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Knill, Dennis J",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Reed, Jill A.",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Rogers, Rick L",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Stein, Jill E",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Thorne, Kevin M",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,write - in,"Warner, Gerald L.",0,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,Democratic,"Obama, Barack",99,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,Libertarian,"Johnson, Gary",7,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,Reform,"Baldwin, Chuck",2,120090
+POTTAWATOMIE,Wamego West S17,President / Vice President,,Republican,"Romney, Mitt",346,120090
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Ayers, Avery L",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Barnett, Andre",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Barr, Roseanne C",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Bush, Kent W",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Christensen, Will",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Duncan, Richard A",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Goode, Virgil",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Hoefling, Tom",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Knill, Dennis J",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Reed, Jill A.",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Rogers, Rick L",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Stein, Jill E",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Thorne, Kevin M",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,write - in,"Warner, Gerald L.",0,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,Democratic,"Obama, Barack",216,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,Libertarian,"Johnson, Gary",14,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,Reform,"Baldwin, Chuck",5,120100
+POTTAWATOMIE,Wamego West S18,President / Vice President,,Republican,"Romney, Mitt",437,120100
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Ayers, Avery L",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Barnett, Andre",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Barr, Roseanne C",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Bush, Kent W",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Christensen, Will",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Duncan, Richard A",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Goode, Virgil",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Hoefling, Tom",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Knill, Dennis J",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Reed, Jill A.",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Rogers, Rick L",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Stein, Jill E",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Thorne, Kevin M",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,write - in,"Warner, Gerald L.",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,Democratic,"Obama, Barack",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,Libertarian,"Johnson, Gary",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,Reform,"Baldwin, Chuck",0,120110
+POTTAWATOMIE,Wamego West S17 A,President / Vice President,,Republican,"Romney, Mitt",0,120110
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Barnett, Andre",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Bush, Kent W",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Christensen, Will",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Goode, Virgil",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Stein, Jill E",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,Democratic,"Obama, Barack",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+POTTAWATOMIE,Wamego Township Enclave,President / Vice President,,Republican,"Romney, Mitt",0,900010
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900030
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Barnett, Andre",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Bush, Kent W",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Christensen, Will",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Goode, Virgil",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Stein, Jill E",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,Democratic,"Obama, Barack",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+POTTAWATOMIE,Wamego East Enclave,President / Vice President,,Republican,"Romney, Mitt",0,900040
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Ayers, Avery L",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Barnett, Andre",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Barr, Roseanne C",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Bush, Kent W",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Christensen, Will",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Duncan, Richard A",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Goode, Virgil",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Hoefling, Tom",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Knill, Dennis J",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Reed, Jill A.",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Rogers, Rick L",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Stein, Jill E",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Thorne, Kevin M",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,write - in,"Warner, Gerald L.",0,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,Democratic,"Obama, Barack",44,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,Libertarian,"Johnson, Gary",6,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,Reform,"Baldwin, Chuck",2,999994
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,President / Vice President,,Republican,"Romney, Mitt",112,999994
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Ayers, Avery L",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Barnett, Andre",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Barr, Roseanne C",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Bush, Kent W",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Christensen, Will",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Duncan, Richard A",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Goode, Virgil",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Hoefling, Tom",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Knill, Dennis J",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Reed, Jill A.",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Rogers, Rick L",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Stein, Jill E",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Thorne, Kevin M",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,write - in,"Warner, Gerald L.",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,Democratic,"Obama, Barack",10,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,Libertarian,"Johnson, Gary",2,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,Reform,"Baldwin, Chuck",0,999995
+POTTAWATOMIE,PROVISIONAL PRECINCT,President / Vice President,,Republican,"Romney, Mitt",26,999995
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Ayers, Avery L",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Barnett, Andre",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Barr, Roseanne C",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Bush, Kent W",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Christensen, Will",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Duncan, Richard A",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Goode, Virgil",1,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Hoefling, Tom",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Knill, Dennis J",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Reed, Jill A.",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Rogers, Rick L",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Stein, Jill E",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Thorne, Kevin M",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,write - in,"Warner, Gerald L.",0,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,Democratic,"Obama, Barack",302,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,Libertarian,"Johnson, Gary",18,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,Reform,"Baldwin, Chuck",14,999996
+POTTAWATOMIE,ADVANCE PRECINCT,President / Vice President,,Republican,"Romney, Mitt",787,999996
+POTTAWATOMIE,Belvue Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",121,000010
+POTTAWATOMIE,Blue Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",981,000020
+POTTAWATOMIE,Blue Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",112,000030
+POTTAWATOMIE,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",42,000040
+POTTAWATOMIE,Clear Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000050
+POTTAWATOMIE,Emmett Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",127,000060
+POTTAWATOMIE,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",88,000070
+POTTAWATOMIE,Green Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",67,000080
+POTTAWATOMIE,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000090
+POTTAWATOMIE,Lone Tree Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",71,000100
+POTTAWATOMIE,Louisville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",312,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,000120
+POTTAWATOMIE,Mill Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",276,000130
+POTTAWATOMIE,Pottawatomie County,United States House of Representatives,1,Republican,"Huelskamp, Tim",195,000140
+POTTAWATOMIE,Rock Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",189,000150
+POTTAWATOMIE,Shannon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",76,000160
+POTTAWATOMIE,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000170
+POTTAWATOMIE,Spring Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000180
+POTTAWATOMIE,St. Clere Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000190
+POTTAWATOMIE,St. Marys East,United States House of Representatives,1,Republican,"Huelskamp, Tim",648,000210
+POTTAWATOMIE,St. Marys West,United States House of Representatives,1,Republican,"Huelskamp, Tim",402,000220
+POTTAWATOMIE,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",70,000230
+POTTAWATOMIE,Vienna Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000240
+POTTAWATOMIE,St. George Township S1,United States House of Representatives,1,Republican,"Huelskamp, Tim",7,120020
+POTTAWATOMIE,St. George Township S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",1013,120030
+POTTAWATOMIE,Wamego East S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120040
+POTTAWATOMIE,Wamego East S18,United States House of Representatives,1,Republican,"Huelskamp, Tim",319,120050
+POTTAWATOMIE,Wamego Township S1,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,120060
+POTTAWATOMIE,Wamego Township S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",203,120070
+POTTAWATOMIE,Wamego Township S18,United States House of Representatives,1,Republican,"Huelskamp, Tim",103,120080
+POTTAWATOMIE,Wamego West S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",381,120090
+POTTAWATOMIE,Wamego West S18,United States House of Representatives,1,Republican,"Huelskamp, Tim",519,120100
+POTTAWATOMIE,Wamego West S17 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120110
+POTTAWATOMIE,Wamego Township Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900030
+POTTAWATOMIE,Wamego East Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900040
+POTTAWATOMIE,FEDERAL SERVICE PRECINCT,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,999997
+POTTAWATOMIE,ADVANCED,United States House of Representatives,1,Republican,"Huelskamp, Tim",131,999998
+POTTAWATOMIE,PROVISIONAL,United States House of Representatives,1,Republican,"Huelskamp, Tim",884,999999

--- a/2012/20121106__ks__general__pratt__precinct.csv
+++ b/2012/20121106__ks__general__pratt__precinct.csv
@@ -1,0 +1,301 @@
+county,precinct,office,district,party,candidate,votes,vtd
+PRATT,Pratt Ward 1,Kansas House of Representatives,113,Republican,"Christmann, Marshall",376,00001A
+PRATT,Pratt Ward 2,Kansas House of Representatives,113,Republican,"Christmann, Marshall",233,00002A
+PRATT,Pratt Ward 3,Kansas House of Representatives,113,Republican,"Christmann, Marshall",527,000030
+PRATT,Pratt Ward 4,Kansas House of Representatives,113,Republican,"Christmann, Marshall",405,00004A
+PRATT,Pratt Ward 5,Kansas House of Representatives,113,Republican,"Christmann, Marshall",366,00005A
+PRATT,Township 6,Kansas House of Representatives,113,Republican,"Christmann, Marshall",191,000060
+PRATT,Township 7,Kansas House of Representatives,113,Republican,"Christmann, Marshall",109,000070
+PRATT,Township 8,Kansas House of Representatives,113,Republican,"Christmann, Marshall",44,000080
+PRATT,Township 9,Kansas House of Representatives,113,Republican,"Christmann, Marshall",103,000090
+PRATT,Township 10,Kansas House of Representatives,113,Republican,"Christmann, Marshall",39,000100
+PRATT,Township 11,Kansas House of Representatives,113,Republican,"Christmann, Marshall",101,000110
+PRATT,Township 12,Kansas House of Representatives,113,Republican,"Christmann, Marshall",382,00012A
+PRATT,Pratt Ward 1,Kansas Senate,33,Republican,"Holmes, Mitch",374,00001A
+PRATT,Pratt Ward 2,Kansas Senate,33,Republican,"Holmes, Mitch",228,00002A
+PRATT,Pratt Ward 3,Kansas Senate,33,Republican,"Holmes, Mitch",498,000030
+PRATT,Pratt Ward 4,Kansas Senate,33,Republican,"Holmes, Mitch",389,00004A
+PRATT,Pratt Ward 5,Kansas Senate,33,Republican,"Holmes, Mitch",359,00005A
+PRATT,Township 6,Kansas Senate,33,Republican,"Holmes, Mitch",178,000060
+PRATT,Township 7,Kansas Senate,33,Republican,"Holmes, Mitch",94,000070
+PRATT,Township 8,Kansas Senate,33,Republican,"Holmes, Mitch",38,000080
+PRATT,Township 9,Kansas Senate,33,Republican,"Holmes, Mitch",103,000090
+PRATT,Township 10,Kansas Senate,33,Republican,"Holmes, Mitch",42,000100
+PRATT,Township 11,Kansas Senate,33,Republican,"Holmes, Mitch",102,000110
+PRATT,Township 12,Kansas Senate,33,Republican,"Holmes, Mitch",343,00012A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Christensen, Will",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,Democratic,"Obama, Barack",127,00001A
+PRATT,Pratt Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",6,00001A
+PRATT,Pratt Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,00001A
+PRATT,Pratt Ward 1,President / Vice President,,Republican,"Romney, Mitt",345,00001A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,Democratic,"Obama, Barack",84,00002A
+PRATT,Pratt Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",4,00002A
+PRATT,Pratt Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,00002A
+PRATT,Pratt Ward 2,President / Vice President,,Republican,"Romney, Mitt",225,00002A
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Goode, Virgil",1,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,Democratic,"Obama, Barack",177,000030
+PRATT,Pratt Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",8,000030
+PRATT,Pratt Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+PRATT,Pratt Ward 3,President / Vice President,,Republican,"Romney, Mitt",499,000030
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Christensen, Will",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,Democratic,"Obama, Barack",186,00004A
+PRATT,Pratt Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",8,00004A
+PRATT,Pratt Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",1,00004A
+PRATT,Pratt Ward 4,President / Vice President,,Republican,"Romney, Mitt",364,00004A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Ayers, Avery L",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Barnett, Andre",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Barr, Roseanne C",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Bush, Kent W",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Christensen, Will",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Duncan, Richard A",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Goode, Virgil",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Knill, Dennis J",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Reed, Jill A.",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Rogers, Rick L",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Stein, Jill E",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Thorne, Kevin M",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Warner, Gerald L.",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,Democratic,"Obama, Barack",131,00005A
+PRATT,Pratt Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",3,00005A
+PRATT,Pratt Ward 5,President / Vice President,,Reform,"Baldwin, Chuck",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,Republican,"Romney, Mitt",351,00005A
+PRATT,Township 6,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Barnett, Andre",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Bush, Kent W",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Christensen, Will",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Goode, Virgil",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Stein, Jill E",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+PRATT,Township 6,President / Vice President,,Democratic,"Obama, Barack",52,000060
+PRATT,Township 6,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+PRATT,Township 6,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+PRATT,Township 6,President / Vice President,,Republican,"Romney, Mitt",187,000060
+PRATT,Township 7,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Barnett, Andre",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Bush, Kent W",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Christensen, Will",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Goode, Virgil",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Stein, Jill E",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+PRATT,Township 7,President / Vice President,,Democratic,"Obama, Barack",41,000070
+PRATT,Township 7,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+PRATT,Township 7,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+PRATT,Township 7,President / Vice President,,Republican,"Romney, Mitt",102,000070
+PRATT,Township 8,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Barnett, Andre",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Bush, Kent W",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Christensen, Will",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Goode, Virgil",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Stein, Jill E",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+PRATT,Township 8,President / Vice President,,Democratic,"Obama, Barack",6,000080
+PRATT,Township 8,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+PRATT,Township 8,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+PRATT,Township 8,President / Vice President,,Republican,"Romney, Mitt",48,000080
+PRATT,Township 9,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Barnett, Andre",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Bush, Kent W",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Christensen, Will",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Goode, Virgil",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Stein, Jill E",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+PRATT,Township 9,President / Vice President,,Democratic,"Obama, Barack",30,000090
+PRATT,Township 9,President / Vice President,,Libertarian,"Johnson, Gary",3,000090
+PRATT,Township 9,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+PRATT,Township 9,President / Vice President,,Republican,"Romney, Mitt",108,000090
+PRATT,Township 10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Barnett, Andre",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Bush, Kent W",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Christensen, Will",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Goode, Virgil",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Stein, Jill E",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+PRATT,Township 10,President / Vice President,,Democratic,"Obama, Barack",10,000100
+PRATT,Township 10,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+PRATT,Township 10,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+PRATT,Township 10,President / Vice President,,Republican,"Romney, Mitt",41,000100
+PRATT,Township 11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Barnett, Andre",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Bush, Kent W",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Christensen, Will",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Goode, Virgil",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Stein, Jill E",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+PRATT,Township 11,President / Vice President,,Democratic,"Obama, Barack",28,000110
+PRATT,Township 11,President / Vice President,,Libertarian,"Johnson, Gary",1,000110
+PRATT,Township 11,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+PRATT,Township 11,President / Vice President,,Republican,"Romney, Mitt",103,000110
+PRATT,Township 12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Ayers, Avery L",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Barnett, Andre",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Barr, Roseanne C",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Bush, Kent W",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Christensen, Will",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Duncan, Richard A",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Goode, Virgil",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Knill, Dennis J",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Reed, Jill A.",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Rogers, Rick L",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Stein, Jill E",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Thorne, Kevin M",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Warner, Gerald L.",0,00012A
+PRATT,Township 12,President / Vice President,,Democratic,"Obama, Barack",108,00012A
+PRATT,Township 12,President / Vice President,,Libertarian,"Johnson, Gary",3,00012A
+PRATT,Township 12,President / Vice President,,Reform,"Baldwin, Chuck",1,00012A
+PRATT,Township 12,President / Vice President,,Republican,"Romney, Mitt",398,00012A
+PRATT,Pratt Ward 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",118,00001A
+PRATT,Pratt Ward 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",28,00001A
+PRATT,Pratt Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",319,00001A
+PRATT,Pratt Ward 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",65,00002A
+PRATT,Pratt Ward 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",23,00002A
+PRATT,Pratt Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",208,00002A
+PRATT,Pratt Ward 3,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",148,000030
+PRATT,Pratt Ward 3,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",32,000030
+PRATT,Pratt Ward 3,United States House of Representatives,4,Republican,"Pompeo, Mike",468,000030
+PRATT,Pratt Ward 4,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",147,00004A
+PRATT,Pratt Ward 4,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",24,00004A
+PRATT,Pratt Ward 4,United States House of Representatives,4,Republican,"Pompeo, Mike",341,00004A
+PRATT,Pratt Ward 5,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",97,00005A
+PRATT,Pratt Ward 5,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",20,00005A
+PRATT,Pratt Ward 5,United States House of Representatives,4,Republican,"Pompeo, Mike",339,00005A
+PRATT,Township 6,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",45,000060
+PRATT,Township 6,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",15,000060
+PRATT,Township 6,United States House of Representatives,4,Republican,"Pompeo, Mike",174,000060
+PRATT,Township 7,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",37,000070
+PRATT,Township 7,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000070
+PRATT,Township 7,United States House of Representatives,4,Republican,"Pompeo, Mike",97,000070
+PRATT,Township 8,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",3,000080
+PRATT,Township 8,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,000080
+PRATT,Township 8,United States House of Representatives,4,Republican,"Pompeo, Mike",49,000080
+PRATT,Township 9,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",21,000090
+PRATT,Township 9,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,000090
+PRATT,Township 9,United States House of Representatives,4,Republican,"Pompeo, Mike",111,000090
+PRATT,Township 10,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",6,000100
+PRATT,Township 10,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000100
+PRATT,Township 10,United States House of Representatives,4,Republican,"Pompeo, Mike",40,000100
+PRATT,Township 11,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",19,000110
+PRATT,Township 11,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",10,000110
+PRATT,Township 11,United States House of Representatives,4,Republican,"Pompeo, Mike",93,000110
+PRATT,Township 12,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",90,00012A
+PRATT,Township 12,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",16,00012A
+PRATT,Township 12,United States House of Representatives,4,Republican,"Pompeo, Mike",375,00012A

--- a/2012/20121106__ks__general__rawlins__precinct.csv
+++ b/2012/20121106__ks__general__rawlins__precinct.csv
@@ -1,0 +1,433 @@
+county,precinct,office,district,party,candidate,votes,vtd
+RAWLINS,Achilles Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",28,000010
+RAWLINS,Atwood City Precinct 1 East,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",123,000020
+RAWLINS,Atwood City Precinct 1 North,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",58,000030
+RAWLINS,Atwood City Precinct 1 West,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",73,000040
+RAWLINS,Atwood City Precinct 2,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",320,000050
+RAWLINS,Atwood Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",13,000060
+RAWLINS,Driftwood Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",38,000070
+RAWLINS,East Center,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",65,000080
+RAWLINS,Herl Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",99,00009A
+RAWLINS,Herl Township South,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",0,00009B
+RAWLINS,Herndon City,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",60,000100
+RAWLINS,Jefferson Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",14,000110
+RAWLINS,Ludell Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",49,000120
+RAWLINS,McDonald City,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",69,000130
+RAWLINS,Mirage Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",26,000140
+RAWLINS,Rocewood Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",145,000150
+RAWLINS,Union Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",28,000160
+RAWLINS,West Center,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",90,000170
+RAWLINS,Achilles Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",7,000010
+RAWLINS,Achilles Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",27,000010
+RAWLINS,Atwood City Precinct 1 East,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",39,000020
+RAWLINS,Atwood City Precinct 1 East,Kansas Senate,40,Republican,"Ostmeyer, Ralph",99,000020
+RAWLINS,Atwood City Precinct 1 North,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",17,000030
+RAWLINS,Atwood City Precinct 1 North,Kansas Senate,40,Republican,"Ostmeyer, Ralph",45,000030
+RAWLINS,Atwood City Precinct 1 West,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",20,000040
+RAWLINS,Atwood City Precinct 1 West,Kansas Senate,40,Republican,"Ostmeyer, Ralph",56,000040
+RAWLINS,Atwood City Precinct 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",127,000050
+RAWLINS,Atwood City Precinct 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",226,000050
+RAWLINS,Atwood Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",2,000060
+RAWLINS,Atwood Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",11,000060
+RAWLINS,Driftwood Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",7,000070
+RAWLINS,Driftwood Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",34,000070
+RAWLINS,East Center,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",15,000080
+RAWLINS,East Center,Kansas Senate,40,Republican,"Ostmeyer, Ralph",58,000080
+RAWLINS,Herl Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",18,00009A
+RAWLINS,Herl Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",85,00009A
+RAWLINS,Herl Township South,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,00009B
+RAWLINS,Herl Township South,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,00009B
+RAWLINS,Herndon City,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",16,000100
+RAWLINS,Herndon City,Kansas Senate,40,Republican,"Ostmeyer, Ralph",53,000100
+RAWLINS,Jefferson Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",2,000110
+RAWLINS,Jefferson Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",14,000110
+RAWLINS,Ludell Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",17,000120
+RAWLINS,Ludell Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",36,000120
+RAWLINS,McDonald City,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",8,000130
+RAWLINS,McDonald City,Kansas Senate,40,Republican,"Ostmeyer, Ralph",68,000130
+RAWLINS,Mirage Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,000140
+RAWLINS,Mirage Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",28,000140
+RAWLINS,Rocewood Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",17,000150
+RAWLINS,Rocewood Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",140,000150
+RAWLINS,Union Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",6,000160
+RAWLINS,Union Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",21,000160
+RAWLINS,West Center,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",18,000170
+RAWLINS,West Center,Kansas Senate,40,Republican,"Ostmeyer, Ralph",79,000170
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+RAWLINS,Achilles Township,President / Vice President,,Democratic,"Obama, Barack",5,000010
+RAWLINS,Achilles Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+RAWLINS,Achilles Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+RAWLINS,Achilles Township,President / Vice President,,Republican,"Romney, Mitt",29,000010
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Barnett, Andre",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Bush, Kent W",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Christensen, Will",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Goode, Virgil",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Stein, Jill E",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,Democratic,"Obama, Barack",22,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,Republican,"Romney, Mitt",113,000020
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Barnett, Andre",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Bush, Kent W",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Christensen, Will",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Goode, Virgil",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Stein, Jill E",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,Democratic,"Obama, Barack",10,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,Republican,"Romney, Mitt",53,000030
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Barnett, Andre",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Bush, Kent W",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Christensen, Will",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Goode, Virgil",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Stein, Jill E",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,Democratic,"Obama, Barack",15,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,Libertarian,"Johnson, Gary",3,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,Republican,"Romney, Mitt",55,000040
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,Democratic,"Obama, Barack",59,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",10,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,Republican,"Romney, Mitt",292,000050
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+RAWLINS,Atwood Township,President / Vice President,,Democratic,"Obama, Barack",0,000060
+RAWLINS,Atwood Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+RAWLINS,Atwood Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+RAWLINS,Atwood Township,President / Vice President,,Republican,"Romney, Mitt",12,000060
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,Democratic,"Obama, Barack",2,000070
+RAWLINS,Driftwood Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+RAWLINS,Driftwood Township,President / Vice President,,Republican,"Romney, Mitt",38,000070
+RAWLINS,East Center,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Barnett, Andre",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Bush, Kent W",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Christensen, Will",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Goode, Virgil",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Stein, Jill E",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+RAWLINS,East Center,President / Vice President,,Democratic,"Obama, Barack",9,000080
+RAWLINS,East Center,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+RAWLINS,East Center,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+RAWLINS,East Center,President / Vice President,,Republican,"Romney, Mitt",65,000080
+RAWLINS,Herl Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Ayers, Avery L",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Barnett, Andre",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Bush, Kent W",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Christensen, Will",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Duncan, Richard A",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Goode, Virgil",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Hoefling, Tom",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Knill, Dennis J",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Reed, Jill A.",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Rogers, Rick L",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Stein, Jill E",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00009A
+RAWLINS,Herl Township,President / Vice President,,Democratic,"Obama, Barack",7,00009A
+RAWLINS,Herl Township,President / Vice President,,Libertarian,"Johnson, Gary",1,00009A
+RAWLINS,Herl Township,President / Vice President,,Reform,"Baldwin, Chuck",0,00009A
+RAWLINS,Herl Township,President / Vice President,,Republican,"Romney, Mitt",98,00009A
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Ayers, Avery L",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Barnett, Andre",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Barr, Roseanne C",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Bush, Kent W",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Christensen, Will",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Duncan, Richard A",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Goode, Virgil",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Hoefling, Tom",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Knill, Dennis J",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Reed, Jill A.",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Rogers, Rick L",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Stein, Jill E",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Thorne, Kevin M",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Warner, Gerald L.",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,Democratic,"Obama, Barack",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,Libertarian,"Johnson, Gary",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,Reform,"Baldwin, Chuck",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,Republican,"Romney, Mitt",0,00009B
+RAWLINS,Herndon City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Barnett, Andre",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Bush, Kent W",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Christensen, Will",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Goode, Virgil",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Stein, Jill E",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+RAWLINS,Herndon City,President / Vice President,,Democratic,"Obama, Barack",16,000100
+RAWLINS,Herndon City,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+RAWLINS,Herndon City,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+RAWLINS,Herndon City,President / Vice President,,Republican,"Romney, Mitt",52,000100
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,Democratic,"Obama, Barack",1,000110
+RAWLINS,Jefferson Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,Republican,"Romney, Mitt",15,000110
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+RAWLINS,Ludell Township,President / Vice President,,Democratic,"Obama, Barack",12,000120
+RAWLINS,Ludell Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+RAWLINS,Ludell Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+RAWLINS,Ludell Township,President / Vice President,,Republican,"Romney, Mitt",46,000120
+RAWLINS,McDonald City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Barnett, Andre",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Bush, Kent W",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Christensen, Will",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Goode, Virgil",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Stein, Jill E",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+RAWLINS,McDonald City,President / Vice President,,Democratic,"Obama, Barack",9,000130
+RAWLINS,McDonald City,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+RAWLINS,McDonald City,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+RAWLINS,McDonald City,President / Vice President,,Republican,"Romney, Mitt",69,000130
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+RAWLINS,Mirage Township,President / Vice President,,Democratic,"Obama, Barack",0,000140
+RAWLINS,Mirage Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+RAWLINS,Mirage Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+RAWLINS,Mirage Township,President / Vice President,,Republican,"Romney, Mitt",28,000140
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,Democratic,"Obama, Barack",4,000150
+RAWLINS,Rocewood Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000150
+RAWLINS,Rocewood Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,Republican,"Romney, Mitt",149,000150
+RAWLINS,Union Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+RAWLINS,Union Township,President / Vice President,,Democratic,"Obama, Barack",4,000160
+RAWLINS,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+RAWLINS,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+RAWLINS,Union Township,President / Vice President,,Republican,"Romney, Mitt",25,000160
+RAWLINS,West Center,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Barnett, Andre",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Bush, Kent W",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Christensen, Will",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Goode, Virgil",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Stein, Jill E",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+RAWLINS,West Center,President / Vice President,,Democratic,"Obama, Barack",15,000170
+RAWLINS,West Center,President / Vice President,,Libertarian,"Johnson, Gary",1,000170
+RAWLINS,West Center,President / Vice President,,Reform,"Baldwin, Chuck",1,000170
+RAWLINS,West Center,President / Vice President,,Republican,"Romney, Mitt",84,000170
+RAWLINS,Achilles Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,000010
+RAWLINS,Atwood City Precinct 1 East,United States House of Representatives,1,Republican,"Huelskamp, Tim",110,000020
+RAWLINS,Atwood City Precinct 1 North,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,000030
+RAWLINS,Atwood City Precinct 1 West,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,000040
+RAWLINS,Atwood City Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",295,000050
+RAWLINS,Atwood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000060
+RAWLINS,Driftwood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000070
+RAWLINS,East Center,United States House of Representatives,1,Republican,"Huelskamp, Tim",64,000080
+RAWLINS,Herl Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",94,00009A
+RAWLINS,Herl Township South,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00009B
+RAWLINS,Herndon City,United States House of Representatives,1,Republican,"Huelskamp, Tim",60,000100
+RAWLINS,Jefferson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000110
+RAWLINS,Ludell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000120
+RAWLINS,McDonald City,United States House of Representatives,1,Republican,"Huelskamp, Tim",70,000130
+RAWLINS,Mirage Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000140
+RAWLINS,Rocewood Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",143,000150
+RAWLINS,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000160
+RAWLINS,West Center,United States House of Representatives,1,Republican,"Huelskamp, Tim",84,000170

--- a/2012/20121106__ks__general__reno__precinct.csv
+++ b/2012/20121106__ks__general__reno__precinct.csv
@@ -1,0 +1,1995 @@
+county,precinct,office,district,party,candidate,votes,vtd
+RENO,Albion Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",319,000010
+RENO,Arlington Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",78,000020
+RENO,Arlington Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",132,000020
+RENO,Bell Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",7,000030
+RENO,Bell Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",23,000030
+RENO,Castleton Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",128,000040
+RENO,Center Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",58,000050
+RENO,Center Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",115,000050
+RENO,Enterprise Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",27,000060
+RENO,Enterprise Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",43,000060
+RENO,Grant Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",274,000070
+RENO,Grant Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",497,000070
+RENO,Grove Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",1,000080
+RENO,Grove Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",19,000080
+RENO,Haven Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",590,000090
+RENO,Hayes Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",8,000100
+RENO,Hayes Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",30,000100
+RENO,Huntsville Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",23,000110
+RENO,Huntsville Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",35,000110
+RENO,Hutchinson Precinct 02,Kansas House of Representatives,102,Democratic,"Pauls, Jan",118,000130
+RENO,Hutchinson Precinct 02,Kansas House of Representatives,102,Republican,"Bass, Dakota",62,000130
+RENO,Hutchinson Precinct 03,Kansas House of Representatives,114,Democratic,"Moore, Carol",106,000140
+RENO,Hutchinson Precinct 03,Kansas House of Representatives,114,Republican,"Thimesch, Jack",33,000140
+RENO,Hutchinson Precinct 04,Kansas House of Representatives,104,Republican,"Becker, Steven R.",726,000150
+RENO,Hutchinson Precinct 05,Kansas House of Representatives,102,Democratic,"Pauls, Jan",223,000160
+RENO,Hutchinson Precinct 05,Kansas House of Representatives,102,Republican,"Bass, Dakota",128,000160
+RENO,Hutchinson Precinct 06,Kansas House of Representatives,102,Democratic,"Pauls, Jan",208,000170
+RENO,Hutchinson Precinct 06,Kansas House of Representatives,102,Republican,"Bass, Dakota",106,000170
+RENO,Hutchinson Precinct 07,Kansas House of Representatives,102,Democratic,"Pauls, Jan",281,000180
+RENO,Hutchinson Precinct 07,Kansas House of Representatives,102,Republican,"Bass, Dakota",161,000180
+RENO,Hutchinson Precinct 09,Kansas House of Representatives,102,Democratic,"Pauls, Jan",387,000200
+RENO,Hutchinson Precinct 09,Kansas House of Representatives,102,Republican,"Bass, Dakota",222,000200
+RENO,Hutchinson Precinct 10,Kansas House of Representatives,104,Republican,"Becker, Steven R.",609,000210
+RENO,Hutchinson Precinct 11,Kansas House of Representatives,104,Republican,"Becker, Steven R.",629,000220
+RENO,Hutchinson Precinct 12,Kansas House of Representatives,104,Republican,"Becker, Steven R.",378,000230
+RENO,Hutchinson Precinct 13,Kansas House of Representatives,104,Republican,"Becker, Steven R.",437,000240
+RENO,Hutchinson Precinct 14,Kansas House of Representatives,102,Democratic,"Pauls, Jan",246,000250
+RENO,Hutchinson Precinct 14,Kansas House of Representatives,102,Republican,"Bass, Dakota",132,000250
+RENO,Hutchinson Precinct 15,Kansas House of Representatives,102,Democratic,"Pauls, Jan",163,000260
+RENO,Hutchinson Precinct 15,Kansas House of Representatives,102,Republican,"Bass, Dakota",69,000260
+RENO,Hutchinson Precinct 16,Kansas House of Representatives,102,Democratic,"Pauls, Jan",317,000270
+RENO,Hutchinson Precinct 16,Kansas House of Representatives,102,Republican,"Bass, Dakota",137,000270
+RENO,Hutchinson Precinct 17,Kansas House of Representatives,104,Republican,"Becker, Steven R.",463,000280
+RENO,Hutchinson Precinct 18,Kansas House of Representatives,102,Democratic,"Pauls, Jan",126,000290
+RENO,Hutchinson Precinct 18,Kansas House of Representatives,102,Republican,"Bass, Dakota",65,000290
+RENO,Hutchinson Precinct 19,Kansas House of Representatives,102,Democratic,"Pauls, Jan",153,000300
+RENO,Hutchinson Precinct 19,Kansas House of Representatives,102,Republican,"Bass, Dakota",81,000300
+RENO,Hutchinson Precinct 20,Kansas House of Representatives,102,Democratic,"Pauls, Jan",252,000310
+RENO,Hutchinson Precinct 20,Kansas House of Representatives,102,Republican,"Bass, Dakota",133,000310
+RENO,Hutchinson Precinct 21,Kansas House of Representatives,104,Republican,"Becker, Steven R.",258,000320
+RENO,Hutchinson Precinct 22,Kansas House of Representatives,104,Republican,"Becker, Steven R.",561,000330
+RENO,Hutchinson Precinct 24,Kansas House of Representatives,104,Republican,"Becker, Steven R.",469,000350
+RENO,Hutchinson Precinct 25,Kansas House of Representatives,102,Democratic,"Pauls, Jan",198,000360
+RENO,Hutchinson Precinct 25,Kansas House of Representatives,102,Republican,"Bass, Dakota",105,000360
+RENO,Hutchinson Precinct 26,Kansas House of Representatives,102,Democratic,"Pauls, Jan",143,00037A
+RENO,Hutchinson Precinct 26,Kansas House of Representatives,102,Republican,"Bass, Dakota",60,00037A
+RENO,Hutchinson Precinct 26 Exclave,Kansas House of Representatives,102,Democratic,"Pauls, Jan",23,00037B
+RENO,Hutchinson Precinct 26 Exclave,Kansas House of Representatives,102,Republican,"Bass, Dakota",8,00037B
+RENO,Hutchinson Precinct 27,Kansas House of Representatives,104,Republican,"Becker, Steven R.",343,000380
+RENO,Hutchinson Precinct 28,Kansas House of Representatives,104,Republican,"Becker, Steven R.",763,00039A
+RENO,Hutchinson Precinct 28 Exclave,Kansas House of Representatives,104,Republican,"Becker, Steven R.",330,00039B
+RENO,Hutchinson Precinct 29,Kansas House of Representatives,102,Democratic,"Pauls, Jan",238,000400
+RENO,Hutchinson Precinct 29,Kansas House of Representatives,102,Republican,"Bass, Dakota",125,000400
+RENO,Hutchinson Precinct 30,Kansas House of Representatives,102,Democratic,"Pauls, Jan",146,000410
+RENO,Hutchinson Precinct 30,Kansas House of Representatives,102,Republican,"Bass, Dakota",66,000410
+RENO,Hutchinson Precinct 31,Kansas House of Representatives,104,Republican,"Becker, Steven R.",300,000420
+RENO,Hutchinson Precinct 32,Kansas House of Representatives,104,Republican,"Becker, Steven R.",97,000430
+RENO,Langdon Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",19,000440
+RENO,Langdon Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",30,000440
+RENO,Lincoln Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",154,000450
+RENO,Little River Township,Kansas House of Representatives,104,Republican,"Becker, Steven R.",866,000460
+RENO,Loda Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",16,000470
+RENO,Loda Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",28,000470
+RENO,Medford Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",23,000480
+RENO,Medford Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",58,000480
+RENO,Medora Township,Kansas House of Representatives,104,Republican,"Becker, Steven R.",721,000490
+RENO,Miami Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",43,000500
+RENO,Miami Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",115,000500
+RENO,Nickerson Ward 1,Kansas House of Representatives,114,Democratic,"Moore, Carol",82,000510
+RENO,Nickerson Ward 1,Kansas House of Representatives,114,Republican,"Thimesch, Jack",80,000510
+RENO,Nickerson Ward 2,Kansas House of Representatives,114,Democratic,"Moore, Carol",44,000520
+RENO,Nickerson Ward 2,Kansas House of Representatives,114,Republican,"Thimesch, Jack",56,000520
+RENO,Nickerson Ward 3,Kansas House of Representatives,114,Democratic,"Moore, Carol",56,000530
+RENO,Nickerson Ward 3,Kansas House of Representatives,114,Republican,"Thimesch, Jack",69,000530
+RENO,Ninnescah Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",80,000540
+RENO,North Clay Township,Kansas House of Representatives,104,Republican,"Becker, Steven R.",398,00055A
+RENO,North Reno Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",288,000560
+RENO,North Reno Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",395,000560
+RENO,Plevna Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",26,000570
+RENO,Plevna Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",86,000570
+RENO,Roscoe Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",43,000580
+RENO,Salt Creek Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",49,000590
+RENO,Salt Creek Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",122,000590
+RENO,South Clay Township Enclave,Kansas House of Representatives,104,Republican,"Becker, Steven R.",0,00060B
+RENO,South Hutchinson Precinct 1,Kansas House of Representatives,114,Democratic,"Moore, Carol",121,000610
+RENO,South Hutchinson Precinct 1,Kansas House of Representatives,114,Republican,"Thimesch, Jack",106,000610
+RENO,South Hutchinson Precinct 2,Kansas House of Representatives,114,Democratic,"Moore, Carol",175,000620
+RENO,South Hutchinson Precinct 2,Kansas House of Representatives,114,Republican,"Thimesch, Jack",248,000620
+RENO,South Hutchinson Precinct 3,Kansas House of Representatives,114,Democratic,"Moore, Carol",126,000630
+RENO,South Hutchinson Precinct 3,Kansas House of Representatives,114,Republican,"Thimesch, Jack",152,000630
+RENO,South Reno Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",51,000640
+RENO,South Reno Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",74,000640
+RENO,Sumner Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",246,000650
+RENO,Sylvia Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",36,000660
+RENO,Sylvia Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",106,000660
+RENO,Troy Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",23,000670
+RENO,Troy Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",39,000670
+RENO,Valley Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",343,000680
+RENO,Walnut Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",11,000690
+RENO,Walnut Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",37,000690
+RENO,Westminister Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",34,000700
+RENO,Westminister Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",69,000700
+RENO,Yoder Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",218,000710
+RENO,Hutchinson Precinct 01 H102,Kansas House of Representatives,102,Democratic,"Pauls, Jan",167,120020
+RENO,Hutchinson Precinct 01 H102,Kansas House of Representatives,102,Republican,"Bass, Dakota",63,120020
+RENO,Hutchinson Precinct 01 H114,Kansas House of Representatives,114,Democratic,"Moore, Carol",10,120030
+RENO,Hutchinson Precinct 01 H114,Kansas House of Representatives,114,Republican,"Thimesch, Jack",1,120030
+RENO,South Clay Township H101,Kansas House of Representatives,101,Republican,"Seiwert, Joe",415,120040
+RENO,South Clay Township Clay H102 A,Kansas House of Representatives,102,Democratic,"Pauls, Jan",2,12005A
+RENO,South Clay Township Clay H102 A,Kansas House of Representatives,102,Republican,"Bass, Dakota",2,12005A
+RENO,South Clay Township H102,Kansas House of Representatives,102,Democratic,"Pauls, Jan",0,120050
+RENO,South Clay Township H102,Kansas House of Representatives,102,Republican,"Bass, Dakota",1,120050
+RENO,Hutchinson Precinct 08 H101,Kansas House of Representatives,102,Democratic,"Pauls, Jan",141,200010
+RENO,Hutchinson Precinct 08 H101,Kansas House of Representatives,102,Republican,"Bass, Dakota",82,200010
+RENO,Hutchinson Precinct 35,Kansas House of Representatives,102,Democratic,"Pauls, Jan",123,200020
+RENO,Hutchinson Precinct 35,Kansas House of Representatives,102,Republican,"Bass, Dakota",64,200020
+RENO,Hutchinson Precinct 23 Exclave,Kansas House of Representatives,104,Republican,"Becker, Steven R.",178,200030
+RENO,Hutchinson Precinct 23 H104,Kansas House of Representatives,104,Republican,"Becker, Steven R.",722,200040
+RENO,Hutchinson Precinct 33,Kansas House of Representatives,104,Republican,"Becker, Steven R.",159,200050
+RENO,Hutchinson Precinct 34,Kansas House of Representatives,102,Democratic,"Pauls, Jan",56,200060
+RENO,Hutchinson Precinct 34,Kansas House of Representatives,102,Republican,"Bass, Dakota",18,200060
+RENO,Albion Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",165,000010
+RENO,Albion Township,Kansas Senate,34,Republican,"Bruce, Terry",242,000010
+RENO,Arlington Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",96,000020
+RENO,Arlington Township,Kansas Senate,34,Republican,"Bruce, Terry",120,000020
+RENO,Bell Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",9,000030
+RENO,Bell Township,Kansas Senate,34,Republican,"Bruce, Terry",21,000030
+RENO,Castleton Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",57,000040
+RENO,Castleton Township,Kansas Senate,34,Republican,"Bruce, Terry",91,000040
+RENO,Center Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",59,000050
+RENO,Center Township,Kansas Senate,34,Republican,"Bruce, Terry",125,000050
+RENO,Enterprise Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",21,000060
+RENO,Enterprise Township,Kansas Senate,34,Republican,"Bruce, Terry",50,000060
+RENO,Grant Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",237,000070
+RENO,Grant Township,Kansas Senate,34,Republican,"Bruce, Terry",543,000070
+RENO,Grove Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",6,000080
+RENO,Grove Township,Kansas Senate,34,Republican,"Bruce, Terry",13,000080
+RENO,Haven Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",276,000090
+RENO,Haven Township,Kansas Senate,34,Republican,"Bruce, Terry",430,000090
+RENO,Hayes Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",12,000100
+RENO,Hayes Township,Kansas Senate,34,Republican,"Bruce, Terry",28,000100
+RENO,Huntsville Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",15,000110
+RENO,Huntsville Township,Kansas Senate,34,Republican,"Bruce, Terry",44,000110
+RENO,Hutchinson Precinct 02,Kansas Senate,34,Democratic,"Treaster, Mark R.",96,000130
+RENO,Hutchinson Precinct 02,Kansas Senate,34,Republican,"Bruce, Terry",89,000130
+RENO,Hutchinson Precinct 03,Kansas Senate,34,Democratic,"Treaster, Mark R.",81,000140
+RENO,Hutchinson Precinct 03,Kansas Senate,34,Republican,"Bruce, Terry",57,000140
+RENO,Hutchinson Precinct 04,Kansas Senate,34,Democratic,"Treaster, Mark R.",320,000150
+RENO,Hutchinson Precinct 04,Kansas Senate,34,Republican,"Bruce, Terry",521,000150
+RENO,Hutchinson Precinct 05,Kansas Senate,34,Democratic,"Treaster, Mark R.",179,000160
+RENO,Hutchinson Precinct 05,Kansas Senate,34,Republican,"Bruce, Terry",175,000160
+RENO,Hutchinson Precinct 06,Kansas Senate,34,Democratic,"Treaster, Mark R.",157,000170
+RENO,Hutchinson Precinct 06,Kansas Senate,34,Republican,"Bruce, Terry",162,000170
+RENO,Hutchinson Precinct 07,Kansas Senate,34,Democratic,"Treaster, Mark R.",234,000180
+RENO,Hutchinson Precinct 07,Kansas Senate,34,Republican,"Bruce, Terry",214,000180
+RENO,Hutchinson Precinct 09,Kansas Senate,34,Democratic,"Treaster, Mark R.",297,000200
+RENO,Hutchinson Precinct 09,Kansas Senate,34,Republican,"Bruce, Terry",327,000200
+RENO,Hutchinson Precinct 10,Kansas Senate,34,Democratic,"Treaster, Mark R.",268,000210
+RENO,Hutchinson Precinct 10,Kansas Senate,34,Republican,"Bruce, Terry",465,000210
+RENO,Hutchinson Precinct 11,Kansas Senate,34,Democratic,"Treaster, Mark R.",272,000220
+RENO,Hutchinson Precinct 11,Kansas Senate,34,Republican,"Bruce, Terry",441,000220
+RENO,Hutchinson Precinct 12,Kansas Senate,34,Democratic,"Treaster, Mark R.",201,000230
+RENO,Hutchinson Precinct 12,Kansas Senate,34,Republican,"Bruce, Terry",242,000230
+RENO,Hutchinson Precinct 13,Kansas Senate,34,Democratic,"Treaster, Mark R.",225,000240
+RENO,Hutchinson Precinct 13,Kansas Senate,34,Republican,"Bruce, Terry",299,000240
+RENO,Hutchinson Precinct 14,Kansas Senate,34,Democratic,"Treaster, Mark R.",179,000250
+RENO,Hutchinson Precinct 14,Kansas Senate,34,Republican,"Bruce, Terry",211,000250
+RENO,Hutchinson Precinct 15,Kansas Senate,34,Democratic,"Treaster, Mark R.",115,000260
+RENO,Hutchinson Precinct 15,Kansas Senate,34,Republican,"Bruce, Terry",117,000260
+RENO,Hutchinson Precinct 16,Kansas Senate,34,Democratic,"Treaster, Mark R.",227,000270
+RENO,Hutchinson Precinct 16,Kansas Senate,34,Republican,"Bruce, Terry",233,000270
+RENO,Hutchinson Precinct 17,Kansas Senate,34,Democratic,"Treaster, Mark R.",234,000280
+RENO,Hutchinson Precinct 17,Kansas Senate,34,Republican,"Bruce, Terry",322,000280
+RENO,Hutchinson Precinct 18,Kansas Senate,34,Democratic,"Treaster, Mark R.",98,000290
+RENO,Hutchinson Precinct 18,Kansas Senate,34,Republican,"Bruce, Terry",99,000290
+RENO,Hutchinson Precinct 19,Kansas Senate,34,Democratic,"Treaster, Mark R.",112,000300
+RENO,Hutchinson Precinct 19,Kansas Senate,34,Republican,"Bruce, Terry",117,000300
+RENO,Hutchinson Precinct 20,Kansas Senate,34,Democratic,"Treaster, Mark R.",181,000310
+RENO,Hutchinson Precinct 20,Kansas Senate,34,Republican,"Bruce, Terry",213,000310
+RENO,Hutchinson Precinct 21,Kansas Senate,34,Democratic,"Treaster, Mark R.",151,000320
+RENO,Hutchinson Precinct 21,Kansas Senate,34,Republican,"Bruce, Terry",161,000320
+RENO,Hutchinson Precinct 22,Kansas Senate,34,Democratic,"Treaster, Mark R.",313,000330
+RENO,Hutchinson Precinct 22,Kansas Senate,34,Republican,"Bruce, Terry",362,000330
+RENO,Hutchinson Precinct 24,Kansas Senate,34,Democratic,"Treaster, Mark R.",224,000350
+RENO,Hutchinson Precinct 24,Kansas Senate,34,Republican,"Bruce, Terry",308,000350
+RENO,Hutchinson Precinct 25,Kansas Senate,34,Democratic,"Treaster, Mark R.",152,000360
+RENO,Hutchinson Precinct 25,Kansas Senate,34,Republican,"Bruce, Terry",156,000360
+RENO,Hutchinson Precinct 26,Kansas Senate,34,Democratic,"Treaster, Mark R.",107,00037A
+RENO,Hutchinson Precinct 26,Kansas Senate,34,Republican,"Bruce, Terry",104,00037A
+RENO,Hutchinson Precinct 26 Exclave,Kansas Senate,34,Democratic,"Treaster, Mark R.",9,00037B
+RENO,Hutchinson Precinct 26 Exclave,Kansas Senate,34,Republican,"Bruce, Terry",22,00037B
+RENO,Hutchinson Precinct 27,Kansas Senate,34,Democratic,"Treaster, Mark R.",178,000380
+RENO,Hutchinson Precinct 27,Kansas Senate,34,Republican,"Bruce, Terry",227,000380
+RENO,Hutchinson Precinct 28,Kansas Senate,34,Democratic,"Treaster, Mark R.",340,00039A
+RENO,Hutchinson Precinct 28,Kansas Senate,34,Republican,"Bruce, Terry",538,00039A
+RENO,Hutchinson Precinct 28 Exclave,Kansas Senate,34,Democratic,"Treaster, Mark R.",108,00039B
+RENO,Hutchinson Precinct 28 Exclave,Kansas Senate,34,Republican,"Bruce, Terry",263,00039B
+RENO,Hutchinson Precinct 29,Kansas Senate,34,Democratic,"Treaster, Mark R.",177,000400
+RENO,Hutchinson Precinct 29,Kansas Senate,34,Republican,"Bruce, Terry",198,000400
+RENO,Hutchinson Precinct 30,Kansas Senate,34,Democratic,"Treaster, Mark R.",97,000410
+RENO,Hutchinson Precinct 30,Kansas Senate,34,Republican,"Bruce, Terry",115,000410
+RENO,Hutchinson Precinct 31,Kansas Senate,34,Democratic,"Treaster, Mark R.",162,000420
+RENO,Hutchinson Precinct 31,Kansas Senate,34,Republican,"Bruce, Terry",199,000420
+RENO,Hutchinson Precinct 32,Kansas Senate,34,Democratic,"Treaster, Mark R.",36,000430
+RENO,Hutchinson Precinct 32,Kansas Senate,34,Republican,"Bruce, Terry",75,000430
+RENO,Langdon Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",15,000440
+RENO,Langdon Township,Kansas Senate,34,Republican,"Bruce, Terry",34,000440
+RENO,Lincoln Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",52,000450
+RENO,Lincoln Township,Kansas Senate,34,Republican,"Bruce, Terry",124,000450
+RENO,Little River Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",311,000460
+RENO,Little River Township,Kansas Senate,34,Republican,"Bruce, Terry",650,000460
+RENO,Loda Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",14,000470
+RENO,Loda Township,Kansas Senate,34,Republican,"Bruce, Terry",30,000470
+RENO,Medford Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",18,000480
+RENO,Medford Township,Kansas Senate,34,Republican,"Bruce, Terry",62,000480
+RENO,Medora Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",277,000490
+RENO,Medora Township,Kansas Senate,34,Republican,"Bruce, Terry",555,000490
+RENO,Miami Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",66,000500
+RENO,Miami Township,Kansas Senate,34,Republican,"Bruce, Terry",93,000500
+RENO,Nickerson Ward 1,Kansas Senate,34,Democratic,"Treaster, Mark R.",62,000510
+RENO,Nickerson Ward 1,Kansas Senate,34,Republican,"Bruce, Terry",104,000510
+RENO,Nickerson Ward 2,Kansas Senate,34,Democratic,"Treaster, Mark R.",47,000520
+RENO,Nickerson Ward 2,Kansas Senate,34,Republican,"Bruce, Terry",58,000520
+RENO,Nickerson Ward 3,Kansas Senate,34,Democratic,"Treaster, Mark R.",38,000530
+RENO,Nickerson Ward 3,Kansas Senate,34,Republican,"Bruce, Terry",85,000530
+RENO,Ninnescah Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",38,000540
+RENO,Ninnescah Township,Kansas Senate,34,Republican,"Bruce, Terry",56,000540
+RENO,North Clay Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",158,00055A
+RENO,North Clay Township,Kansas Senate,34,Republican,"Bruce, Terry",291,00055A
+RENO,North Reno Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",252,000560
+RENO,North Reno Township,Kansas Senate,34,Republican,"Bruce, Terry",448,000560
+RENO,Plevna Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",31,000570
+RENO,Plevna Township,Kansas Senate,34,Republican,"Bruce, Terry",82,000570
+RENO,Roscoe Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",26,000580
+RENO,Roscoe Township,Kansas Senate,34,Republican,"Bruce, Terry",37,000580
+RENO,Salt Creek Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",40,000590
+RENO,Salt Creek Township,Kansas Senate,34,Republican,"Bruce, Terry",138,000590
+RENO,South Clay Township Enclave,Kansas Senate,34,Democratic,"Treaster, Mark R.",0,00060B
+RENO,South Clay Township Enclave,Kansas Senate,34,Republican,"Bruce, Terry",0,00060B
+RENO,South Hutchinson Precinct 1,Kansas Senate,34,Democratic,"Treaster, Mark R.",109,000610
+RENO,South Hutchinson Precinct 1,Kansas Senate,34,Republican,"Bruce, Terry",126,000610
+RENO,South Hutchinson Precinct 2,Kansas Senate,34,Democratic,"Treaster, Mark R.",186,000620
+RENO,South Hutchinson Precinct 2,Kansas Senate,34,Republican,"Bruce, Terry",247,000620
+RENO,South Hutchinson Precinct 3,Kansas Senate,34,Democratic,"Treaster, Mark R.",132,000630
+RENO,South Hutchinson Precinct 3,Kansas Senate,34,Republican,"Bruce, Terry",165,000630
+RENO,South Reno Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",37,000640
+RENO,South Reno Township,Kansas Senate,34,Republican,"Bruce, Terry",88,000640
+RENO,Sumner Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",70,000650
+RENO,Sumner Township,Kansas Senate,34,Republican,"Bruce, Terry",190,000650
+RENO,Sylvia Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",47,000660
+RENO,Sylvia Township,Kansas Senate,34,Republican,"Bruce, Terry",94,000660
+RENO,Troy Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",29,000670
+RENO,Troy Township,Kansas Senate,34,Republican,"Bruce, Terry",33,000670
+RENO,Valley Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",129,000680
+RENO,Valley Township,Kansas Senate,34,Republican,"Bruce, Terry",256,000680
+RENO,Walnut Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",8,000690
+RENO,Walnut Township,Kansas Senate,34,Republican,"Bruce, Terry",39,000690
+RENO,Westminister Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",29,000700
+RENO,Westminister Township,Kansas Senate,34,Republican,"Bruce, Terry",75,000700
+RENO,Yoder Township,Kansas Senate,34,Democratic,"Treaster, Mark R.",77,000710
+RENO,Yoder Township,Kansas Senate,34,Republican,"Bruce, Terry",172,000710
+RENO,Hutchinson Precinct 01 H102,Kansas Senate,34,Democratic,"Treaster, Mark R.",133,120020
+RENO,Hutchinson Precinct 01 H102,Kansas Senate,34,Republican,"Bruce, Terry",100,120020
+RENO,Hutchinson Precinct 01 H114,Kansas Senate,34,Democratic,"Treaster, Mark R.",8,120030
+RENO,Hutchinson Precinct 01 H114,Kansas Senate,34,Republican,"Bruce, Terry",3,120030
+RENO,South Clay Township H101,Kansas Senate,34,Democratic,"Treaster, Mark R.",178,120040
+RENO,South Clay Township H101,Kansas Senate,34,Republican,"Bruce, Terry",321,120040
+RENO,South Clay Township Clay H102 A,Kansas Senate,34,Democratic,"Treaster, Mark R.",1,12005A
+RENO,South Clay Township Clay H102 A,Kansas Senate,34,Republican,"Bruce, Terry",3,12005A
+RENO,South Clay Township H102,Kansas Senate,34,Democratic,"Treaster, Mark R.",0,120050
+RENO,South Clay Township H102,Kansas Senate,34,Republican,"Bruce, Terry",1,120050
+RENO,Hutchinson Precinct 08 H101,Kansas Senate,34,Democratic,"Treaster, Mark R.",93,200010
+RENO,Hutchinson Precinct 08 H101,Kansas Senate,34,Republican,"Bruce, Terry",136,200010
+RENO,Hutchinson Precinct 35,Kansas Senate,34,Democratic,"Treaster, Mark R.",78,200020
+RENO,Hutchinson Precinct 35,Kansas Senate,34,Republican,"Bruce, Terry",110,200020
+RENO,Hutchinson Precinct 23 Exclave,Kansas Senate,34,Democratic,"Treaster, Mark R.",61,200030
+RENO,Hutchinson Precinct 23 Exclave,Kansas Senate,34,Republican,"Bruce, Terry",137,200030
+RENO,Hutchinson Precinct 23 H104,Kansas Senate,34,Democratic,"Treaster, Mark R.",354,200040
+RENO,Hutchinson Precinct 23 H104,Kansas Senate,34,Republican,"Bruce, Terry",513,200040
+RENO,Hutchinson Precinct 33,Kansas Senate,34,Democratic,"Treaster, Mark R.",89,200050
+RENO,Hutchinson Precinct 33,Kansas Senate,34,Republican,"Bruce, Terry",105,200050
+RENO,Hutchinson Precinct 34,Kansas Senate,34,Democratic,"Treaster, Mark R.",42,200060
+RENO,Hutchinson Precinct 34,Kansas Senate,34,Republican,"Bruce, Terry",34,200060
+RENO,Albion Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+RENO,Albion Township,President / Vice President,,Democratic,"Obama, Barack",96,000010
+RENO,Albion Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000010
+RENO,Albion Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+RENO,Albion Township,President / Vice President,,Republican,"Romney, Mitt",301,000010
+RENO,Arlington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+RENO,Arlington Township,President / Vice President,,Democratic,"Obama, Barack",67,000020
+RENO,Arlington Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000020
+RENO,Arlington Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+RENO,Arlington Township,President / Vice President,,Republican,"Romney, Mitt",137,000020
+RENO,Bell Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+RENO,Bell Township,President / Vice President,,Democratic,"Obama, Barack",2,000030
+RENO,Bell Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+RENO,Bell Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+RENO,Bell Township,President / Vice President,,Republican,"Romney, Mitt",27,000030
+RENO,Castleton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+RENO,Castleton Township,President / Vice President,,Democratic,"Obama, Barack",35,000040
+RENO,Castleton Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000040
+RENO,Castleton Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000040
+RENO,Castleton Township,President / Vice President,,Republican,"Romney, Mitt",109,000040
+RENO,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Goode, Virgil",3,000050
+RENO,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+RENO,Center Township,President / Vice President,,Democratic,"Obama, Barack",41,000050
+RENO,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000050
+RENO,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+RENO,Center Township,President / Vice President,,Republican,"Romney, Mitt",135,000050
+RENO,Enterprise Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+RENO,Enterprise Township,President / Vice President,,Democratic,"Obama, Barack",16,000060
+RENO,Enterprise Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+RENO,Enterprise Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+RENO,Enterprise Township,President / Vice President,,Republican,"Romney, Mitt",53,000060
+RENO,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Stein, Jill E",1,000070
+RENO,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+RENO,Grant Township,President / Vice President,,Democratic,"Obama, Barack",182,000070
+RENO,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000070
+RENO,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",6,000070
+RENO,Grant Township,President / Vice President,,Republican,"Romney, Mitt",576,000070
+RENO,Grove Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+RENO,Grove Township,President / Vice President,,Democratic,"Obama, Barack",2,000080
+RENO,Grove Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+RENO,Grove Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+RENO,Grove Township,President / Vice President,,Republican,"Romney, Mitt",17,000080
+RENO,Haven Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+RENO,Haven Township,President / Vice President,,Democratic,"Obama, Barack",190,000090
+RENO,Haven Township,President / Vice President,,Libertarian,"Johnson, Gary",17,000090
+RENO,Haven Township,President / Vice President,,Reform,"Baldwin, Chuck",7,000090
+RENO,Haven Township,President / Vice President,,Republican,"Romney, Mitt",491,000090
+RENO,Hayes Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+RENO,Hayes Township,President / Vice President,,Democratic,"Obama, Barack",11,000100
+RENO,Hayes Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+RENO,Hayes Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+RENO,Hayes Township,President / Vice President,,Republican,"Romney, Mitt",26,000100
+RENO,Huntsville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+RENO,Huntsville Township,President / Vice President,,Democratic,"Obama, Barack",14,000110
+RENO,Huntsville Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+RENO,Huntsville Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+RENO,Huntsville Township,President / Vice President,,Republican,"Romney, Mitt",45,000110
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,Democratic,"Obama, Barack",89,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",2,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,Republican,"Romney, Mitt",100,000130
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,Democratic,"Obama, Barack",92,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",4,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,Republican,"Romney, Mitt",46,000140
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,Democratic,"Obama, Barack",239,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",8,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",4,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,Republican,"Romney, Mitt",588,000150
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Stein, Jill E",1,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,Democratic,"Obama, Barack",161,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",12,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",6,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,Republican,"Romney, Mitt",179,000160
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Barnett, Andre",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Bush, Kent W",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Christensen, Will",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Goode, Virgil",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Stein, Jill E",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,Democratic,"Obama, Barack",136,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",11,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,Reform,"Baldwin, Chuck",4,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,Republican,"Romney, Mitt",177,000170
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Barnett, Andre",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Bush, Kent W",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Christensen, Will",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Goode, Virgil",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Stein, Jill E",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,Democratic,"Obama, Barack",219,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",13,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,Reform,"Baldwin, Chuck",3,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,Republican,"Romney, Mitt",222,000180
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Barnett, Andre",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Bush, Kent W",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Christensen, Will",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Goode, Virgil",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Stein, Jill E",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,Democratic,"Obama, Barack",240,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",19,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,Reform,"Baldwin, Chuck",4,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,Republican,"Romney, Mitt",356,000200
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Barnett, Andre",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Bush, Kent W",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Christensen, Will",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Goode, Virgil",1,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Stein, Jill E",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,Democratic,"Obama, Barack",217,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",14,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,Reform,"Baldwin, Chuck",2,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,Republican,"Romney, Mitt",491,000210
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Barnett, Andre",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Bush, Kent W",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Christensen, Will",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Goode, Virgil",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Stein, Jill E",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,Democratic,"Obama, Barack",214,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",5,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,Reform,"Baldwin, Chuck",1,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,Republican,"Romney, Mitt",489,000220
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Barnett, Andre",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Bush, Kent W",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Christensen, Will",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Goode, Virgil",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Stein, Jill E",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,Democratic,"Obama, Barack",169,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,Libertarian,"Johnson, Gary",12,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,Reform,"Baldwin, Chuck",1,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,Republican,"Romney, Mitt",271,000230
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Barnett, Andre",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Bush, Kent W",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Christensen, Will",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Goode, Virgil",2,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Stein, Jill E",1,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,Democratic,"Obama, Barack",206,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,Libertarian,"Johnson, Gary",11,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,Reform,"Baldwin, Chuck",4,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,Republican,"Romney, Mitt",301,000240
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Barnett, Andre",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Bush, Kent W",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Christensen, Will",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Goode, Virgil",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Stein, Jill E",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,Democratic,"Obama, Barack",168,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,Libertarian,"Johnson, Gary",10,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,Reform,"Baldwin, Chuck",1,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,Republican,"Romney, Mitt",215,000250
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Barnett, Andre",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Bush, Kent W",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Christensen, Will",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Goode, Virgil",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Stein, Jill E",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,Democratic,"Obama, Barack",117,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,Libertarian,"Johnson, Gary",5,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,Reform,"Baldwin, Chuck",4,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,Republican,"Romney, Mitt",108,000260
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Barnett, Andre",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Bush, Kent W",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Christensen, Will",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Goode, Virgil",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Stein, Jill E",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,Democratic,"Obama, Barack",229,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,Libertarian,"Johnson, Gary",11,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,Reform,"Baldwin, Chuck",10,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,Republican,"Romney, Mitt",208,000270
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Barnett, Andre",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Bush, Kent W",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Christensen, Will",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Goode, Virgil",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Stein, Jill E",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,Democratic,"Obama, Barack",208,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,Libertarian,"Johnson, Gary",6,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,Reform,"Baldwin, Chuck",3,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,Republican,"Romney, Mitt",343,000280
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Barnett, Andre",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Bush, Kent W",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Christensen, Will",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Goode, Virgil",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Stein, Jill E",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,Democratic,"Obama, Barack",80,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,Libertarian,"Johnson, Gary",6,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,Reform,"Baldwin, Chuck",3,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,Republican,"Romney, Mitt",105,000290
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Barnett, Andre",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Bush, Kent W",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Christensen, Will",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Goode, Virgil",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Stein, Jill E",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,Democratic,"Obama, Barack",116,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,Libertarian,"Johnson, Gary",11,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,Reform,"Baldwin, Chuck",2,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,Republican,"Romney, Mitt",106,000300
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Barnett, Andre",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Bush, Kent W",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Christensen, Will",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Goode, Virgil",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Stein, Jill E",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,Democratic,"Obama, Barack",173,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,Libertarian,"Johnson, Gary",9,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,Reform,"Baldwin, Chuck",2,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,Republican,"Romney, Mitt",210,000310
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Barnett, Andre",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Bush, Kent W",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Christensen, Will",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Goode, Virgil",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Stein, Jill E",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,Democratic,"Obama, Barack",145,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,Libertarian,"Johnson, Gary",4,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,Reform,"Baldwin, Chuck",5,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,Republican,"Romney, Mitt",161,000320
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Ayers, Avery L",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Barnett, Andre",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Barr, Roseanne C",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Bush, Kent W",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Christensen, Will",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Duncan, Richard A",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Goode, Virgil",1,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Knill, Dennis J",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Reed, Jill A.",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Rogers, Rick L",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Stein, Jill E",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Thorne, Kevin M",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Warner, Gerald L.",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,Democratic,"Obama, Barack",259,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,Libertarian,"Johnson, Gary",11,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,Reform,"Baldwin, Chuck",2,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,Republican,"Romney, Mitt",415,000330
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Ayers, Avery L",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Barnett, Andre",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Barr, Roseanne C",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Bush, Kent W",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Christensen, Will",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Duncan, Richard A",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Goode, Virgil",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Knill, Dennis J",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Reed, Jill A.",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Rogers, Rick L",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Stein, Jill E",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Thorne, Kevin M",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Warner, Gerald L.",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,Democratic,"Obama, Barack",180,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,Libertarian,"Johnson, Gary",7,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,Reform,"Baldwin, Chuck",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,Republican,"Romney, Mitt",344,000350
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Ayers, Avery L",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Barnett, Andre",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Barr, Roseanne C",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Bush, Kent W",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Christensen, Will",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Duncan, Richard A",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Goode, Virgil",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Knill, Dennis J",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Reed, Jill A.",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Rogers, Rick L",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Stein, Jill E",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Thorne, Kevin M",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Warner, Gerald L.",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,Democratic,"Obama, Barack",160,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,Libertarian,"Johnson, Gary",7,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,Reform,"Baldwin, Chuck",4,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,Republican,"Romney, Mitt",144,000360
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Ayers, Avery L",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Barnett, Andre",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Barr, Roseanne C",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Bush, Kent W",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Christensen, Will",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Duncan, Richard A",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Goode, Virgil",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Hoefling, Tom",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Knill, Dennis J",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Reed, Jill A.",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Rogers, Rick L",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Stein, Jill E",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Thorne, Kevin M",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Warner, Gerald L.",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,Democratic,"Obama, Barack",100,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,Libertarian,"Johnson, Gary",6,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,Reform,"Baldwin, Chuck",2,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,Republican,"Romney, Mitt",104,00037A
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,Democratic,"Obama, Barack",8,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",1,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,Republican,"Romney, Mitt",22,00037B
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Ayers, Avery L",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Barnett, Andre",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Barr, Roseanne C",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Bush, Kent W",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Christensen, Will",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Duncan, Richard A",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Goode, Virgil",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Knill, Dennis J",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Reed, Jill A.",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Rogers, Rick L",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Stein, Jill E",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Thorne, Kevin M",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Warner, Gerald L.",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,Democratic,"Obama, Barack",147,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,Libertarian,"Johnson, Gary",7,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,Reform,"Baldwin, Chuck",2,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,Republican,"Romney, Mitt",244,000380
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Ayers, Avery L",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Barnett, Andre",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Barr, Roseanne C",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Bush, Kent W",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Christensen, Will",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Duncan, Richard A",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Goode, Virgil",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Hoefling, Tom",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Knill, Dennis J",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Reed, Jill A.",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Rogers, Rick L",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Stein, Jill E",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Thorne, Kevin M",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Warner, Gerald L.",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,Democratic,"Obama, Barack",262,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,Libertarian,"Johnson, Gary",8,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,Reform,"Baldwin, Chuck",3,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,Republican,"Romney, Mitt",620,00039A
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,Democratic,"Obama, Barack",68,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,Republican,"Romney, Mitt",303,00039B
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Ayers, Avery L",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Barnett, Andre",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Barr, Roseanne C",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Bush, Kent W",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Christensen, Will",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Duncan, Richard A",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Goode, Virgil",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Knill, Dennis J",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Reed, Jill A.",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Rogers, Rick L",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Stein, Jill E",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Thorne, Kevin M",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Warner, Gerald L.",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,Democratic,"Obama, Barack",146,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,Libertarian,"Johnson, Gary",7,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,Reform,"Baldwin, Chuck",2,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,Republican,"Romney, Mitt",222,000400
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Ayers, Avery L",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Barnett, Andre",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Barr, Roseanne C",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Bush, Kent W",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Christensen, Will",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Duncan, Richard A",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Goode, Virgil",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Hoefling, Tom",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Knill, Dennis J",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Reed, Jill A.",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Rogers, Rick L",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Stein, Jill E",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Thorne, Kevin M",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Warner, Gerald L.",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,Democratic,"Obama, Barack",91,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,Libertarian,"Johnson, Gary",4,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,Reform,"Baldwin, Chuck",1,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,Republican,"Romney, Mitt",117,000410
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Ayers, Avery L",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Barnett, Andre",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Barr, Roseanne C",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Bush, Kent W",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Christensen, Will",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Duncan, Richard A",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Goode, Virgil",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Hoefling, Tom",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Knill, Dennis J",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Reed, Jill A.",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Rogers, Rick L",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Stein, Jill E",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Thorne, Kevin M",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Warner, Gerald L.",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,Democratic,"Obama, Barack",128,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,Libertarian,"Johnson, Gary",9,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,Reform,"Baldwin, Chuck",1,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,Republican,"Romney, Mitt",228,000420
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Ayers, Avery L",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Barnett, Andre",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Barr, Roseanne C",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Bush, Kent W",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Christensen, Will",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Duncan, Richard A",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Goode, Virgil",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Hoefling, Tom",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Knill, Dennis J",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Reed, Jill A.",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Rogers, Rick L",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Stein, Jill E",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Thorne, Kevin M",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Warner, Gerald L.",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,Democratic,"Obama, Barack",25,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,Libertarian,"Johnson, Gary",2,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,Reform,"Baldwin, Chuck",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,Republican,"Romney, Mitt",86,000430
+RENO,Langdon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Barnett, Andre",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Bush, Kent W",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Christensen, Will",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Goode, Virgil",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Stein, Jill E",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000440
+RENO,Langdon Township,President / Vice President,,Democratic,"Obama, Barack",12,000440
+RENO,Langdon Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000440
+RENO,Langdon Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000440
+RENO,Langdon Township,President / Vice President,,Republican,"Romney, Mitt",37,000440
+RENO,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000450
+RENO,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",37,000450
+RENO,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000450
+RENO,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000450
+RENO,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",142,000450
+RENO,Little River Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Ayers, Avery L",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Barnett, Andre",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Bush, Kent W",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Christensen, Will",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Duncan, Richard A",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Goode, Virgil",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Hoefling, Tom",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Knill, Dennis J",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Reed, Jill A.",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Rogers, Rick L",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Stein, Jill E",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000460
+RENO,Little River Township,President / Vice President,,Democratic,"Obama, Barack",222,000460
+RENO,Little River Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000460
+RENO,Little River Township,President / Vice President,,Reform,"Baldwin, Chuck",7,000460
+RENO,Little River Township,President / Vice President,,Republican,"Romney, Mitt",710,000460
+RENO,Loda Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Ayers, Avery L",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Barnett, Andre",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Bush, Kent W",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Christensen, Will",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Duncan, Richard A",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Goode, Virgil",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Hoefling, Tom",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Knill, Dennis J",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Reed, Jill A.",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Rogers, Rick L",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Stein, Jill E",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000470
+RENO,Loda Township,President / Vice President,,Democratic,"Obama, Barack",12,000470
+RENO,Loda Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000470
+RENO,Loda Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000470
+RENO,Loda Township,President / Vice President,,Republican,"Romney, Mitt",30,000470
+RENO,Medford Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Ayers, Avery L",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Barnett, Andre",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Bush, Kent W",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Christensen, Will",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Duncan, Richard A",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Goode, Virgil",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Knill, Dennis J",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Reed, Jill A.",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Rogers, Rick L",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Stein, Jill E",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000480
+RENO,Medford Township,President / Vice President,,Democratic,"Obama, Barack",19,000480
+RENO,Medford Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000480
+RENO,Medford Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000480
+RENO,Medford Township,President / Vice President,,Republican,"Romney, Mitt",63,000480
+RENO,Medora Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",2,000490
+RENO,Medora Township,President / Vice President,,write - in,"Ayers, Avery L",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Barnett, Andre",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Bush, Kent W",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Christensen, Will",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Duncan, Richard A",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Goode, Virgil",3,000490
+RENO,Medora Township,President / Vice President,,write - in,"Hoefling, Tom",1,000490
+RENO,Medora Township,President / Vice President,,write - in,"Knill, Dennis J",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Reed, Jill A.",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Rogers, Rick L",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Stein, Jill E",1,000490
+RENO,Medora Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000490
+RENO,Medora Township,President / Vice President,,Democratic,"Obama, Barack",226,000490
+RENO,Medora Township,President / Vice President,,Libertarian,"Johnson, Gary",17,000490
+RENO,Medora Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000490
+RENO,Medora Township,President / Vice President,,Republican,"Romney, Mitt",591,000490
+RENO,Miami Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Ayers, Avery L",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Barnett, Andre",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Bush, Kent W",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Christensen, Will",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Duncan, Richard A",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Goode, Virgil",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Hoefling, Tom",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Knill, Dennis J",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Reed, Jill A.",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Rogers, Rick L",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Stein, Jill E",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000500
+RENO,Miami Township,President / Vice President,,Democratic,"Obama, Barack",50,000500
+RENO,Miami Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000500
+RENO,Miami Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000500
+RENO,Miami Township,President / Vice President,,Republican,"Romney, Mitt",108,000500
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,Democratic,"Obama, Barack",62,000510
+RENO,Nickerson Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",6,000510
+RENO,Nickerson Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000510
+RENO,Nickerson Ward 1,President / Vice President,,Republican,"Romney, Mitt",97,000510
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,Democratic,"Obama, Barack",40,000520
+RENO,Nickerson Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000520
+RENO,Nickerson Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,Republican,"Romney, Mitt",55,000520
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,Democratic,"Obama, Barack",38,000530
+RENO,Nickerson Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",5,000530
+RENO,Nickerson Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",3,000530
+RENO,Nickerson Ward 3,President / Vice President,,Republican,"Romney, Mitt",78,000530
+RENO,Ninnescah Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Ayers, Avery L",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Barnett, Andre",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Bush, Kent W",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Christensen, Will",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Duncan, Richard A",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Goode, Virgil",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Hoefling, Tom",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Knill, Dennis J",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Reed, Jill A.",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Rogers, Rick L",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Stein, Jill E",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000540
+RENO,Ninnescah Township,President / Vice President,,Democratic,"Obama, Barack",34,000540
+RENO,Ninnescah Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000540
+RENO,Ninnescah Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000540
+RENO,Ninnescah Township,President / Vice President,,Republican,"Romney, Mitt",59,000540
+RENO,North Clay Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Ayers, Avery L",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Barnett, Andre",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Bush, Kent W",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Christensen, Will",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Duncan, Richard A",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Goode, Virgil",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Hoefling, Tom",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Knill, Dennis J",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Reed, Jill A.",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Rogers, Rick L",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Stein, Jill E",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00055A
+RENO,North Clay Township,President / Vice President,,Democratic,"Obama, Barack",98,00055A
+RENO,North Clay Township,President / Vice President,,Libertarian,"Johnson, Gary",6,00055A
+RENO,North Clay Township,President / Vice President,,Reform,"Baldwin, Chuck",1,00055A
+RENO,North Clay Township,President / Vice President,,Republican,"Romney, Mitt",343,00055A
+RENO,North Reno Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Ayers, Avery L",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Barnett, Andre",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Bush, Kent W",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Christensen, Will",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Duncan, Richard A",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Goode, Virgil",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Hoefling, Tom",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Knill, Dennis J",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Reed, Jill A.",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Rogers, Rick L",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Stein, Jill E",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000560
+RENO,North Reno Township,President / Vice President,,Democratic,"Obama, Barack",204,000560
+RENO,North Reno Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000560
+RENO,North Reno Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000560
+RENO,North Reno Township,President / Vice President,,Republican,"Romney, Mitt",469,000560
+RENO,Plevna Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Ayers, Avery L",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Barnett, Andre",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Bush, Kent W",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Christensen, Will",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Duncan, Richard A",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Goode, Virgil",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Hoefling, Tom",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Knill, Dennis J",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Reed, Jill A.",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Rogers, Rick L",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Stein, Jill E",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000570
+RENO,Plevna Township,President / Vice President,,Democratic,"Obama, Barack",23,000570
+RENO,Plevna Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000570
+RENO,Plevna Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000570
+RENO,Plevna Township,President / Vice President,,Republican,"Romney, Mitt",92,000570
+RENO,Roscoe Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Ayers, Avery L",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Barnett, Andre",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Bush, Kent W",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Christensen, Will",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Duncan, Richard A",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Goode, Virgil",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Hoefling, Tom",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Knill, Dennis J",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Reed, Jill A.",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Rogers, Rick L",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Stein, Jill E",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000580
+RENO,Roscoe Township,President / Vice President,,Democratic,"Obama, Barack",23,000580
+RENO,Roscoe Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000580
+RENO,Roscoe Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000580
+RENO,Roscoe Township,President / Vice President,,Republican,"Romney, Mitt",38,000580
+RENO,Salt Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000590
+RENO,Salt Creek Township,President / Vice President,,Democratic,"Obama, Barack",31,000590
+RENO,Salt Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000590
+RENO,Salt Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000590
+RENO,Salt Creek Township,President / Vice President,,Republican,"Romney, Mitt",142,000590
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Christensen, Will",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00060B
+RENO,South Clay Township Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00060B
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Stein, Jill E",1,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,Democratic,"Obama, Barack",99,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",4,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",4,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,Republican,"Romney, Mitt",125,000610
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,Democratic,"Obama, Barack",127,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,Republican,"Romney, Mitt",293,000620
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,Democratic,"Obama, Barack",105,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",3,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",2,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,Republican,"Romney, Mitt",186,000630
+RENO,South Reno Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Ayers, Avery L",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Barnett, Andre",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Bush, Kent W",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Christensen, Will",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Duncan, Richard A",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Goode, Virgil",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Hoefling, Tom",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Knill, Dennis J",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Reed, Jill A.",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Rogers, Rick L",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Stein, Jill E",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000640
+RENO,South Reno Township,President / Vice President,,Democratic,"Obama, Barack",28,000640
+RENO,South Reno Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000640
+RENO,South Reno Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000640
+RENO,South Reno Township,President / Vice President,,Republican,"Romney, Mitt",96,000640
+RENO,Sumner Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Ayers, Avery L",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Barnett, Andre",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Bush, Kent W",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Christensen, Will",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Duncan, Richard A",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Goode, Virgil",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Knill, Dennis J",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Reed, Jill A.",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Rogers, Rick L",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Stein, Jill E",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000650
+RENO,Sumner Township,President / Vice President,,Democratic,"Obama, Barack",52,000650
+RENO,Sumner Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000650
+RENO,Sumner Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000650
+RENO,Sumner Township,President / Vice President,,Republican,"Romney, Mitt",217,000650
+RENO,Sylvia Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Ayers, Avery L",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Barnett, Andre",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Bush, Kent W",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Christensen, Will",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Duncan, Richard A",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Goode, Virgil",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Knill, Dennis J",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Reed, Jill A.",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Rogers, Rick L",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Stein, Jill E",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000660
+RENO,Sylvia Township,President / Vice President,,Democratic,"Obama, Barack",32,000660
+RENO,Sylvia Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000660
+RENO,Sylvia Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000660
+RENO,Sylvia Township,President / Vice President,,Republican,"Romney, Mitt",108,000660
+RENO,Troy Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Ayers, Avery L",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Barnett, Andre",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Bush, Kent W",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Christensen, Will",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Duncan, Richard A",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Goode, Virgil",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Hoefling, Tom",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Knill, Dennis J",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Reed, Jill A.",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Rogers, Rick L",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Stein, Jill E",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000670
+RENO,Troy Township,President / Vice President,,Democratic,"Obama, Barack",17,000670
+RENO,Troy Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000670
+RENO,Troy Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000670
+RENO,Troy Township,President / Vice President,,Republican,"Romney, Mitt",41,000670
+RENO,Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000680
+RENO,Valley Township,President / Vice President,,Democratic,"Obama, Barack",92,000680
+RENO,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000680
+RENO,Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000680
+RENO,Valley Township,President / Vice President,,Republican,"Romney, Mitt",288,000680
+RENO,Walnut Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Ayers, Avery L",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Barnett, Andre",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Bush, Kent W",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Christensen, Will",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Duncan, Richard A",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Goode, Virgil",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Knill, Dennis J",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Reed, Jill A.",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Rogers, Rick L",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Stein, Jill E",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000690
+RENO,Walnut Township,President / Vice President,,Democratic,"Obama, Barack",4,000690
+RENO,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000690
+RENO,Walnut Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000690
+RENO,Walnut Township,President / Vice President,,Republican,"Romney, Mitt",41,000690
+RENO,Westminister Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Ayers, Avery L",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Barnett, Andre",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Bush, Kent W",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Christensen, Will",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Duncan, Richard A",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Goode, Virgil",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Hoefling, Tom",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Knill, Dennis J",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Reed, Jill A.",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Rogers, Rick L",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Stein, Jill E",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000700
+RENO,Westminister Township,President / Vice President,,Democratic,"Obama, Barack",24,000700
+RENO,Westminister Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000700
+RENO,Westminister Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000700
+RENO,Westminister Township,President / Vice President,,Republican,"Romney, Mitt",81,000700
+RENO,Yoder Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Ayers, Avery L",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Barnett, Andre",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Bush, Kent W",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Christensen, Will",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Duncan, Richard A",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Goode, Virgil",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Hoefling, Tom",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Knill, Dennis J",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Reed, Jill A.",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Rogers, Rick L",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Stein, Jill E",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000710
+RENO,Yoder Township,President / Vice President,,Democratic,"Obama, Barack",50,000710
+RENO,Yoder Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000710
+RENO,Yoder Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000710
+RENO,Yoder Township,President / Vice President,,Republican,"Romney, Mitt",196,000710
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Barnett, Andre",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Bush, Kent W",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Christensen, Will",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Goode, Virgil",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Stein, Jill E",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,Democratic,"Obama, Barack",132,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,Libertarian,"Johnson, Gary",2,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,Reform,"Baldwin, Chuck",4,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,Republican,"Romney, Mitt",92,120020
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Barnett, Andre",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Bush, Kent W",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Christensen, Will",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Goode, Virgil",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Stein, Jill E",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,Democratic,"Obama, Barack",10,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,Republican,"Romney, Mitt",1,120030
+RENO,South Clay Township H101,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Barnett, Andre",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Bush, Kent W",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Christensen, Will",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Goode, Virgil",2,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Stein, Jill E",1,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+RENO,South Clay Township H101,President / Vice President,,Democratic,"Obama, Barack",144,120040
+RENO,South Clay Township H101,President / Vice President,,Libertarian,"Johnson, Gary",7,120040
+RENO,South Clay Township H101,President / Vice President,,Reform,"Baldwin, Chuck",0,120040
+RENO,South Clay Township H101,President / Vice President,,Republican,"Romney, Mitt",343,120040
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Ayers, Avery L",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Barnett, Andre",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Bush, Kent W",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Christensen, Will",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Duncan, Richard A",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Goode, Virgil",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Hoefling, Tom",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Knill, Dennis J",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Reed, Jill A.",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Rogers, Rick L",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Stein, Jill E",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,Democratic,"Obama, Barack",1,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,Republican,"Romney, Mitt",3,12005A
+RENO,South Clay Township H102,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Barnett, Andre",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Bush, Kent W",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Christensen, Will",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Goode, Virgil",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Stein, Jill E",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+RENO,South Clay Township H102,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+RENO,South Clay Township H102,President / Vice President,,Democratic,"Obama, Barack",0,120050
+RENO,South Clay Township H102,President / Vice President,,Libertarian,"Johnson, Gary",0,120050
+RENO,South Clay Township H102,President / Vice President,,Reform,"Baldwin, Chuck",0,120050
+RENO,South Clay Township H102,President / Vice President,,Republican,"Romney, Mitt",1,120050
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Ayers, Avery L",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Barnett, Andre",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Barr, Roseanne C",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Bush, Kent W",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Christensen, Will",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Duncan, Richard A",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Goode, Virgil",1,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Hoefling, Tom",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Knill, Dennis J",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Reed, Jill A.",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Rogers, Rick L",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Stein, Jill E",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Thorne, Kevin M",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Warner, Gerald L.",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,Democratic,"Obama, Barack",88,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,Libertarian,"Johnson, Gary",4,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,Reform,"Baldwin, Chuck",1,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,Republican,"Romney, Mitt",134,200010
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Ayers, Avery L",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Barnett, Andre",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Barr, Roseanne C",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Bush, Kent W",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Christensen, Will",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Duncan, Richard A",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Goode, Virgil",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Hoefling, Tom",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Knill, Dennis J",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Reed, Jill A.",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Rogers, Rick L",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Stein, Jill E",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Thorne, Kevin M",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Warner, Gerald L.",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,Democratic,"Obama, Barack",73,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,Libertarian,"Johnson, Gary",2,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,Reform,"Baldwin, Chuck",3,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,Republican,"Romney, Mitt",108,200020
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Christensen, Will",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,Democratic,"Obama, Barack",43,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",1,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,Republican,"Romney, Mitt",158,200030
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Ayers, Avery L",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Barnett, Andre",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Barr, Roseanne C",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Bush, Kent W",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Christensen, Will",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Duncan, Richard A",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Goode, Virgil",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Hoefling, Tom",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Knill, Dennis J",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Reed, Jill A.",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Rogers, Rick L",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Stein, Jill E",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Thorne, Kevin M",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Warner, Gerald L.",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,Democratic,"Obama, Barack",286,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,Libertarian,"Johnson, Gary",17,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,Reform,"Baldwin, Chuck",1,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,Republican,"Romney, Mitt",553,200040
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Ayers, Avery L",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Barnett, Andre",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Barr, Roseanne C",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Bush, Kent W",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Christensen, Will",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Duncan, Richard A",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Goode, Virgil",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Hoefling, Tom",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Knill, Dennis J",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Reed, Jill A.",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Rogers, Rick L",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Stein, Jill E",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Thorne, Kevin M",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Warner, Gerald L.",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,Democratic,"Obama, Barack",60,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,Libertarian,"Johnson, Gary",4,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,Reform,"Baldwin, Chuck",1,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,Republican,"Romney, Mitt",127,200050
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Ayers, Avery L",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Barnett, Andre",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Barr, Roseanne C",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Bush, Kent W",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Christensen, Will",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Duncan, Richard A",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Goode, Virgil",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Hoefling, Tom",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Knill, Dennis J",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Reed, Jill A.",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Rogers, Rick L",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Stein, Jill E",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Thorne, Kevin M",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Warner, Gerald L.",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,Democratic,"Obama, Barack",39,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,Libertarian,"Johnson, Gary",4,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,Reform,"Baldwin, Chuck",3,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,Republican,"Romney, Mitt",30,200060
+RENO,Albion Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",321,000010
+RENO,Arlington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",173,000020
+RENO,Bell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000030
+RENO,Castleton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",123,000040
+RENO,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",148,000050
+RENO,Enterprise Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",58,000060
+RENO,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",638,000070
+RENO,Grove Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000080
+RENO,Haven Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",572,000090
+RENO,Hayes Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000100
+RENO,Huntsville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",49,000110
+RENO,Hutchinson Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",142,000130
+RENO,Hutchinson Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",91,000140
+RENO,Hutchinson Precinct 04,United States House of Representatives,1,Republican,"Huelskamp, Tim",644,000150
+RENO,Hutchinson Precinct 05,United States House of Representatives,1,Republican,"Huelskamp, Tim",268,000160
+RENO,Hutchinson Precinct 06,United States House of Representatives,1,Republican,"Huelskamp, Tim",247,000170
+RENO,Hutchinson Precinct 07,United States House of Representatives,1,Republican,"Huelskamp, Tim",334,000180
+RENO,Hutchinson Precinct 09,United States House of Representatives,1,Republican,"Huelskamp, Tim",490,000200
+RENO,Hutchinson Precinct 10,United States House of Representatives,1,Republican,"Huelskamp, Tim",555,000210
+RENO,Hutchinson Precinct 11,United States House of Representatives,1,Republican,"Huelskamp, Tim",556,000220
+RENO,Hutchinson Precinct 12,United States House of Representatives,1,Republican,"Huelskamp, Tim",331,000230
+RENO,Hutchinson Precinct 13,United States House of Representatives,1,Republican,"Huelskamp, Tim",396,000240
+RENO,Hutchinson Precinct 14,United States House of Representatives,1,Republican,"Huelskamp, Tim",305,000250
+RENO,Hutchinson Precinct 15,United States House of Representatives,1,Republican,"Huelskamp, Tim",168,000260
+RENO,Hutchinson Precinct 16,United States House of Representatives,1,Republican,"Huelskamp, Tim",334,000270
+RENO,Hutchinson Precinct 17,United States House of Representatives,1,Republican,"Huelskamp, Tim",429,000280
+RENO,Hutchinson Precinct 18,United States House of Representatives,1,Republican,"Huelskamp, Tim",155,000290
+RENO,Hutchinson Precinct 19,United States House of Representatives,1,Republican,"Huelskamp, Tim",181,000300
+RENO,Hutchinson Precinct 20,United States House of Representatives,1,Republican,"Huelskamp, Tim",313,000310
+RENO,Hutchinson Precinct 21,United States House of Representatives,1,Republican,"Huelskamp, Tim",242,000320
+RENO,Hutchinson Precinct 22,United States House of Representatives,1,Republican,"Huelskamp, Tim",511,000330
+RENO,Hutchinson Precinct 24,United States House of Representatives,1,Republican,"Huelskamp, Tim",417,000350
+RENO,Hutchinson Precinct 25,United States House of Representatives,1,Republican,"Huelskamp, Tim",235,000360
+RENO,Hutchinson Precinct 26,United States House of Representatives,1,Republican,"Huelskamp, Tim",162,00037A
+RENO,Hutchinson Precinct 26 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,00037B
+RENO,Hutchinson Precinct 27,United States House of Representatives,1,Republican,"Huelskamp, Tim",313,000380
+RENO,Hutchinson Precinct 28,United States House of Representatives,1,Republican,"Huelskamp, Tim",682,00039A
+RENO,Hutchinson Precinct 28 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",299,00039B
+RENO,Hutchinson Precinct 29,United States House of Representatives,1,Republican,"Huelskamp, Tim",281,000400
+RENO,Hutchinson Precinct 30,United States House of Representatives,1,Republican,"Huelskamp, Tim",164,000410
+RENO,Hutchinson Precinct 31,United States House of Representatives,1,Republican,"Huelskamp, Tim",288,000420
+RENO,Hutchinson Precinct 32,United States House of Representatives,1,Republican,"Huelskamp, Tim",85,000430
+RENO,Langdon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000440
+RENO,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",152,000450
+RENO,Little River Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",824,000460
+RENO,Loda Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000470
+RENO,Medford Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",69,000480
+RENO,Medora Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",692,000490
+RENO,Miami Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",120,000500
+RENO,Nickerson Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",136,000510
+RENO,Nickerson Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",81,000520
+RENO,Nickerson Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",98,000530
+RENO,Ninnescah Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",79,000540
+RENO,North Clay Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",354,00055A
+RENO,North Reno Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",567,000560
+RENO,Plevna Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",100,000570
+RENO,Roscoe Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000580
+RENO,Salt Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",147,000590
+RENO,South Clay Township Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00060B
+RENO,South Hutchinson Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",179,000610
+RENO,South Hutchinson Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",341,000620
+RENO,South Hutchinson Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",219,000630
+RENO,South Reno Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",103,000640
+RENO,Sumner Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",237,000650
+RENO,Sylvia Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",125,000660
+RENO,Troy Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,000670
+RENO,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",345,000680
+RENO,Walnut Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000690
+RENO,Westminister Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",86,000700
+RENO,Yoder Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",213,000710
+RENO,Hutchinson Precinct 01 H102,United States House of Representatives,1,Republican,"Huelskamp, Tim",179,120020
+RENO,Hutchinson Precinct 01 H114,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,120030
+RENO,South Clay Township H101,United States House of Representatives,1,Republican,"Huelskamp, Tim",415,120040
+RENO,South Clay Township Clay H102 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",2,12005A
+RENO,South Clay Township H102,United States House of Representatives,1,Republican,"Huelskamp, Tim",1,120050
+RENO,Hutchinson Precinct 08 H101,United States House of Representatives,1,Republican,"Huelskamp, Tim",178,200010
+RENO,Hutchinson Precinct 35,United States House of Representatives,1,Republican,"Huelskamp, Tim",117,200020
+RENO,Hutchinson Precinct 23 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",172,200030
+RENO,Hutchinson Precinct 23 H104,United States House of Representatives,1,Republican,"Huelskamp, Tim",670,200040
+RENO,Hutchinson Precinct 33,United States House of Representatives,1,Republican,"Huelskamp, Tim",159,200050
+RENO,Hutchinson Precinct 34,United States House of Representatives,1,Republican,"Huelskamp, Tim",56,200060

--- a/2012/20121106__ks__general__republic__precinct.csv
+++ b/2012/20121106__ks__general__republic__precinct.csv
@@ -1,0 +1,651 @@
+county,precinct,office,district,party,candidate,votes,vtd
+REPUBLIC,Albion Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",39,000010
+REPUBLIC,Albion Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",37,000010
+REPUBLIC,Beaver Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",27,000020
+REPUBLIC,Beaver Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",19,000020
+REPUBLIC,Belleville Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",62,000030
+REPUBLIC,Belleville Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",77,000030
+REPUBLIC,Belleville Ward 1,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",198,000040
+REPUBLIC,Belleville Ward 1,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",158,000040
+REPUBLIC,Belleville Ward 2,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",223,00005A
+REPUBLIC,Belleville Ward 2,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",179,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",0,00005B
+REPUBLIC,Belleville Ward 3,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",101,00006A
+REPUBLIC,Belleville Ward 3,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",95,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",0,00006B
+REPUBLIC,Big Bend Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",38,000070
+REPUBLIC,Big Bend Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",49,000070
+REPUBLIC,Courtland Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",154,000080
+REPUBLIC,Courtland Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",77,000080
+REPUBLIC,Elk Creek Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",37,000090
+REPUBLIC,Elk Creek Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",43,000090
+REPUBLIC,Fairview Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",50,000100
+REPUBLIC,Fairview Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",39,000100
+REPUBLIC,Farmington Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",10,000110
+REPUBLIC,Farmington Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",23,000110
+REPUBLIC,Freedom Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",48,00012A
+REPUBLIC,Freedom Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",61,00012A
+REPUBLIC,Freedom Township Enclave,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",0,00012B
+REPUBLIC,Freedom Township Enclave,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",0,00012B
+REPUBLIC,Grant Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",18,000130
+REPUBLIC,Grant Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",19,000130
+REPUBLIC,Jefferson Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",36,000140
+REPUBLIC,Jefferson Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",19,000140
+REPUBLIC,Liberty Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",18,000150
+REPUBLIC,Liberty Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",15,000150
+REPUBLIC,Lincoln Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",24,000160
+REPUBLIC,Lincoln Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",24,000160
+REPUBLIC,Norway Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",32,000170
+REPUBLIC,Norway Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",44,000170
+REPUBLIC,Richland Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",94,000180
+REPUBLIC,Richland Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",54,000180
+REPUBLIC,Rose Creek Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",38,000190
+REPUBLIC,Rose Creek Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",33,000190
+REPUBLIC,Scandia Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",146,000200
+REPUBLIC,Scandia Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",98,000200
+REPUBLIC,Union Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",10,000210
+REPUBLIC,Union Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",11,000210
+REPUBLIC,Washington Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",19,000220
+REPUBLIC,Washington Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",26,000220
+REPUBLIC,White Rock Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",20,000230
+REPUBLIC,White Rock Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",28,000230
+REPUBLIC,Albion Township,Kansas Senate,36,Democratic,"Clark, Marquis",11,000010
+REPUBLIC,Albion Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",64,000010
+REPUBLIC,Beaver Township,Kansas Senate,36,Democratic,"Clark, Marquis",6,000020
+REPUBLIC,Beaver Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",40,000020
+REPUBLIC,Belleville Township,Kansas Senate,36,Democratic,"Clark, Marquis",10,000030
+REPUBLIC,Belleville Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",127,000030
+REPUBLIC,Belleville Ward 1,Kansas Senate,36,Democratic,"Clark, Marquis",64,000040
+REPUBLIC,Belleville Ward 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",280,000040
+REPUBLIC,Belleville Ward 2,Kansas Senate,36,Democratic,"Clark, Marquis",55,00005A
+REPUBLIC,Belleville Ward 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",335,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,Kansas Senate,36,Democratic,"Clark, Marquis",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00005B
+REPUBLIC,Belleville Ward 3,Kansas Senate,36,Democratic,"Clark, Marquis",28,00006A
+REPUBLIC,Belleville Ward 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",167,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Kansas Senate,36,Democratic,"Clark, Marquis",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00006B
+REPUBLIC,Big Bend Township,Kansas Senate,36,Democratic,"Clark, Marquis",11,000070
+REPUBLIC,Big Bend Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",73,000070
+REPUBLIC,Courtland Township,Kansas Senate,36,Democratic,"Clark, Marquis",34,000080
+REPUBLIC,Courtland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",191,000080
+REPUBLIC,Elk Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000090
+REPUBLIC,Elk Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",73,000090
+REPUBLIC,Fairview Township,Kansas Senate,36,Democratic,"Clark, Marquis",13,000100
+REPUBLIC,Fairview Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",75,000100
+REPUBLIC,Farmington Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000110
+REPUBLIC,Farmington Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",29,000110
+REPUBLIC,Freedom Township,Kansas Senate,36,Democratic,"Clark, Marquis",6,00012A
+REPUBLIC,Freedom Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",100,00012A
+REPUBLIC,Freedom Township Enclave,Kansas Senate,36,Democratic,"Clark, Marquis",0,00012B
+REPUBLIC,Freedom Township Enclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00012B
+REPUBLIC,Grant Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000130
+REPUBLIC,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",36,000130
+REPUBLIC,Jefferson Township,Kansas Senate,36,Democratic,"Clark, Marquis",14,000140
+REPUBLIC,Jefferson Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",40,000140
+REPUBLIC,Liberty Township,Kansas Senate,36,Democratic,"Clark, Marquis",5,000150
+REPUBLIC,Liberty Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",27,000150
+REPUBLIC,Lincoln Township,Kansas Senate,36,Democratic,"Clark, Marquis",5,000160
+REPUBLIC,Lincoln Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",43,000160
+REPUBLIC,Norway Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000170
+REPUBLIC,Norway Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",74,000170
+REPUBLIC,Richland Township,Kansas Senate,36,Democratic,"Clark, Marquis",12,000180
+REPUBLIC,Richland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",129,000180
+REPUBLIC,Rose Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",12,000190
+REPUBLIC,Rose Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",57,000190
+REPUBLIC,Scandia Township,Kansas Senate,36,Democratic,"Clark, Marquis",35,000200
+REPUBLIC,Scandia Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",204,000200
+REPUBLIC,Union Township,Kansas Senate,36,Democratic,"Clark, Marquis",5,000210
+REPUBLIC,Union Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000210
+REPUBLIC,Washington Township,Kansas Senate,36,Democratic,"Clark, Marquis",5,000220
+REPUBLIC,Washington Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",38,000220
+REPUBLIC,White Rock Township,Kansas Senate,36,Democratic,"Clark, Marquis",6,000230
+REPUBLIC,White Rock Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",40,000230
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+REPUBLIC,Albion Township,President / Vice President,,Democratic,"Obama, Barack",17,000010
+REPUBLIC,Albion Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+REPUBLIC,Albion Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+REPUBLIC,Albion Township,President / Vice President,,Republican,"Romney, Mitt",59,000010
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,Democratic,"Obama, Barack",8,000020
+REPUBLIC,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+REPUBLIC,Beaver Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,Republican,"Romney, Mitt",36,000020
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,Democratic,"Obama, Barack",12,000030
+REPUBLIC,Belleville Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+REPUBLIC,Belleville Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,Republican,"Romney, Mitt",126,000030
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,Democratic,"Obama, Barack",72,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,Republican,"Romney, Mitt",271,000040
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,Democratic,"Obama, Barack",86,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",9,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",5,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,Republican,"Romney, Mitt",310,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Ayers, Avery L",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Barnett, Andre",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Barr, Roseanne C",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Bush, Kent W",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Christensen, Will",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Duncan, Richard A",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Goode, Virgil",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Knill, Dennis J",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Reed, Jill A.",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Rogers, Rick L",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Stein, Jill E",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Thorne, Kevin M",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Warner, Gerald L.",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,Democratic,"Obama, Barack",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,Reform,"Baldwin, Chuck",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,Republican,"Romney, Mitt",0,00005B
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,Democratic,"Obama, Barack",38,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",2,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",4,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,Republican,"Romney, Mitt",155,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Ayers, Avery L",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Barnett, Andre",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Barr, Roseanne C",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Bush, Kent W",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Christensen, Will",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Duncan, Richard A",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Goode, Virgil",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Knill, Dennis J",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Reed, Jill A.",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Rogers, Rick L",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Stein, Jill E",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Thorne, Kevin M",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Warner, Gerald L.",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,Democratic,"Obama, Barack",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,Reform,"Baldwin, Chuck",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,Republican,"Romney, Mitt",0,00006B
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,Democratic,"Obama, Barack",13,000070
+REPUBLIC,Big Bend Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+REPUBLIC,Big Bend Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+REPUBLIC,Big Bend Township,President / Vice President,,Republican,"Romney, Mitt",73,000070
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,Democratic,"Obama, Barack",41,000080
+REPUBLIC,Courtland Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000080
+REPUBLIC,Courtland Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000080
+REPUBLIC,Courtland Township,President / Vice President,,Republican,"Romney, Mitt",183,000080
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,Democratic,"Obama, Barack",13,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,Republican,"Romney, Mitt",66,000090
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,Democratic,"Obama, Barack",13,000100
+REPUBLIC,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+REPUBLIC,Fairview Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000100
+REPUBLIC,Fairview Township,President / Vice President,,Republican,"Romney, Mitt",72,000100
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,Democratic,"Obama, Barack",5,000110
+REPUBLIC,Farmington Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,Republican,"Romney, Mitt",28,000110
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Ayers, Avery L",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Barnett, Andre",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Bush, Kent W",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Christensen, Will",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Duncan, Richard A",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Goode, Virgil",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Knill, Dennis J",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Reed, Jill A.",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Rogers, Rick L",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Stein, Jill E",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,Democratic,"Obama, Barack",10,00012A
+REPUBLIC,Freedom Township,President / Vice President,,Libertarian,"Johnson, Gary",2,00012A
+REPUBLIC,Freedom Township,President / Vice President,,Reform,"Baldwin, Chuck",1,00012A
+REPUBLIC,Freedom Township,President / Vice President,,Republican,"Romney, Mitt",96,00012A
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Christensen, Will",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00012B
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+REPUBLIC,Grant Township,President / Vice President,,Democratic,"Obama, Barack",5,000130
+REPUBLIC,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+REPUBLIC,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+REPUBLIC,Grant Township,President / Vice President,,Republican,"Romney, Mitt",33,000130
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,Democratic,"Obama, Barack",14,000140
+REPUBLIC,Jefferson Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000140
+REPUBLIC,Jefferson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,Republican,"Romney, Mitt",39,000140
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",2,000150
+REPUBLIC,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",31,000150
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",5,000160
+REPUBLIC,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000160
+REPUBLIC,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",42,000160
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+REPUBLIC,Norway Township,President / Vice President,,Democratic,"Obama, Barack",7,000170
+REPUBLIC,Norway Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+REPUBLIC,Norway Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+REPUBLIC,Norway Township,President / Vice President,,Republican,"Romney, Mitt",69,000170
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+REPUBLIC,Richland Township,President / Vice President,,Democratic,"Obama, Barack",31,000180
+REPUBLIC,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+REPUBLIC,Richland Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000180
+REPUBLIC,Richland Township,President / Vice President,,Republican,"Romney, Mitt",111,000180
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,Democratic,"Obama, Barack",12,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,Republican,"Romney, Mitt",56,000190
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,Democratic,"Obama, Barack",55,000200
+REPUBLIC,Scandia Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000200
+REPUBLIC,Scandia Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,Republican,"Romney, Mitt",183,000200
+REPUBLIC,Union Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+REPUBLIC,Union Township,President / Vice President,,Democratic,"Obama, Barack",4,000210
+REPUBLIC,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+REPUBLIC,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+REPUBLIC,Union Township,President / Vice President,,Republican,"Romney, Mitt",18,000210
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+REPUBLIC,Washington Township,President / Vice President,,Democratic,"Obama, Barack",4,000220
+REPUBLIC,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000220
+REPUBLIC,Washington Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+REPUBLIC,Washington Township,President / Vice President,,Republican,"Romney, Mitt",40,000220
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,Democratic,"Obama, Barack",10,000230
+REPUBLIC,White Rock Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+REPUBLIC,White Rock Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,Republican,"Romney, Mitt",37,000230
+REPUBLIC,Albion Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",62,000010
+REPUBLIC,Beaver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000020
+REPUBLIC,Belleville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",125,000030
+REPUBLIC,Belleville Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",282,000040
+REPUBLIC,Belleville Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",349,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00005B
+REPUBLIC,Belleville Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",169,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00006B
+REPUBLIC,Big Bend Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",70,000070
+REPUBLIC,Courtland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",186,000080
+REPUBLIC,Elk Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",69,000090
+REPUBLIC,Fairview Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",63,000100
+REPUBLIC,Farmington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000110
+REPUBLIC,Freedom Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",99,00012A
+REPUBLIC,Freedom Township Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00012B
+REPUBLIC,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000130
+REPUBLIC,Jefferson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000140
+REPUBLIC,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000150
+REPUBLIC,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000160
+REPUBLIC,Norway Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",69,000170
+REPUBLIC,Richland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",110,000180
+REPUBLIC,Rose Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",60,000190
+REPUBLIC,Scandia Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",205,000200
+REPUBLIC,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000210
+REPUBLIC,Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",41,000220
+REPUBLIC,White Rock Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000230

--- a/2012/20121106__ks__general__rice__precinct.csv
+++ b/2012/20121106__ks__general__rice__precinct.csv
@@ -1,0 +1,674 @@
+county,precinct,office,district,party,candidate,votes,vtd
+RICE,Atlanta Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",64,000010
+RICE,Bell Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",1,000020
+RICE,Center Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",43,000030
+RICE,East Washington Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",13,000040
+RICE,East Washington Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",47,000040
+RICE,Eureka Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",21,000050
+RICE,Farmer Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",139,000060
+RICE,Galt Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",42,000070
+RICE,Harrison Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",81,000080
+RICE,Lincoln Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",146,000090
+RICE,Lyons Ward 1,Kansas House of Representatives,113,Republican,"Christmann, Marshall",357,000100
+RICE,Lyons Ward 2,Kansas House of Representatives,113,Republican,"Christmann, Marshall",225,000110
+RICE,Lyons Ward 3,Kansas House of Representatives,113,Republican,"Christmann, Marshall",185,000120
+RICE,Lyons Ward 4,Kansas House of Representatives,113,Republican,"Christmann, Marshall",208,000130
+RICE,Mitchell Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",65,000140
+RICE,Odessa Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",28,000150
+RICE,Pioneer Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",24,000160
+RICE,Raymond Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",64,000170
+RICE,Rockville Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",21,000180
+RICE,Rockville Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",42,000180
+RICE,Sterling City East Ward,Kansas House of Representatives,114,Democratic,"Moore, Carol",201,00019A
+RICE,Sterling City East Ward,Kansas House of Representatives,114,Republican,"Thimesch, Jack",313,00019A
+RICE,Sterling City East Ward Exclave A,Kansas House of Representatives,114,Democratic,"Moore, Carol",0,00019B
+RICE,Sterling City East Ward Exclave A,Kansas House of Representatives,114,Republican,"Thimesch, Jack",0,00019B
+RICE,Sterling City East Ward Exclave B,Kansas House of Representatives,114,Democratic,"Moore, Carol",0,00019C
+RICE,Sterling City East Ward Exclave B,Kansas House of Representatives,114,Republican,"Thimesch, Jack",0,00019C
+RICE,Sterling City West Ward,Kansas House of Representatives,114,Democratic,"Moore, Carol",117,000200
+RICE,Sterling City West Ward,Kansas House of Representatives,114,Republican,"Thimesch, Jack",171,000200
+RICE,Sterling Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",22,000210
+RICE,Sterling Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",53,000210
+RICE,Union Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",275,000220
+RICE,Valley Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",78,000230
+RICE,Victoria Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",105,000240
+RICE,West Washington Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",22,000250
+RICE,West Washington Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",36,000250
+RICE,Wilson Township,Kansas House of Representatives,114,Democratic,"Moore, Carol",23,000260
+RICE,Wilson Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",38,000260
+RICE,Atlanta Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",13,000010
+RICE,Atlanta Township,Kansas Senate,35,Republican,"Emler, Jay Scott",54,000010
+RICE,Bell Township,Kansas Senate,33,Republican,"Holmes, Mitch",1,000020
+RICE,Center Township,Kansas Senate,33,Republican,"Holmes, Mitch",41,000030
+RICE,East Washington Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",13,000040
+RICE,East Washington Township,Kansas Senate,35,Republican,"Emler, Jay Scott",44,000040
+RICE,Eureka Township,Kansas Senate,33,Republican,"Holmes, Mitch",20,000050
+RICE,Farmer Township,Kansas Senate,33,Republican,"Holmes, Mitch",139,000060
+RICE,Galt Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",12,000070
+RICE,Galt Township,Kansas Senate,35,Republican,"Emler, Jay Scott",36,000070
+RICE,Harrison Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",11,000080
+RICE,Harrison Township,Kansas Senate,35,Republican,"Emler, Jay Scott",76,000080
+RICE,Lincoln Township,Kansas Senate,33,Republican,"Holmes, Mitch",151,000090
+RICE,Lyons Ward 1,Kansas Senate,35,Libertarian,"Bryant, Jesse",59,000100
+RICE,Lyons Ward 1,Kansas Senate,35,Republican,"Emler, Jay Scott",354,000100
+RICE,Lyons Ward 2,Kansas Senate,35,Libertarian,"Bryant, Jesse",59,000110
+RICE,Lyons Ward 2,Kansas Senate,35,Republican,"Emler, Jay Scott",197,000110
+RICE,Lyons Ward 3,Kansas Senate,35,Libertarian,"Bryant, Jesse",51,000120
+RICE,Lyons Ward 3,Kansas Senate,35,Republican,"Emler, Jay Scott",150,000120
+RICE,Lyons Ward 4,Kansas Senate,35,Libertarian,"Bryant, Jesse",63,000130
+RICE,Lyons Ward 4,Kansas Senate,35,Republican,"Emler, Jay Scott",174,000130
+RICE,Mitchell Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",9,000140
+RICE,Mitchell Township,Kansas Senate,35,Republican,"Emler, Jay Scott",59,000140
+RICE,Odessa Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",4,000150
+RICE,Odessa Township,Kansas Senate,35,Republican,"Emler, Jay Scott",28,000150
+RICE,Pioneer Township,Kansas Senate,33,Republican,"Holmes, Mitch",25,000160
+RICE,Raymond Township,Kansas Senate,33,Republican,"Holmes, Mitch",62,000170
+RICE,Rockville Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",17,000180
+RICE,Rockville Township,Kansas Senate,35,Republican,"Emler, Jay Scott",48,000180
+RICE,Sterling City East Ward,Kansas Senate,35,Libertarian,"Bryant, Jesse",85,00019A
+RICE,Sterling City East Ward,Kansas Senate,35,Republican,"Emler, Jay Scott",415,00019A
+RICE,Sterling City East Ward Exclave A,Kansas Senate,35,Libertarian,"Bryant, Jesse",0,00019B
+RICE,Sterling City East Ward Exclave A,Kansas Senate,35,Republican,"Emler, Jay Scott",0,00019B
+RICE,Sterling City East Ward Exclave B,Kansas Senate,35,Libertarian,"Bryant, Jesse",0,00019C
+RICE,Sterling City East Ward Exclave B,Kansas Senate,35,Republican,"Emler, Jay Scott",0,00019C
+RICE,Sterling City West Ward,Kansas Senate,35,Libertarian,"Bryant, Jesse",63,000200
+RICE,Sterling City West Ward,Kansas Senate,35,Republican,"Emler, Jay Scott",215,000200
+RICE,Sterling Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",13,000210
+RICE,Sterling Township,Kansas Senate,35,Republican,"Emler, Jay Scott",62,000210
+RICE,Union Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",54,000220
+RICE,Union Township,Kansas Senate,35,Republican,"Emler, Jay Scott",239,000220
+RICE,Valley Township,Kansas Senate,33,Republican,"Holmes, Mitch",75,000230
+RICE,Victoria Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",30,000240
+RICE,Victoria Township,Kansas Senate,35,Republican,"Emler, Jay Scott",90,000240
+RICE,West Washington Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",13,000250
+RICE,West Washington Township,Kansas Senate,35,Republican,"Emler, Jay Scott",44,000250
+RICE,Wilson Township,Kansas Senate,35,Libertarian,"Bryant, Jesse",3,000260
+RICE,Wilson Township,Kansas Senate,35,Republican,"Emler, Jay Scott",57,000260
+RICE,Atlanta Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+RICE,Atlanta Township,President / Vice President,,Democratic,"Obama, Barack",7,000010
+RICE,Atlanta Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+RICE,Atlanta Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000010
+RICE,Atlanta Township,President / Vice President,,Republican,"Romney, Mitt",58,000010
+RICE,Bell Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+RICE,Bell Township,President / Vice President,,Democratic,"Obama, Barack",0,000020
+RICE,Bell Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+RICE,Bell Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+RICE,Bell Township,President / Vice President,,Republican,"Romney, Mitt",1,000020
+RICE,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+RICE,Center Township,President / Vice President,,Democratic,"Obama, Barack",5,000030
+RICE,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+RICE,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+RICE,Center Township,President / Vice President,,Republican,"Romney, Mitt",46,000030
+RICE,East Washington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+RICE,East Washington Township,President / Vice President,,Democratic,"Obama, Barack",13,000040
+RICE,East Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+RICE,East Washington Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+RICE,East Washington Township,President / Vice President,,Republican,"Romney, Mitt",49,000040
+RICE,Eureka Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+RICE,Eureka Township,President / Vice President,,Democratic,"Obama, Barack",2,000050
+RICE,Eureka Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+RICE,Eureka Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+RICE,Eureka Township,President / Vice President,,Republican,"Romney, Mitt",21,000050
+RICE,Farmer Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+RICE,Farmer Township,President / Vice President,,Democratic,"Obama, Barack",36,000060
+RICE,Farmer Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000060
+RICE,Farmer Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+RICE,Farmer Township,President / Vice President,,Republican,"Romney, Mitt",125,000060
+RICE,Galt Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+RICE,Galt Township,President / Vice President,,Democratic,"Obama, Barack",10,000070
+RICE,Galt Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+RICE,Galt Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+RICE,Galt Township,President / Vice President,,Republican,"Romney, Mitt",38,000070
+RICE,Harrison Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+RICE,Harrison Township,President / Vice President,,Democratic,"Obama, Barack",6,000080
+RICE,Harrison Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+RICE,Harrison Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+RICE,Harrison Township,President / Vice President,,Republican,"Romney, Mitt",80,000080
+RICE,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+RICE,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",42,000090
+RICE,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+RICE,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000090
+RICE,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",133,000090
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+RICE,Lyons Ward 1,President / Vice President,,Democratic,"Obama, Barack",136,000100
+RICE,Lyons Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000100
+RICE,Lyons Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000100
+RICE,Lyons Ward 1,President / Vice President,,Republican,"Romney, Mitt",304,000100
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+RICE,Lyons Ward 2,President / Vice President,,Democratic,"Obama, Barack",106,000110
+RICE,Lyons Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",8,000110
+RICE,Lyons Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+RICE,Lyons Ward 2,President / Vice President,,Republican,"Romney, Mitt",150,000110
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+RICE,Lyons Ward 3,President / Vice President,,Democratic,"Obama, Barack",76,000120
+RICE,Lyons Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",8,000120
+RICE,Lyons Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",3,000120
+RICE,Lyons Ward 3,President / Vice President,,Republican,"Romney, Mitt",129,000120
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+RICE,Lyons Ward 4,President / Vice President,,Democratic,"Obama, Barack",63,000130
+RICE,Lyons Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",6,000130
+RICE,Lyons Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",2,000130
+RICE,Lyons Ward 4,President / Vice President,,Republican,"Romney, Mitt",185,000130
+RICE,Mitchell Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+RICE,Mitchell Township,President / Vice President,,Democratic,"Obama, Barack",20,000140
+RICE,Mitchell Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+RICE,Mitchell Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+RICE,Mitchell Township,President / Vice President,,Republican,"Romney, Mitt",55,000140
+RICE,Odessa Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+RICE,Odessa Township,President / Vice President,,Democratic,"Obama, Barack",2,000150
+RICE,Odessa Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+RICE,Odessa Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+RICE,Odessa Township,President / Vice President,,Republican,"Romney, Mitt",30,000150
+RICE,Pioneer Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+RICE,Pioneer Township,President / Vice President,,Democratic,"Obama, Barack",5,000160
+RICE,Pioneer Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+RICE,Pioneer Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+RICE,Pioneer Township,President / Vice President,,Republican,"Romney, Mitt",22,000160
+RICE,Raymond Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+RICE,Raymond Township,President / Vice President,,Democratic,"Obama, Barack",12,000170
+RICE,Raymond Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000170
+RICE,Raymond Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000170
+RICE,Raymond Township,President / Vice President,,Republican,"Romney, Mitt",58,000170
+RICE,Rockville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+RICE,Rockville Township,President / Vice President,,Democratic,"Obama, Barack",16,000180
+RICE,Rockville Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+RICE,Rockville Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+RICE,Rockville Township,President / Vice President,,Republican,"Romney, Mitt",53,000180
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Ayers, Avery L",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Barnett, Andre",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Barr, Roseanne C",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Bush, Kent W",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Christensen, Will",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Duncan, Richard A",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Goode, Virgil",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Knill, Dennis J",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Reed, Jill A.",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Rogers, Rick L",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Stein, Jill E",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Thorne, Kevin M",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Warner, Gerald L.",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,Democratic,"Obama, Barack",115,00019A
+RICE,Sterling City East Ward,President / Vice President,,Libertarian,"Johnson, Gary",14,00019A
+RICE,Sterling City East Ward,President / Vice President,,Reform,"Baldwin, Chuck",3,00019A
+RICE,Sterling City East Ward,President / Vice President,,Republican,"Romney, Mitt",391,00019A
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Christensen, Will",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,00019B
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Christensen, Will",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,Democratic,"Obama, Barack",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,Republican,"Romney, Mitt",0,00019C
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Barnett, Andre",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Bush, Kent W",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Christensen, Will",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Goode, Virgil",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Stein, Jill E",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+RICE,Sterling City West Ward,President / Vice President,,Democratic,"Obama, Barack",85,000200
+RICE,Sterling City West Ward,President / Vice President,,Libertarian,"Johnson, Gary",8,000200
+RICE,Sterling City West Ward,President / Vice President,,Reform,"Baldwin, Chuck",3,000200
+RICE,Sterling City West Ward,President / Vice President,,Republican,"Romney, Mitt",191,000200
+RICE,Sterling Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+RICE,Sterling Township,President / Vice President,,Democratic,"Obama, Barack",14,000210
+RICE,Sterling Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000210
+RICE,Sterling Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+RICE,Sterling Township,President / Vice President,,Republican,"Romney, Mitt",60,000210
+RICE,Union Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+RICE,Union Township,President / Vice President,,Democratic,"Obama, Barack",55,000220
+RICE,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000220
+RICE,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000220
+RICE,Union Township,President / Vice President,,Republican,"Romney, Mitt",245,000220
+RICE,Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+RICE,Valley Township,President / Vice President,,Democratic,"Obama, Barack",23,000230
+RICE,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000230
+RICE,Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000230
+RICE,Valley Township,President / Vice President,,Republican,"Romney, Mitt",66,000230
+RICE,Victoria Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+RICE,Victoria Township,President / Vice President,,Democratic,"Obama, Barack",33,000240
+RICE,Victoria Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000240
+RICE,Victoria Township,President / Vice President,,Reform,"Baldwin, Chuck",5,000240
+RICE,Victoria Township,President / Vice President,,Republican,"Romney, Mitt",93,000240
+RICE,West Washington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+RICE,West Washington Township,President / Vice President,,Democratic,"Obama, Barack",18,000250
+RICE,West Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000250
+RICE,West Washington Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+RICE,West Washington Township,President / Vice President,,Republican,"Romney, Mitt",43,000250
+RICE,Wilson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Barnett, Andre",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Bush, Kent W",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Christensen, Will",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Goode, Virgil",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Stein, Jill E",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+RICE,Wilson Township,President / Vice President,,Democratic,"Obama, Barack",11,000260
+RICE,Wilson Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000260
+RICE,Wilson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000260
+RICE,Wilson Township,President / Vice President,,Republican,"Romney, Mitt",50,000260
+RICE,Atlanta Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",60,000010
+RICE,Bell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",1,000020
+RICE,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000030
+RICE,East Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,000040
+RICE,Eureka Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000050
+RICE,Farmer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",141,000060
+RICE,Galt Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000070
+RICE,Harrison Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",80,000080
+RICE,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",150,000090
+RICE,Lyons Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",362,000100
+RICE,Lyons Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",215,000110
+RICE,Lyons Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",178,000120
+RICE,Lyons Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",213,000130
+RICE,Mitchell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",59,000140
+RICE,Odessa Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000150
+RICE,Pioneer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000160
+RICE,Raymond Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,000170
+RICE,Rockville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",56,000180
+RICE,Sterling City East Ward,United States House of Representatives,1,Republican,"Huelskamp, Tim",450,00019A
+RICE,Sterling City East Ward Exclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00019B
+RICE,Sterling City East Ward Exclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00019C
+RICE,Sterling City West Ward,United States House of Representatives,1,Republican,"Huelskamp, Tim",240,000200
+RICE,Sterling Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",72,000210
+RICE,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",277,000220
+RICE,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",75,000230
+RICE,Victoria Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",111,000240
+RICE,West Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,000250
+RICE,Wilson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000260

--- a/2012/20121106__ks__general__riley__precinct.csv
+++ b/2012/20121106__ks__general__riley__precinct.csv
@@ -1,0 +1,1915 @@
+county,precinct,office,district,party,candidate,votes,vtd
+RILEY,Ashland Township,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",34,000010
+RILEY,Ashland Township,Kansas House of Representatives,67,Republican,"Phillips, Tom",68,000010
+RILEY,Bala Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",59,000020
+RILEY,Bala Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",250,000020
+RILEY,Center Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",5,000030
+RILEY,Center Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",38,000030
+RILEY,Fancy Creek Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",15,000040
+RILEY,Fancy Creek Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",50,000040
+RILEY,Fort Riley B Madison Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",24,00005B
+RILEY,Fort Riley B Madison Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",36,00005B
+RILEY,Grant Township,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",156,000060
+RILEY,Grant Township,Kansas House of Representatives,67,Republican,"Phillips, Tom",419,000060
+RILEY,Jackson Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",34,000070
+RILEY,Jackson Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",113,000070
+RILEY,Manhattan City Ward 02 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",203,000120
+RILEY,Manhattan City Ward 02 Precinct 02,Kansas House of Representatives,66,Republican,"Modesitt, Lee",94,000120
+RILEY,Manhattan City Ward 02 Precinct 04,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",335,000140
+RILEY,Manhattan City Ward 02 Precinct 04,Kansas House of Representatives,66,Republican,"Modesitt, Lee",326,000140
+RILEY,Manhattan City Ward 03 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",224,000170
+RILEY,Manhattan City Ward 03 Precinct 02,Kansas House of Representatives,66,Republican,"Modesitt, Lee",171,000170
+RILEY,Manhattan City Ward 04 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",149,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,Kansas House of Representatives,66,Republican,"Modesitt, Lee",108,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",330,000230
+RILEY,Manhattan City Ward 04 Precinct 03,Kansas House of Representatives,67,Republican,"Phillips, Tom",268,000230
+RILEY,Manhattan City Ward 04 Precinct 05,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",230,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,Kansas House of Representatives,67,Republican,"Phillips, Tom",370,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",164,000310
+RILEY,Manhattan City Ward 05 Precinct 05,Kansas House of Representatives,67,Republican,"Phillips, Tom",192,000310
+RILEY,Manhattan City Ward 05 Precinct 06,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",260,000320
+RILEY,Manhattan City Ward 05 Precinct 06,Kansas House of Representatives,67,Republican,"Phillips, Tom",472,000320
+RILEY,Manhattan City Ward 05 Precinct 07,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",153,000330
+RILEY,Manhattan City Ward 05 Precinct 07,Kansas House of Representatives,67,Republican,"Phillips, Tom",187,000330
+RILEY,Manhattan City Ward 05 Precinct 08,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",175,000340
+RILEY,Manhattan City Ward 05 Precinct 08,Kansas House of Representatives,67,Republican,"Phillips, Tom",319,000340
+RILEY,Manhattan City Ward 05 Precinct 09,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",432,000350
+RILEY,Manhattan City Ward 05 Precinct 09,Kansas House of Representatives,67,Republican,"Phillips, Tom",775,000350
+RILEY,Manhattan City Ward 05 Precinct 10,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",401,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,Kansas House of Representatives,67,Republican,"Phillips, Tom",727,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",465,000370
+RILEY,Manhattan City Ward 05 Precinct 11,Kansas House of Representatives,67,Republican,"Phillips, Tom",828,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Kansas House of Representatives,64,Republican,"Swanson, Vern",2,000380
+RILEY,Manhattan Township Precinct 1,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",132,00039A
+RILEY,Manhattan Township Precinct 1,Kansas House of Representatives,66,Republican,"Modesitt, Lee",163,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,Kansas House of Representatives,67,Republican,"Phillips, Tom",1,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00039H
+RILEY,Manhattan Township Precinct 2,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",106,000400
+RILEY,Manhattan Township Precinct 2,Kansas House of Representatives,67,Republican,"Phillips, Tom",192,000400
+RILEY,Manhattan Township Precinct 3,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",31,000410
+RILEY,Manhattan Township Precinct 3,Kansas House of Representatives,67,Republican,"Phillips, Tom",71,000410
+RILEY,Manhattan Township Precinct 4,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",143,000420
+RILEY,Manhattan Township Precinct 4,Kansas House of Representatives,66,Republican,"Modesitt, Lee",164,000420
+RILEY,May Day Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",3,000430
+RILEY,May Day Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",29,000430
+RILEY,Ogden Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",53,00044A
+RILEY,Ogden Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",131,00044A
+RILEY,Sherman Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",77,000450
+RILEY,Sherman Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",205,000450
+RILEY,Swede Creek Township,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",17,000460
+RILEY,Swede Creek Township,Kansas House of Representatives,64,Republican,"Swanson, Vern",51,000460
+RILEY,Wildcat Township,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",97,00047A
+RILEY,Wildcat Township,Kansas House of Representatives,67,Republican,"Phillips, Tom",388,00047A
+RILEY,Wildcat Township Enclave A,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",0,00047B
+RILEY,Wildcat Township Enclave A,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00047B
+RILEY,Wildcat Township Enclave B,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",0,00047C
+RILEY,Wildcat Township Enclave B,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",12,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,Kansas House of Representatives,67,Republican,"Phillips, Tom",14,00047D
+RILEY,Zeandale Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",54,000480
+RILEY,Zeandale Township,Kansas House of Representatives,51,Republican,"Highland, Ron",143,000480
+RILEY,Fort Riley A Madison Township H64,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",32,120020
+RILEY,Fort Riley A Madison Township H64,Kansas House of Representatives,64,Republican,"Swanson, Vern",39,120020
+RILEY,Fort Riley A Madison Township H67,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",0,120030
+RILEY,Fort Riley A Madison Township H67,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,120030
+RILEY,Madison Township H64,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",154,120040
+RILEY,Madison Township H64,Kansas House of Representatives,64,Republican,"Swanson, Vern",317,120040
+RILEY,Madison Township H67,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",3,120050
+RILEY,Madison Township H67,Kansas House of Representatives,67,Republican,"Phillips, Tom",12,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Kansas House of Representatives,64,Republican,"Swanson, Vern",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",117,300020
+RILEY,Manhattan City Ward 08 Precinct 01,Kansas House of Representatives,66,Republican,"Modesitt, Lee",81,300020
+RILEY,Manhattan City Ward 08 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",3,300030
+RILEY,Manhattan City Ward 08 Precinct 02,Kansas House of Representatives,66,Republican,"Modesitt, Lee",0,300030
+RILEY,Manhattan City Ward 09 Precinct 01,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",63,300040
+RILEY,Manhattan City Ward 09 Precinct 01,Kansas House of Representatives,66,Republican,"Modesitt, Lee",35,300040
+RILEY,Manhattan City Ward 09 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",83,300050
+RILEY,Manhattan City Ward 09 Precinct 02,Kansas House of Representatives,66,Republican,"Modesitt, Lee",41,300050
+RILEY,Ogden Township Fort Riley A,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",163,300060
+RILEY,Ogden Township Fort Riley A,Kansas House of Representatives,64,Republican,"Swanson, Vern",194,300060
+RILEY,Ogden Township Ward 2 Annex order 506,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,Kansas House of Representatives,64,Republican,"Swanson, Vern",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,Kansas House of Representatives,64,Republican,"Swanson, Vern",0,300090
+RILEY,Ogden Township Ward 5,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",0,300100
+RILEY,Ogden Township Ward 5,Kansas House of Representatives,64,Republican,"Swanson, Vern",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",480,400010
+RILEY,Manhattan City Ward 01 Precinct 01,Kansas House of Representatives,66,Republican,"Modesitt, Lee",220,400010
+RILEY,Manhattan City Ward 02 Precinct 01,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",455,400020
+RILEY,Manhattan City Ward 02 Precinct 01,Kansas House of Representatives,66,Republican,"Modesitt, Lee",222,400020
+RILEY,Manhattan City Ward 02 Precinct 03,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",633,400030
+RILEY,Manhattan City Ward 02 Precinct 03,Kansas House of Representatives,66,Republican,"Modesitt, Lee",540,400030
+RILEY,Manhattan City Ward 03 Precinct 03,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",512,400040
+RILEY,Manhattan City Ward 03 Precinct 03,Kansas House of Representatives,66,Republican,"Modesitt, Lee",324,400040
+RILEY,Manhattan City Ward 04 Precinct 04,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",397,400050
+RILEY,Manhattan City Ward 04 Precinct 04,Kansas House of Representatives,67,Republican,"Phillips, Tom",667,400050
+RILEY,Manhattan City Ward 05 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",413,400060
+RILEY,Manhattan City Ward 05 Precinct 02,Kansas House of Representatives,66,Republican,"Modesitt, Lee",246,400060
+RILEY,Manhattan City Ward 05 Precinct 03,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",456,400070
+RILEY,Manhattan City Ward 05 Precinct 03,Kansas House of Representatives,66,Republican,"Modesitt, Lee",301,400070
+RILEY,Manhattan City Ward 04 Precinct 07,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",6,400080
+RILEY,Manhattan City Ward 04 Precinct 07,Kansas House of Representatives,67,Republican,"Phillips, Tom",20,400080
+RILEY,Manhattan City Ward 04 Precinct 06,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",48,400090
+RILEY,Manhattan City Ward 04 Precinct 06,Kansas House of Representatives,67,Republican,"Phillips, Tom",170,400090
+RILEY,Manhattan City Ward 11 Precinct 01,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",76,500010
+RILEY,Manhattan City Ward 11 Precinct 01,Kansas House of Representatives,67,Republican,"Phillips, Tom",118,500010
+RILEY,Manhattan City Ward 08 Precinct 03,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",171,500030
+RILEY,Manhattan City Ward 08 Precinct 03,Kansas House of Representatives,66,Republican,"Modesitt, Lee",177,500030
+RILEY,Manhattan City Ward 11 Precinct 03,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",3,600001
+RILEY,Manhattan City Ward 11 Precinct 03,Kansas House of Representatives,67,Republican,"Phillips, Tom",20,600001
+RILEY,Manhattan City Ward 09 Precinct 03,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",15,800001
+RILEY,Manhattan City Ward 09 Precinct 03,Kansas House of Representatives,67,Republican,"Phillips, Tom",35,800001
+RILEY,Ogden Township Enclave 1,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",0,900010
+RILEY,Ogden Township Enclave 1,Kansas House of Representatives,64,Republican,"Swanson, Vern",0,900010
+RILEY,Ogden Township Enclave 2,Kansas House of Representatives,64,Libertarian,"Breitmeyer, Philip ""Skip""",0,900020
+RILEY,Ogden Township Enclave 2,Kansas House of Representatives,64,Republican,"Swanson, Vern",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",40,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Kansas House of Representatives,67,Republican,"Phillips, Tom",107,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,900060
+RILEY,HAND COUNTED PAPER BALLOTS,Kansas House of Representatives,67,Democratic,"Estabrook, Aaron",4,999996
+RILEY,HAND COUNTED PAPER BALLOTS,Kansas House of Representatives,67,Republican,"Phillips, Tom",2,999996
+RILEY,HAND COUNTED PAPER BALLOTS,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",1,999997
+RILEY,HAND COUNTED PAPER BALLOTS,Kansas House of Representatives,66,Republican,"Modesitt, Lee",0,999997
+RILEY,PROVISIONAL,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",0,999999
+RILEY,PROVISIONAL,Kansas House of Representatives,51,Republican,"Highland, Ron",0,999999
+RILEY,Ashland Township,Kansas Senate,22,Democratic,"Hawk, Tom",51,000010
+RILEY,Ashland Township,Kansas Senate,22,Republican,"Reader, Bob",55,000010
+RILEY,Bala Township,Kansas Senate,22,Democratic,"Hawk, Tom",122,000020
+RILEY,Bala Township,Kansas Senate,22,Republican,"Reader, Bob",198,000020
+RILEY,Center Township,Kansas Senate,22,Democratic,"Hawk, Tom",11,000030
+RILEY,Center Township,Kansas Senate,22,Republican,"Reader, Bob",32,000030
+RILEY,Fancy Creek Township,Kansas Senate,22,Democratic,"Hawk, Tom",24,000040
+RILEY,Fancy Creek Township,Kansas Senate,22,Republican,"Reader, Bob",44,000040
+RILEY,Fort Riley B Madison Township,Kansas Senate,22,Democratic,"Hawk, Tom",32,00005B
+RILEY,Fort Riley B Madison Township,Kansas Senate,22,Republican,"Reader, Bob",35,00005B
+RILEY,Grant Township,Kansas Senate,22,Democratic,"Hawk, Tom",270,000060
+RILEY,Grant Township,Kansas Senate,22,Republican,"Reader, Bob",317,000060
+RILEY,Jackson Township,Kansas Senate,22,Democratic,"Hawk, Tom",56,000070
+RILEY,Jackson Township,Kansas Senate,22,Republican,"Reader, Bob",104,000070
+RILEY,Manhattan City Ward 02 Precinct 02,Kansas Senate,22,Democratic,"Hawk, Tom",192,000120
+RILEY,Manhattan City Ward 02 Precinct 02,Kansas Senate,22,Republican,"Reader, Bob",108,000120
+RILEY,Manhattan City Ward 02 Precinct 04,Kansas Senate,22,Democratic,"Hawk, Tom",342,000140
+RILEY,Manhattan City Ward 02 Precinct 04,Kansas Senate,22,Republican,"Reader, Bob",316,000140
+RILEY,Manhattan City Ward 03 Precinct 02,Kansas Senate,22,Democratic,"Hawk, Tom",224,000170
+RILEY,Manhattan City Ward 03 Precinct 02,Kansas Senate,22,Republican,"Reader, Bob",181,000170
+RILEY,Manhattan City Ward 04 Precinct 02,Kansas Senate,22,Democratic,"Hawk, Tom",141,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,Kansas Senate,22,Republican,"Reader, Bob",112,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,Kansas Senate,22,Democratic,"Hawk, Tom",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,Kansas Senate,22,Republican,"Reader, Bob",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,Kansas Senate,22,Democratic,"Hawk, Tom",414,000230
+RILEY,Manhattan City Ward 04 Precinct 03,Kansas Senate,22,Republican,"Reader, Bob",206,000230
+RILEY,Manhattan City Ward 04 Precinct 05,Kansas Senate,22,Democratic,"Hawk, Tom",348,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,Kansas Senate,22,Republican,"Reader, Bob",262,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Kansas Senate,22,Democratic,"Hawk, Tom",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Kansas Senate,22,Republican,"Reader, Bob",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,Kansas Senate,22,Democratic,"Hawk, Tom",205,000310
+RILEY,Manhattan City Ward 05 Precinct 05,Kansas Senate,22,Republican,"Reader, Bob",159,000310
+RILEY,Manhattan City Ward 05 Precinct 06,Kansas Senate,22,Democratic,"Hawk, Tom",394,000320
+RILEY,Manhattan City Ward 05 Precinct 06,Kansas Senate,22,Republican,"Reader, Bob",350,000320
+RILEY,Manhattan City Ward 05 Precinct 07,Kansas Senate,22,Democratic,"Hawk, Tom",218,000330
+RILEY,Manhattan City Ward 05 Precinct 07,Kansas Senate,22,Republican,"Reader, Bob",127,000330
+RILEY,Manhattan City Ward 05 Precinct 08,Kansas Senate,22,Democratic,"Hawk, Tom",291,000340
+RILEY,Manhattan City Ward 05 Precinct 08,Kansas Senate,22,Republican,"Reader, Bob",210,000340
+RILEY,Manhattan City Ward 05 Precinct 09,Kansas Senate,22,Democratic,"Hawk, Tom",732,000350
+RILEY,Manhattan City Ward 05 Precinct 09,Kansas Senate,22,Republican,"Reader, Bob",492,000350
+RILEY,Manhattan City Ward 05 Precinct 10,Kansas Senate,22,Democratic,"Hawk, Tom",657,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,Kansas Senate,22,Republican,"Reader, Bob",501,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,Kansas Senate,22,Democratic,"Hawk, Tom",731,000370
+RILEY,Manhattan City Ward 05 Precinct 11,Kansas Senate,22,Republican,"Reader, Bob",579,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Kansas Senate,22,Democratic,"Hawk, Tom",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Kansas Senate,22,Republican,"Reader, Bob",2,000380
+RILEY,Manhattan Township Precinct 1,Kansas Senate,22,Democratic,"Hawk, Tom",131,00039A
+RILEY,Manhattan Township Precinct 1,Kansas Senate,22,Republican,"Reader, Bob",165,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,Kansas Senate,22,Democratic,"Hawk, Tom",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,Kansas Senate,22,Republican,"Reader, Bob",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,Kansas Senate,22,Democratic,"Hawk, Tom",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,Kansas Senate,22,Republican,"Reader, Bob",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,Kansas Senate,22,Democratic,"Hawk, Tom",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,Kansas Senate,22,Republican,"Reader, Bob",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,Kansas Senate,22,Democratic,"Hawk, Tom",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,Kansas Senate,22,Republican,"Reader, Bob",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,Kansas Senate,22,Democratic,"Hawk, Tom",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,Kansas Senate,22,Republican,"Reader, Bob",0,00039H
+RILEY,Manhattan Township Precinct 2,Kansas Senate,22,Democratic,"Hawk, Tom",167,000400
+RILEY,Manhattan Township Precinct 2,Kansas Senate,22,Republican,"Reader, Bob",134,000400
+RILEY,Manhattan Township Precinct 3,Kansas Senate,22,Democratic,"Hawk, Tom",45,000410
+RILEY,Manhattan Township Precinct 3,Kansas Senate,22,Republican,"Reader, Bob",59,000410
+RILEY,Manhattan Township Precinct 4,Kansas Senate,22,Democratic,"Hawk, Tom",151,000420
+RILEY,Manhattan Township Precinct 4,Kansas Senate,22,Republican,"Reader, Bob",158,000420
+RILEY,May Day Township,Kansas Senate,22,Democratic,"Hawk, Tom",6,000430
+RILEY,May Day Township,Kansas Senate,22,Republican,"Reader, Bob",27,000430
+RILEY,Ogden Township,Kansas Senate,22,Democratic,"Hawk, Tom",73,00044A
+RILEY,Ogden Township,Kansas Senate,22,Republican,"Reader, Bob",129,00044A
+RILEY,Sherman Township,Kansas Senate,22,Democratic,"Hawk, Tom",114,000450
+RILEY,Sherman Township,Kansas Senate,22,Republican,"Reader, Bob",186,000450
+RILEY,Swede Creek Township,Kansas Senate,22,Democratic,"Hawk, Tom",23,000460
+RILEY,Swede Creek Township,Kansas Senate,22,Republican,"Reader, Bob",46,000460
+RILEY,Wildcat Township,Kansas Senate,22,Democratic,"Hawk, Tom",176,00047A
+RILEY,Wildcat Township,Kansas Senate,22,Republican,"Reader, Bob",322,00047A
+RILEY,Wildcat Township Enclave A,Kansas Senate,22,Democratic,"Hawk, Tom",0,00047B
+RILEY,Wildcat Township Enclave A,Kansas Senate,22,Republican,"Reader, Bob",0,00047B
+RILEY,Wildcat Township Enclave B,Kansas Senate,22,Democratic,"Hawk, Tom",0,00047C
+RILEY,Wildcat Township Enclave B,Kansas Senate,22,Republican,"Reader, Bob",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,Kansas Senate,22,Democratic,"Hawk, Tom",17,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,Kansas Senate,22,Republican,"Reader, Bob",9,00047D
+RILEY,Zeandale Township,Kansas Senate,22,Democratic,"Hawk, Tom",85,000480
+RILEY,Zeandale Township,Kansas Senate,22,Republican,"Reader, Bob",115,000480
+RILEY,Fort Riley A Madison Township H64,Kansas Senate,22,Democratic,"Hawk, Tom",52,120020
+RILEY,Fort Riley A Madison Township H64,Kansas Senate,22,Republican,"Reader, Bob",39,120020
+RILEY,Fort Riley A Madison Township H67,Kansas Senate,22,Democratic,"Hawk, Tom",0,120030
+RILEY,Fort Riley A Madison Township H67,Kansas Senate,22,Republican,"Reader, Bob",0,120030
+RILEY,Madison Township H64,Kansas Senate,22,Democratic,"Hawk, Tom",199,120040
+RILEY,Madison Township H64,Kansas Senate,22,Republican,"Reader, Bob",297,120040
+RILEY,Madison Township H67,Kansas Senate,22,Democratic,"Hawk, Tom",5,120050
+RILEY,Madison Township H67,Kansas Senate,22,Republican,"Reader, Bob",10,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Kansas Senate,22,Democratic,"Hawk, Tom",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Kansas Senate,22,Republican,"Reader, Bob",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,Kansas Senate,22,Democratic,"Hawk, Tom",107,300020
+RILEY,Manhattan City Ward 08 Precinct 01,Kansas Senate,22,Republican,"Reader, Bob",90,300020
+RILEY,Manhattan City Ward 08 Precinct 02,Kansas Senate,22,Democratic,"Hawk, Tom",3,300030
+RILEY,Manhattan City Ward 08 Precinct 02,Kansas Senate,22,Republican,"Reader, Bob",0,300030
+RILEY,Manhattan City Ward 09 Precinct 01,Kansas Senate,22,Democratic,"Hawk, Tom",55,300040
+RILEY,Manhattan City Ward 09 Precinct 01,Kansas Senate,22,Republican,"Reader, Bob",41,300040
+RILEY,Manhattan City Ward 09 Precinct 02,Kansas Senate,22,Democratic,"Hawk, Tom",88,300050
+RILEY,Manhattan City Ward 09 Precinct 02,Kansas Senate,22,Republican,"Reader, Bob",36,300050
+RILEY,Ogden Township Fort Riley A,Kansas Senate,22,Democratic,"Hawk, Tom",187,300060
+RILEY,Ogden Township Fort Riley A,Kansas Senate,22,Republican,"Reader, Bob",217,300060
+RILEY,Ogden Township Ward 2 Annex order 506,Kansas Senate,22,Democratic,"Hawk, Tom",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,Kansas Senate,22,Republican,"Reader, Bob",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,Kansas Senate,22,Democratic,"Hawk, Tom",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,Kansas Senate,22,Republican,"Reader, Bob",0,300090
+RILEY,Ogden Township Ward 5,Kansas Senate,22,Democratic,"Hawk, Tom",0,300100
+RILEY,Ogden Township Ward 5,Kansas Senate,22,Republican,"Reader, Bob",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,Kansas Senate,22,Democratic,"Hawk, Tom",459,400010
+RILEY,Manhattan City Ward 01 Precinct 01,Kansas Senate,22,Republican,"Reader, Bob",245,400010
+RILEY,Manhattan City Ward 02 Precinct 01,Kansas Senate,22,Democratic,"Hawk, Tom",434,400020
+RILEY,Manhattan City Ward 02 Precinct 01,Kansas Senate,22,Republican,"Reader, Bob",241,400020
+RILEY,Manhattan City Ward 02 Precinct 03,Kansas Senate,22,Democratic,"Hawk, Tom",614,400030
+RILEY,Manhattan City Ward 02 Precinct 03,Kansas Senate,22,Republican,"Reader, Bob",568,400030
+RILEY,Manhattan City Ward 03 Precinct 03,Kansas Senate,22,Democratic,"Hawk, Tom",495,400040
+RILEY,Manhattan City Ward 03 Precinct 03,Kansas Senate,22,Republican,"Reader, Bob",342,400040
+RILEY,Manhattan City Ward 04 Precinct 04,Kansas Senate,22,Democratic,"Hawk, Tom",612,400050
+RILEY,Manhattan City Ward 04 Precinct 04,Kansas Senate,22,Republican,"Reader, Bob",478,400050
+RILEY,Manhattan City Ward 05 Precinct 02,Kansas Senate,22,Democratic,"Hawk, Tom",424,400060
+RILEY,Manhattan City Ward 05 Precinct 02,Kansas Senate,22,Republican,"Reader, Bob",246,400060
+RILEY,Manhattan City Ward 05 Precinct 03,Kansas Senate,22,Democratic,"Hawk, Tom",454,400070
+RILEY,Manhattan City Ward 05 Precinct 03,Kansas Senate,22,Republican,"Reader, Bob",309,400070
+RILEY,Manhattan City Ward 04 Precinct 07,Kansas Senate,22,Democratic,"Hawk, Tom",12,400080
+RILEY,Manhattan City Ward 04 Precinct 07,Kansas Senate,22,Republican,"Reader, Bob",15,400080
+RILEY,Manhattan City Ward 04 Precinct 06,Kansas Senate,22,Democratic,"Hawk, Tom",89,400090
+RILEY,Manhattan City Ward 04 Precinct 06,Kansas Senate,22,Republican,"Reader, Bob",132,400090
+RILEY,Manhattan City Ward 11 Precinct 01,Kansas Senate,22,Democratic,"Hawk, Tom",87,500010
+RILEY,Manhattan City Ward 11 Precinct 01,Kansas Senate,22,Republican,"Reader, Bob",113,500010
+RILEY,Manhattan City Ward 08 Precinct 03,Kansas Senate,22,Democratic,"Hawk, Tom",175,500030
+RILEY,Manhattan City Ward 08 Precinct 03,Kansas Senate,22,Republican,"Reader, Bob",175,500030
+RILEY,Manhattan City Ward 11 Precinct 03,Kansas Senate,22,Democratic,"Hawk, Tom",8,600001
+RILEY,Manhattan City Ward 11 Precinct 03,Kansas Senate,22,Republican,"Reader, Bob",17,600001
+RILEY,Manhattan City Ward 09 Precinct 03,Kansas Senate,22,Democratic,"Hawk, Tom",26,800001
+RILEY,Manhattan City Ward 09 Precinct 03,Kansas Senate,22,Republican,"Reader, Bob",26,800001
+RILEY,Ogden Township Enclave 1,Kansas Senate,22,Democratic,"Hawk, Tom",0,900010
+RILEY,Ogden Township Enclave 1,Kansas Senate,22,Republican,"Reader, Bob",0,900010
+RILEY,Ogden Township Enclave 2,Kansas Senate,22,Democratic,"Hawk, Tom",0,900020
+RILEY,Ogden Township Enclave 2,Kansas Senate,22,Republican,"Reader, Bob",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Kansas Senate,22,Democratic,"Hawk, Tom",71,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Kansas Senate,22,Republican,"Reader, Bob",81,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Kansas Senate,22,Democratic,"Hawk, Tom",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Kansas Senate,22,Republican,"Reader, Bob",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,Kansas Senate,22,Democratic,"Hawk, Tom",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,Kansas Senate,22,Republican,"Reader, Bob",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,Kansas Senate,22,Democratic,"Hawk, Tom",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,Kansas Senate,22,Republican,"Reader, Bob",0,900060
+RILEY,PROVISIONAL,Kansas Senate,22,Democratic,"Hawk, Tom",5,999999
+RILEY,PROVISIONAL,Kansas Senate,22,Republican,"Reader, Bob",3,999999
+RILEY,Ashland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+RILEY,Ashland Township,President / Vice President,,Democratic,"Obama, Barack",42,000010
+RILEY,Ashland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+RILEY,Ashland Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+RILEY,Ashland Township,President / Vice President,,Republican,"Romney, Mitt",63,000010
+RILEY,Bala Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Stein, Jill E",1,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+RILEY,Bala Township,President / Vice President,,Democratic,"Obama, Barack",81,000020
+RILEY,Bala Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+RILEY,Bala Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+RILEY,Bala Township,President / Vice President,,Republican,"Romney, Mitt",238,000020
+RILEY,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+RILEY,Center Township,President / Vice President,,Democratic,"Obama, Barack",4,000030
+RILEY,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+RILEY,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+RILEY,Center Township,President / Vice President,,Republican,"Romney, Mitt",40,000030
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,Democratic,"Obama, Barack",13,000040
+RILEY,Fancy Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,Republican,"Romney, Mitt",56,000040
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Ayers, Avery L",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Barnett, Andre",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Bush, Kent W",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Christensen, Will",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Duncan, Richard A",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Goode, Virgil",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Knill, Dennis J",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Reed, Jill A.",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Rogers, Rick L",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Stein, Jill E",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,Democratic,"Obama, Barack",31,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,Reform,"Baldwin, Chuck",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,Republican,"Romney, Mitt",38,00005B
+RILEY,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+RILEY,Grant Township,President / Vice President,,Democratic,"Obama, Barack",175,000060
+RILEY,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000060
+RILEY,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+RILEY,Grant Township,President / Vice President,,Republican,"Romney, Mitt",400,000060
+RILEY,Jackson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+RILEY,Jackson Township,President / Vice President,,Democratic,"Obama, Barack",42,000070
+RILEY,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+RILEY,Jackson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+RILEY,Jackson Township,President / Vice President,,Republican,"Romney, Mitt",122,000070
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",2,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",178,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",21,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",105,000120
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",1,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",287,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",18,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",3,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",357,000140
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",6,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",223,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",29,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",182,000170
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",115,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",8,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",2,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",133,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",3,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",358,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",11,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",5,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",239,000230
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Stein, Jill E",4,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,Democratic,"Obama, Barack",259,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",11,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",4,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,Republican,"Romney, Mitt",340,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,Democratic,"Obama, Barack",186,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",10,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",1,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,Republican,"Romney, Mitt",183,000310
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Barnett, Andre",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Bush, Kent W",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Christensen, Will",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Goode, Virgil",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Stein, Jill E",1,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,Democratic,"Obama, Barack",295,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",7,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,Reform,"Baldwin, Chuck",3,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,Republican,"Romney, Mitt",452,000320
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Ayers, Avery L",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Barnett, Andre",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Barr, Roseanne C",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Bush, Kent W",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Christensen, Will",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Duncan, Richard A",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Goode, Virgil",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Knill, Dennis J",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Reed, Jill A.",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Rogers, Rick L",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Stein, Jill E",1,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Thorne, Kevin M",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Warner, Gerald L.",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,Democratic,"Obama, Barack",160,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",7,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,Reform,"Baldwin, Chuck",1,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,Republican,"Romney, Mitt",179,000330
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Ayers, Avery L",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Barnett, Andre",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Barr, Roseanne C",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Bush, Kent W",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Christensen, Will",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Duncan, Richard A",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Goode, Virgil",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Knill, Dennis J",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Reed, Jill A.",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Rogers, Rick L",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Stein, Jill E",1,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Thorne, Kevin M",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Warner, Gerald L.",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,Democratic,"Obama, Barack",214,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",10,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,Reform,"Baldwin, Chuck",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,Republican,"Romney, Mitt",288,000340
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Ayers, Avery L",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Barnett, Andre",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Barr, Roseanne C",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Bush, Kent W",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Christensen, Will",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Duncan, Richard A",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Goode, Virgil",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Knill, Dennis J",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Reed, Jill A.",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Rogers, Rick L",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Stein, Jill E",1,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Thorne, Kevin M",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Warner, Gerald L.",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,Democratic,"Obama, Barack",519,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",15,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,Reform,"Baldwin, Chuck",2,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,Republican,"Romney, Mitt",698,000350
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Ayers, Avery L",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Barnett, Andre",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Barr, Roseanne C",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Bush, Kent W",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Christensen, Will",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Duncan, Richard A",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Goode, Virgil",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Knill, Dennis J",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Reed, Jill A.",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Rogers, Rick L",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Stein, Jill E",1,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Thorne, Kevin M",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Warner, Gerald L.",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,Democratic,"Obama, Barack",484,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",9,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,Reform,"Baldwin, Chuck",2,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,Republican,"Romney, Mitt",671,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Ayers, Avery L",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Barnett, Andre",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Barr, Roseanne C",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Bush, Kent W",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Christensen, Will",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Duncan, Richard A",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Goode, Virgil",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Knill, Dennis J",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Reed, Jill A.",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Rogers, Rick L",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Stein, Jill E",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Thorne, Kevin M",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Warner, Gerald L.",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,Democratic,"Obama, Barack",512,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",30,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,Reform,"Baldwin, Chuck",6,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,Republican,"Romney, Mitt",791,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Ayers, Avery L",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Barnett, Andre",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Barr, Roseanne C",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Bush, Kent W",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Christensen, Will",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Duncan, Richard A",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Goode, Virgil",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Knill, Dennis J",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Reed, Jill A.",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Rogers, Rick L",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Stein, Jill E",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Thorne, Kevin M",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Warner, Gerald L.",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,Democratic,"Obama, Barack",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,Libertarian,"Johnson, Gary",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,Reform,"Baldwin, Chuck",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,Republican,"Romney, Mitt",2,000380
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,Democratic,"Obama, Barack",99,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",5,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,Republican,"Romney, Mitt",191,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Barnett, Andre",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Bush, Kent W",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Christensen, Will",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Goode, Virgil",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Stein, Jill E",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,Democratic,"Obama, Barack",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,Republican,"Romney, Mitt",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Barnett, Andre",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Bush, Kent W",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Christensen, Will",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Goode, Virgil",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Stein, Jill E",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,Democratic,"Obama, Barack",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,Republican,"Romney, Mitt",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Ayers, Avery L",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Barnett, Andre",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Barr, Roseanne C",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Bush, Kent W",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Christensen, Will",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Duncan, Richard A",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Goode, Virgil",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Hoefling, Tom",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Knill, Dennis J",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Reed, Jill A.",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Rogers, Rick L",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Stein, Jill E",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Thorne, Kevin M",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Warner, Gerald L.",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,Democratic,"Obama, Barack",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,Libertarian,"Johnson, Gary",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,Reform,"Baldwin, Chuck",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,Republican,"Romney, Mitt",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Ayers, Avery L",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Barnett, Andre",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Barr, Roseanne C",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Bush, Kent W",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Christensen, Will",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Duncan, Richard A",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Goode, Virgil",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Hoefling, Tom",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Knill, Dennis J",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Reed, Jill A.",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Rogers, Rick L",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Stein, Jill E",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Thorne, Kevin M",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Warner, Gerald L.",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,Democratic,"Obama, Barack",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,Libertarian,"Johnson, Gary",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,Reform,"Baldwin, Chuck",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,Republican,"Romney, Mitt",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Barnett, Andre",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Bush, Kent W",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Christensen, Will",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Goode, Virgil",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Stein, Jill E",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,Democratic,"Obama, Barack",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,Reform,"Baldwin, Chuck",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,Republican,"Romney, Mitt",0,00039H
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,Democratic,"Obama, Barack",112,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",8,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,Republican,"Romney, Mitt",182,000400
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,Democratic,"Obama, Barack",35,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",2,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,Republican,"Romney, Mitt",67,000410
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Ayers, Avery L",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Barnett, Andre",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Bush, Kent W",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Christensen, Will",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Duncan, Richard A",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Goode, Virgil",2,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Knill, Dennis J",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Reed, Jill A.",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Rogers, Rick L",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Stein, Jill E",1,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,Democratic,"Obama, Barack",116,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",10,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,Reform,"Baldwin, Chuck",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,Republican,"Romney, Mitt",182,000420
+RILEY,May Day Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Ayers, Avery L",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Barnett, Andre",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Bush, Kent W",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Christensen, Will",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Duncan, Richard A",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Goode, Virgil",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Hoefling, Tom",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Knill, Dennis J",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Reed, Jill A.",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Rogers, Rick L",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Stein, Jill E",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000430
+RILEY,May Day Township,President / Vice President,,Democratic,"Obama, Barack",1,000430
+RILEY,May Day Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000430
+RILEY,May Day Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000430
+RILEY,May Day Township,President / Vice President,,Republican,"Romney, Mitt",33,000430
+RILEY,Ogden Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Ayers, Avery L",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Barnett, Andre",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Bush, Kent W",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Christensen, Will",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Duncan, Richard A",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Goode, Virgil",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Hoefling, Tom",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Knill, Dennis J",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Reed, Jill A.",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Rogers, Rick L",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Stein, Jill E",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00044A
+RILEY,Ogden Township,President / Vice President,,Democratic,"Obama, Barack",55,00044A
+RILEY,Ogden Township,President / Vice President,,Libertarian,"Johnson, Gary",1,00044A
+RILEY,Ogden Township,President / Vice President,,Reform,"Baldwin, Chuck",4,00044A
+RILEY,Ogden Township,President / Vice President,,Republican,"Romney, Mitt",147,00044A
+RILEY,Sherman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Barnett, Andre",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Bush, Kent W",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Christensen, Will",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Goode, Virgil",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Stein, Jill E",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000450
+RILEY,Sherman Township,President / Vice President,,Democratic,"Obama, Barack",83,000450
+RILEY,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000450
+RILEY,Sherman Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000450
+RILEY,Sherman Township,President / Vice President,,Republican,"Romney, Mitt",215,000450
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000460
+RILEY,Swede Creek Township,President / Vice President,,Democratic,"Obama, Barack",20,000460
+RILEY,Swede Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000460
+RILEY,Swede Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000460
+RILEY,Swede Creek Township,President / Vice President,,Republican,"Romney, Mitt",53,000460
+RILEY,Wildcat Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Ayers, Avery L",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Barnett, Andre",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Barr, Roseanne C",1,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Bush, Kent W",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Christensen, Will",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Duncan, Richard A",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Goode, Virgil",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Hoefling, Tom",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Knill, Dennis J",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Reed, Jill A.",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Rogers, Rick L",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Stein, Jill E",1,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00047A
+RILEY,Wildcat Township,President / Vice President,,Democratic,"Obama, Barack",114,00047A
+RILEY,Wildcat Township,President / Vice President,,Libertarian,"Johnson, Gary",5,00047A
+RILEY,Wildcat Township,President / Vice President,,Reform,"Baldwin, Chuck",2,00047A
+RILEY,Wildcat Township,President / Vice President,,Republican,"Romney, Mitt",374,00047A
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Ayers, Avery L",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Barnett, Andre",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Bush, Kent W",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Christensen, Will",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Duncan, Richard A",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Goode, Virgil",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Knill, Dennis J",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Reed, Jill A.",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Rogers, Rick L",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Stein, Jill E",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,Democratic,"Obama, Barack",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,Republican,"Romney, Mitt",0,00047B
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Ayers, Avery L",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Barnett, Andre",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Bush, Kent W",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Christensen, Will",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Duncan, Richard A",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Goode, Virgil",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Knill, Dennis J",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Reed, Jill A.",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Rogers, Rick L",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Stein, Jill E",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,Democratic,"Obama, Barack",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,Republican,"Romney, Mitt",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",12,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",13,00047D
+RILEY,Zeandale Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Ayers, Avery L",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Barnett, Andre",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Bush, Kent W",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Christensen, Will",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Duncan, Richard A",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Goode, Virgil",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Knill, Dennis J",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Reed, Jill A.",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Rogers, Rick L",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Stein, Jill E",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000480
+RILEY,Zeandale Township,President / Vice President,,Democratic,"Obama, Barack",59,000480
+RILEY,Zeandale Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000480
+RILEY,Zeandale Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000480
+RILEY,Zeandale Township,President / Vice President,,Republican,"Romney, Mitt",145,000480
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Barnett, Andre",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Bush, Kent W",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Christensen, Will",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Goode, Virgil",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Stein, Jill E",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,Democratic,"Obama, Barack",58,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,Libertarian,"Johnson, Gary",2,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,Republican,"Romney, Mitt",39,120020
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Barnett, Andre",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Bush, Kent W",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Christensen, Will",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Goode, Virgil",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Stein, Jill E",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,Democratic,"Obama, Barack",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,Republican,"Romney, Mitt",0,120030
+RILEY,Madison Township H64,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Barnett, Andre",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Bush, Kent W",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Christensen, Will",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Goode, Virgil",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Stein, Jill E",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+RILEY,Madison Township H64,President / Vice President,,Democratic,"Obama, Barack",132,120040
+RILEY,Madison Township H64,President / Vice President,,Libertarian,"Johnson, Gary",16,120040
+RILEY,Madison Township H64,President / Vice President,,Reform,"Baldwin, Chuck",1,120040
+RILEY,Madison Township H64,President / Vice President,,Republican,"Romney, Mitt",350,120040
+RILEY,Madison Township H67,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Barnett, Andre",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Bush, Kent W",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Christensen, Will",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Goode, Virgil",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Stein, Jill E",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+RILEY,Madison Township H67,President / Vice President,,Democratic,"Obama, Barack",1,120050
+RILEY,Madison Township H67,President / Vice President,,Libertarian,"Johnson, Gary",2,120050
+RILEY,Madison Township H67,President / Vice President,,Reform,"Baldwin, Chuck",0,120050
+RILEY,Madison Township H67,President / Vice President,,Republican,"Romney, Mitt",12,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Ayers, Avery L",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Barnett, Andre",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Barr, Roseanne C",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Bush, Kent W",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Christensen, Will",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Duncan, Richard A",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Goode, Virgil",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Hoefling, Tom",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Knill, Dennis J",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Reed, Jill A.",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Rogers, Rick L",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Stein, Jill E",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Thorne, Kevin M",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Warner, Gerald L.",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,Democratic,"Obama, Barack",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,Libertarian,"Johnson, Gary",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,Reform,"Baldwin, Chuck",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,Republican,"Romney, Mitt",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",105,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",3,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",1,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",91,300020
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",2,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",1,300030
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",46,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",1,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",55,300040
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",64,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",2,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",57,300050
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Ayers, Avery L",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Barnett, Andre",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Barr, Roseanne C",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Bush, Kent W",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Christensen, Will",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Duncan, Richard A",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Goode, Virgil",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Hoefling, Tom",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Knill, Dennis J",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Reed, Jill A.",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Rogers, Rick L",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Stein, Jill E",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Thorne, Kevin M",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Warner, Gerald L.",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,Democratic,"Obama, Barack",165,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,Libertarian,"Johnson, Gary",11,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,Reform,"Baldwin, Chuck",2,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,Republican,"Romney, Mitt",240,300060
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Ayers, Avery L",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Barnett, Andre",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Barr, Roseanne C",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Bush, Kent W",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Christensen, Will",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Duncan, Richard A",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Goode, Virgil",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Hoefling, Tom",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Knill, Dennis J",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Reed, Jill A.",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Rogers, Rick L",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Stein, Jill E",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Thorne, Kevin M",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Warner, Gerald L.",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,Democratic,"Obama, Barack",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,Libertarian,"Johnson, Gary",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,Reform,"Baldwin, Chuck",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,Republican,"Romney, Mitt",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Ayers, Avery L",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Barnett, Andre",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Barr, Roseanne C",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Bush, Kent W",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Christensen, Will",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Duncan, Richard A",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Goode, Virgil",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Hoefling, Tom",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Knill, Dennis J",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Reed, Jill A.",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Rogers, Rick L",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Stein, Jill E",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Thorne, Kevin M",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Warner, Gerald L.",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,Democratic,"Obama, Barack",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,Libertarian,"Johnson, Gary",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,Reform,"Baldwin, Chuck",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,Republican,"Romney, Mitt",0,300090
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Ayers, Avery L",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Barnett, Andre",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Barr, Roseanne C",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Bush, Kent W",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Christensen, Will",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Duncan, Richard A",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Goode, Virgil",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Knill, Dennis J",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Reed, Jill A.",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Rogers, Rick L",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Stein, Jill E",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Thorne, Kevin M",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Warner, Gerald L.",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,Democratic,"Obama, Barack",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,Reform,"Baldwin, Chuck",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,Republican,"Romney, Mitt",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",2,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",6,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",407,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",28,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",6,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",262,400010
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",1,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",5,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",426,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",24,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",2,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",242,400020
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",531,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",29,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",6,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",641,400030
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",3,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",482,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",16,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",426,400040
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",456,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",32,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",4,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",615,400050
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",6,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",377,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",22,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",2,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",272,400060
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",3,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",411,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",28,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",2,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",358,400070
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Ayers, Avery L",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Barnett, Andre",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Barr, Roseanne C",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Bush, Kent W",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Christensen, Will",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Duncan, Richard A",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Goode, Virgil",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Knill, Dennis J",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Reed, Jill A.",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Rogers, Rick L",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Stein, Jill E",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Thorne, Kevin M",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Warner, Gerald L.",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,Democratic,"Obama, Barack",11,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",2,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,Reform,"Baldwin, Chuck",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,Republican,"Romney, Mitt",18,400080
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Ayers, Avery L",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Barnett, Andre",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Barr, Roseanne C",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Bush, Kent W",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Christensen, Will",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Duncan, Richard A",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Goode, Virgil",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Knill, Dennis J",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Reed, Jill A.",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Rogers, Rick L",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Stein, Jill E",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Thorne, Kevin M",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Warner, Gerald L.",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,Democratic,"Obama, Barack",65,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",1,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,Reform,"Baldwin, Chuck",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,Republican,"Romney, Mitt",164,400090
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",84,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",5,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",126,500010
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",166,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",8,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",185,500030
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",5,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",20,600001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",19,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",33,800001
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Christensen, Will",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900010
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Christensen, Will",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Barnett, Andre",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Bush, Kent W",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Christensen, Will",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Goode, Virgil",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Stein, Jill E",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,Democratic,"Obama, Barack",52,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,Libertarian,"Johnson, Gary",9,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,Republican,"Romney, Mitt",93,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Barnett, Andre",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Bush, Kent W",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Christensen, Will",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Goode, Virgil",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Stein, Jill E",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,Democratic,"Obama, Barack",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,Republican,"Romney, Mitt",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Ayers, Avery L",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Barnett, Andre",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Bush, Kent W",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Christensen, Will",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Duncan, Richard A",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Goode, Virgil",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Knill, Dennis J",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Reed, Jill A.",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Rogers, Rick L",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Stein, Jill E",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,Democratic,"Obama, Barack",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,Republican,"Romney, Mitt",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Ayers, Avery L",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Barnett, Andre",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Bush, Kent W",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Christensen, Will",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Duncan, Richard A",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Goode, Virgil",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Knill, Dennis J",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Reed, Jill A.",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Rogers, Rick L",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Stein, Jill E",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,Democratic,"Obama, Barack",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,Republican,"Romney, Mitt",0,900060
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Ayers, Avery L",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Barnett, Andre",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Barr, Roseanne C",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Bush, Kent W",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Christensen, Will",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Duncan, Richard A",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Goode, Virgil",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Hoefling, Tom",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Knill, Dennis J",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Reed, Jill A.",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Rogers, Rick L",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Stein, Jill E",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Thorne, Kevin M",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Warner, Gerald L.",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,Democratic,"Obama, Barack",28,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,Libertarian,"Johnson, Gary",1,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,Reform,"Baldwin, Chuck",0,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,Republican,"Romney, Mitt",28,999996
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Ayers, Avery L",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Barnett, Andre",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Barr, Roseanne C",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Bush, Kent W",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Christensen, Will",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Duncan, Richard A",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Goode, Virgil",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Hoefling, Tom",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Knill, Dennis J",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Reed, Jill A.",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Rogers, Rick L",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Stein, Jill E",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Thorne, Kevin M",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,write - in,"Warner, Gerald L.",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,Democratic,"Obama, Barack",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,Libertarian,"Johnson, Gary",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,Reform,"Baldwin, Chuck",0,999997
+RILEY,HAND COUNTED PAPER BALLOTS,President / Vice President,,Republican,"Romney, Mitt",0,999997
+RILEY,ADVANCED,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Ayers, Avery L",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Barnett, Andre",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Barr, Roseanne C",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Bush, Kent W",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Christensen, Will",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Duncan, Richard A",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Goode, Virgil",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Hoefling, Tom",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Knill, Dennis J",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Reed, Jill A.",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Rogers, Rick L",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Stein, Jill E",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Thorne, Kevin M",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,999998
+RILEY,ADVANCED,President / Vice President,,write - in,"Warner, Gerald L.",0,999998
+RILEY,ADVANCED,President / Vice President,,Democratic,"Obama, Barack",0,999998
+RILEY,ADVANCED,President / Vice President,,Libertarian,"Johnson, Gary",0,999998
+RILEY,ADVANCED,President / Vice President,,Reform,"Baldwin, Chuck",0,999998
+RILEY,ADVANCED,President / Vice President,,Republican,"Romney, Mitt",0,999998
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Ayers, Avery L",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Barnett, Andre",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Barr, Roseanne C",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Bush, Kent W",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Christensen, Will",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Duncan, Richard A",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Goode, Virgil",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Hoefling, Tom",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Knill, Dennis J",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Reed, Jill A.",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Rogers, Rick L",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Stein, Jill E",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Thorne, Kevin M",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,999999
+RILEY,PROVISIONAL,President / Vice President,,write - in,"Warner, Gerald L.",0,999999
+RILEY,PROVISIONAL,President / Vice President,,Democratic,"Obama, Barack",0,999999
+RILEY,PROVISIONAL,President / Vice President,,Libertarian,"Johnson, Gary",0,999999
+RILEY,PROVISIONAL,President / Vice President,,Reform,"Baldwin, Chuck",0,999999
+RILEY,PROVISIONAL,President / Vice President,,Republican,"Romney, Mitt",0,999999
+RILEY,Ashland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",78,000010
+RILEY,Bala Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",284,000020
+RILEY,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",41,000030
+RILEY,Fancy Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",58,000040
+RILEY,Fort Riley B Madison Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,00005B
+RILEY,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",462,000060
+RILEY,Jackson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",134,000070
+RILEY,Manhattan City Ward 02 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",196,000120
+RILEY,Manhattan City Ward 02 Precinct 04,United States House of Representatives,1,Republican,"Huelskamp, Tim",507,000140
+RILEY,Manhattan City Ward 03 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",289,000170
+RILEY,Manhattan City Ward 04 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",165,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",370,000230
+RILEY,Manhattan City Ward 04 Precinct 05,United States House of Representatives,1,Republican,"Huelskamp, Tim",421,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,United States House of Representatives,1,Republican,"Huelskamp, Tim",249,000310
+RILEY,Manhattan City Ward 05 Precinct 06,United States House of Representatives,1,Republican,"Huelskamp, Tim",543,000320
+RILEY,Manhattan City Ward 05 Precinct 07,United States House of Representatives,1,Republican,"Huelskamp, Tim",247,000330
+RILEY,Manhattan City Ward 05 Precinct 08,United States House of Representatives,1,Republican,"Huelskamp, Tim",346,000340
+RILEY,Manhattan City Ward 05 Precinct 09,United States House of Representatives,1,Republican,"Huelskamp, Tim",847,000350
+RILEY,Manhattan City Ward 05 Precinct 10,United States House of Representatives,1,Republican,"Huelskamp, Tim",811,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,United States House of Representatives,1,Republican,"Huelskamp, Tim",954,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,United States House of Representatives,1,Republican,"Huelskamp, Tim",2,000380
+RILEY,Manhattan Township Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",231,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00039H
+RILEY,Manhattan Township Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",237,000400
+RILEY,Manhattan Township Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",83,000410
+RILEY,Manhattan Township Precinct 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",250,000420
+RILEY,May Day Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000430
+RILEY,Ogden Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",167,00044A
+RILEY,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",251,000450
+RILEY,Swede Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",60,000460
+RILEY,Wildcat Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",420,00047A
+RILEY,Wildcat Township Enclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00047B
+RILEY,Wildcat Township Enclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,00047D
+RILEY,Zeandale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",158,000480
+RILEY,Fort Riley A Madison Township H64,United States House of Representatives,1,Republican,"Huelskamp, Tim",64,120020
+RILEY,Fort Riley A Madison Township H67,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120030
+RILEY,Madison Township H64,United States House of Representatives,1,Republican,"Huelskamp, Tim",418,120040
+RILEY,Madison Township H67,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",149,300020
+RILEY,Manhattan City Ward 08 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",3,300030
+RILEY,Manhattan City Ward 09 Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",64,300040
+RILEY,Manhattan City Ward 09 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,300050
+RILEY,Ogden Township Fort Riley A,United States House of Representatives,1,Republican,"Huelskamp, Tim",328,300060
+RILEY,Ogden Township Ward 2 Annex order 506,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,300090
+RILEY,Ogden Township Ward 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",428,400010
+RILEY,Manhattan City Ward 02 Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",436,400020
+RILEY,Manhattan City Ward 02 Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",878,400030
+RILEY,Manhattan City Ward 03 Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",580,400040
+RILEY,Manhattan City Ward 04 Precinct 04,United States House of Representatives,1,Republican,"Huelskamp, Tim",784,400050
+RILEY,Manhattan City Ward 05 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",412,400060
+RILEY,Manhattan City Ward 05 Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",496,400070
+RILEY,Manhattan City Ward 04 Precinct 07,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,400080
+RILEY,Manhattan City Ward 04 Precinct 06,United States House of Representatives,1,Republican,"Huelskamp, Tim",180,400090
+RILEY,Manhattan City Ward 11 Precinct 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",147,500010
+RILEY,Manhattan City Ward 08 Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",283,500030
+RILEY,Manhattan City Ward 11 Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,600001
+RILEY,Manhattan City Ward 09 Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,800001
+RILEY,Ogden Township Enclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+RILEY,Ogden Township Enclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",122,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900060
+RILEY,PROVISIONAL,United States House of Representatives,1,Republican,"Huelskamp, Tim",28,999999

--- a/2012/20121106__ks__general__rooks__precinct.csv
+++ b/2012/20121106__ks__general__rooks__precinct.csv
@@ -1,0 +1,399 @@
+county,precinct,office,district,party,candidate,votes,vtd
+ROOKS,Township 01,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",12,000010
+ROOKS,Township 01,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",93,000010
+ROOKS,Township 02,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",31,000020
+ROOKS,Township 02,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",148,000020
+ROOKS,Township 03 Precinct 1,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",6,000030
+ROOKS,Township 03 Precinct 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",32,000030
+ROOKS,Township 03 Precinct 2,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",82,000040
+ROOKS,Township 03 Precinct 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",447,000040
+ROOKS,Township 04,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",8,000050
+ROOKS,Township 04,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",11,000050
+ROOKS,Township 06,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",10,000070
+ROOKS,Township 06,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",37,000070
+ROOKS,Township 07,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",23,000080
+ROOKS,Township 07,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",63,000080
+ROOKS,Township 08,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",39,000090
+ROOKS,Township 08,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",92,000090
+ROOKS,Township 09,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",1,000100
+ROOKS,Township 09,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",25,000100
+ROOKS,Township 10,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",14,000110
+ROOKS,Township 10,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",69,000110
+ROOKS,Township 11 Precinct 1,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",57,000120
+ROOKS,Township 11 Precinct 1,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",225,000120
+ROOKS,Township 11 Precinct 2,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",136,000130
+ROOKS,Township 11 Precinct 2,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",623,000130
+ROOKS,Township 12,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",16,000140
+ROOKS,Township 12,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",70,000140
+ROOKS,Township 05 H110,Kansas House of Representatives,110,Democratic,"Martin, Philip H.",3,120020
+ROOKS,Township 05 H110,Kansas House of Representatives,110,Republican,"Couture-Lovelady, Travis",39,120020
+ROOKS,Township 05 H118 A,Kansas House of Representatives,118,Republican,"Hineman, Don",0,12003A
+ROOKS,Township 05 H118,Kansas House of Representatives,118,Republican,"Hineman, Don",0,120030
+ROOKS,Township 01,Kansas Senate,36,Democratic,"Clark, Marquis",19,000010
+ROOKS,Township 01,Kansas Senate,36,Republican,"Bowers, Elaine S.",84,000010
+ROOKS,Township 02,Kansas Senate,36,Democratic,"Clark, Marquis",22,000020
+ROOKS,Township 02,Kansas Senate,36,Republican,"Bowers, Elaine S.",147,000020
+ROOKS,Township 03 Precinct 1,Kansas Senate,36,Democratic,"Clark, Marquis",6,000030
+ROOKS,Township 03 Precinct 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",33,000030
+ROOKS,Township 03 Precinct 2,Kansas Senate,36,Democratic,"Clark, Marquis",75,000040
+ROOKS,Township 03 Precinct 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",427,000040
+ROOKS,Township 04,Kansas Senate,36,Democratic,"Clark, Marquis",8,000050
+ROOKS,Township 04,Kansas Senate,36,Republican,"Bowers, Elaine S.",9,000050
+ROOKS,Township 06,Kansas Senate,36,Democratic,"Clark, Marquis",5,000070
+ROOKS,Township 06,Kansas Senate,36,Republican,"Bowers, Elaine S.",41,000070
+ROOKS,Township 07,Kansas Senate,36,Democratic,"Clark, Marquis",16,000080
+ROOKS,Township 07,Kansas Senate,36,Republican,"Bowers, Elaine S.",60,000080
+ROOKS,Township 08,Kansas Senate,36,Democratic,"Clark, Marquis",27,000090
+ROOKS,Township 08,Kansas Senate,36,Republican,"Bowers, Elaine S.",93,000090
+ROOKS,Township 09,Kansas Senate,36,Democratic,"Clark, Marquis",4,000100
+ROOKS,Township 09,Kansas Senate,36,Republican,"Bowers, Elaine S.",21,000100
+ROOKS,Township 10,Kansas Senate,36,Democratic,"Clark, Marquis",8,000110
+ROOKS,Township 10,Kansas Senate,36,Republican,"Bowers, Elaine S.",70,000110
+ROOKS,Township 11 Precinct 1,Kansas Senate,36,Democratic,"Clark, Marquis",44,000120
+ROOKS,Township 11 Precinct 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",226,000120
+ROOKS,Township 11 Precinct 2,Kansas Senate,36,Democratic,"Clark, Marquis",108,000130
+ROOKS,Township 11 Precinct 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",607,000130
+ROOKS,Township 12,Kansas Senate,36,Democratic,"Clark, Marquis",14,000140
+ROOKS,Township 12,Kansas Senate,36,Republican,"Bowers, Elaine S.",65,000140
+ROOKS,Township 05 H110,Kansas Senate,36,Democratic,"Clark, Marquis",7,120020
+ROOKS,Township 05 H110,Kansas Senate,36,Republican,"Bowers, Elaine S.",33,120020
+ROOKS,Township 05 H118 A,Kansas Senate,36,Democratic,"Clark, Marquis",0,12003A
+ROOKS,Township 05 H118 A,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,12003A
+ROOKS,Township 05 H118,Kansas Senate,36,Democratic,"Clark, Marquis",0,120030
+ROOKS,Township 05 H118,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,120030
+ROOKS,Township 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Barnett, Andre",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Bush, Kent W",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Christensen, Will",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Goode, Virgil",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Stein, Jill E",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+ROOKS,Township 01,President / Vice President,,Democratic,"Obama, Barack",15,000010
+ROOKS,Township 01,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+ROOKS,Township 01,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+ROOKS,Township 01,President / Vice President,,Republican,"Romney, Mitt",93,000010
+ROOKS,Township 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Barnett, Andre",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Bush, Kent W",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Christensen, Will",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Goode, Virgil",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Stein, Jill E",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+ROOKS,Township 02,President / Vice President,,Democratic,"Obama, Barack",28,000020
+ROOKS,Township 02,President / Vice President,,Libertarian,"Johnson, Gary",7,000020
+ROOKS,Township 02,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+ROOKS,Township 02,President / Vice President,,Republican,"Romney, Mitt",146,000020
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",5,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",34,000030
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",80,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",14,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",447,000040
+ROOKS,Township 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Barnett, Andre",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Bush, Kent W",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Christensen, Will",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Goode, Virgil",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Stein, Jill E",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+ROOKS,Township 04,President / Vice President,,Democratic,"Obama, Barack",6,000050
+ROOKS,Township 04,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+ROOKS,Township 04,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+ROOKS,Township 04,President / Vice President,,Republican,"Romney, Mitt",13,000050
+ROOKS,Township 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Barnett, Andre",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Bush, Kent W",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Christensen, Will",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Goode, Virgil",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Stein, Jill E",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+ROOKS,Township 06,President / Vice President,,Democratic,"Obama, Barack",5,000070
+ROOKS,Township 06,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+ROOKS,Township 06,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+ROOKS,Township 06,President / Vice President,,Republican,"Romney, Mitt",42,000070
+ROOKS,Township 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Barnett, Andre",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Bush, Kent W",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Christensen, Will",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Goode, Virgil",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Stein, Jill E",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+ROOKS,Township 07,President / Vice President,,Democratic,"Obama, Barack",16,000080
+ROOKS,Township 07,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+ROOKS,Township 07,President / Vice President,,Reform,"Baldwin, Chuck",2,000080
+ROOKS,Township 07,President / Vice President,,Republican,"Romney, Mitt",73,000080
+ROOKS,Township 08,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Barnett, Andre",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Bush, Kent W",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Christensen, Will",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Goode, Virgil",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Stein, Jill E",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+ROOKS,Township 08,President / Vice President,,Democratic,"Obama, Barack",24,000090
+ROOKS,Township 08,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+ROOKS,Township 08,President / Vice President,,Reform,"Baldwin, Chuck",2,000090
+ROOKS,Township 08,President / Vice President,,Republican,"Romney, Mitt",107,000090
+ROOKS,Township 09,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Barnett, Andre",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Bush, Kent W",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Christensen, Will",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Goode, Virgil",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Stein, Jill E",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+ROOKS,Township 09,President / Vice President,,Democratic,"Obama, Barack",3,000100
+ROOKS,Township 09,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+ROOKS,Township 09,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+ROOKS,Township 09,President / Vice President,,Republican,"Romney, Mitt",23,000100
+ROOKS,Township 10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Barnett, Andre",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Bush, Kent W",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Christensen, Will",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Goode, Virgil",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Stein, Jill E",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+ROOKS,Township 10,President / Vice President,,Democratic,"Obama, Barack",7,000110
+ROOKS,Township 10,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+ROOKS,Township 10,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+ROOKS,Township 10,President / Vice President,,Republican,"Romney, Mitt",73,000110
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",1,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",38,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",245,000120
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",116,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",13,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",5,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",632,000130
+ROOKS,Township 12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Barnett, Andre",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Bush, Kent W",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Christensen, Will",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Goode, Virgil",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Stein, Jill E",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+ROOKS,Township 12,President / Vice President,,Democratic,"Obama, Barack",16,000140
+ROOKS,Township 12,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+ROOKS,Township 12,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+ROOKS,Township 12,President / Vice President,,Republican,"Romney, Mitt",72,000140
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Barnett, Andre",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Bush, Kent W",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Christensen, Will",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Goode, Virgil",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Stein, Jill E",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+ROOKS,Township 05 H110,President / Vice President,,Democratic,"Obama, Barack",2,120020
+ROOKS,Township 05 H110,President / Vice President,,Libertarian,"Johnson, Gary",2,120020
+ROOKS,Township 05 H110,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+ROOKS,Township 05 H110,President / Vice President,,Republican,"Romney, Mitt",38,120020
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Ayers, Avery L",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Barnett, Andre",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Bush, Kent W",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Christensen, Will",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Duncan, Richard A",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Goode, Virgil",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Hoefling, Tom",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Knill, Dennis J",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Reed, Jill A.",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Rogers, Rick L",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Stein, Jill E",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,Democratic,"Obama, Barack",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,Republican,"Romney, Mitt",0,12003A
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Barnett, Andre",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Bush, Kent W",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Christensen, Will",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Goode, Virgil",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Stein, Jill E",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+ROOKS,Township 05 H118,President / Vice President,,Democratic,"Obama, Barack",0,120030
+ROOKS,Township 05 H118,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+ROOKS,Township 05 H118,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+ROOKS,Township 05 H118,President / Vice President,,Republican,"Romney, Mitt",0,120030
+ROOKS,Township 01,United States House of Representatives,1,Republican,"Huelskamp, Tim",98,000010
+ROOKS,Township 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",165,000020
+ROOKS,Township 03 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000030
+ROOKS,Township 03 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",467,000040
+ROOKS,Township 04,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000050
+ROOKS,Township 06,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000070
+ROOKS,Township 07,United States House of Representatives,1,Republican,"Huelskamp, Tim",71,000080
+ROOKS,Township 08,United States House of Representatives,1,Republican,"Huelskamp, Tim",108,000090
+ROOKS,Township 09,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000100
+ROOKS,Township 10,United States House of Representatives,1,Republican,"Huelskamp, Tim",76,000110
+ROOKS,Township 11 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",255,000120
+ROOKS,Township 11 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",671,000130
+ROOKS,Township 12,United States House of Representatives,1,Republican,"Huelskamp, Tim",72,000140
+ROOKS,Township 05 H110,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,120020
+ROOKS,Township 05 H118 A,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,12003A
+ROOKS,Township 05 H118,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120030

--- a/2012/20121106__ks__general__rush__precinct.csv
+++ b/2012/20121106__ks__general__rush__precinct.csv
@@ -1,0 +1,306 @@
+county,precinct,office,district,party,candidate,votes,vtd
+RUSH,Alexander - Belle Prairie Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",19,000010
+RUSH,Alexander - Belle Prairie Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",40,000010
+RUSH,Banner Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",61,000020
+RUSH,Big Timber Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",24,000030
+RUSH,Big Timber Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",46,000030
+RUSH,Brookdale,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",97,000040
+RUSH,Brookdale,Kansas House of Representatives,117,Republican,"Ewy, John L.",153,000040
+RUSH,Center Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",110,000050
+RUSH,Garfield Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",49,000060
+RUSH,Hampton - Fairview Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",67,000070
+RUSH,Hampton - Fairview Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",81,000070
+RUSH,Illinois Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",23,000080
+RUSH,LaCrosse,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",148,000090
+RUSH,LaCrosse,Kansas House of Representatives,117,Republican,"Ewy, John L.",221,000090
+RUSH,Lone Star Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",114,000100
+RUSH,Pioneer Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",140,000110
+RUSH,Pleasantdale Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",10,000120
+RUSH,Union Township,Kansas House of Representatives,117,Democratic,"McKinney, Dennis",10,000130
+RUSH,Union Township,Kansas House of Representatives,117,Republican,"Ewy, John L.",22,000130
+RUSH,Alexander - Belle Prairie Township,Kansas Senate,33,Republican,"Holmes, Mitch",51,000010
+RUSH,Banner Township,Kansas Senate,33,Republican,"Holmes, Mitch",62,000020
+RUSH,Big Timber Township,Kansas Senate,33,Republican,"Holmes, Mitch",62,000030
+RUSH,Brookdale,Kansas Senate,33,Republican,"Holmes, Mitch",209,000040
+RUSH,Center Township,Kansas Senate,33,Republican,"Holmes, Mitch",105,000050
+RUSH,Garfield Township,Kansas Senate,33,Republican,"Holmes, Mitch",49,000060
+RUSH,Hampton - Fairview Township,Kansas Senate,33,Republican,"Holmes, Mitch",114,000070
+RUSH,Illinois Township,Kansas Senate,33,Republican,"Holmes, Mitch",22,000080
+RUSH,LaCrosse,Kansas Senate,33,Republican,"Holmes, Mitch",315,000090
+RUSH,Lone Star Township,Kansas Senate,33,Republican,"Holmes, Mitch",111,000100
+RUSH,Pioneer Township,Kansas Senate,33,Republican,"Holmes, Mitch",139,000110
+RUSH,Pleasantdale Township,Kansas Senate,33,Republican,"Holmes, Mitch",9,000120
+RUSH,Union Township,Kansas Senate,33,Republican,"Holmes, Mitch",26,000130
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,Democratic,"Obama, Barack",15,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,Republican,"Romney, Mitt",45,000010
+RUSH,Banner Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+RUSH,Banner Township,President / Vice President,,Democratic,"Obama, Barack",8,000020
+RUSH,Banner Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000020
+RUSH,Banner Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+RUSH,Banner Township,President / Vice President,,Republican,"Romney, Mitt",62,000020
+RUSH,Big Timber Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+RUSH,Big Timber Township,President / Vice President,,Democratic,"Obama, Barack",16,000030
+RUSH,Big Timber Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+RUSH,Big Timber Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+RUSH,Big Timber Township,President / Vice President,,Republican,"Romney, Mitt",56,000030
+RUSH,Brookdale,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Barnett, Andre",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Bush, Kent W",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Christensen, Will",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Goode, Virgil",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Stein, Jill E",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+RUSH,Brookdale,President / Vice President,,Democratic,"Obama, Barack",68,000040
+RUSH,Brookdale,President / Vice President,,Libertarian,"Johnson, Gary",4,000040
+RUSH,Brookdale,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+RUSH,Brookdale,President / Vice President,,Republican,"Romney, Mitt",179,000040
+RUSH,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+RUSH,Center Township,President / Vice President,,Democratic,"Obama, Barack",35,000050
+RUSH,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000050
+RUSH,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+RUSH,Center Township,President / Vice President,,Republican,"Romney, Mitt",92,000050
+RUSH,Garfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+RUSH,Garfield Township,President / Vice President,,Democratic,"Obama, Barack",15,000060
+RUSH,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+RUSH,Garfield Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+RUSH,Garfield Township,President / Vice President,,Republican,"Romney, Mitt",46,000060
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,Democratic,"Obama, Barack",45,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,Republican,"Romney, Mitt",104,000070
+RUSH,Illinois Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+RUSH,Illinois Township,President / Vice President,,Democratic,"Obama, Barack",11,000080
+RUSH,Illinois Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+RUSH,Illinois Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+RUSH,Illinois Township,President / Vice President,,Republican,"Romney, Mitt",23,000080
+RUSH,LaCrosse,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Barnett, Andre",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Bush, Kent W",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Christensen, Will",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Goode, Virgil",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Stein, Jill E",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+RUSH,LaCrosse,President / Vice President,,Democratic,"Obama, Barack",85,000090
+RUSH,LaCrosse,President / Vice President,,Libertarian,"Johnson, Gary",4,000090
+RUSH,LaCrosse,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+RUSH,LaCrosse,President / Vice President,,Republican,"Romney, Mitt",292,000090
+RUSH,Lone Star Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+RUSH,Lone Star Township,President / Vice President,,Democratic,"Obama, Barack",36,000100
+RUSH,Lone Star Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+RUSH,Lone Star Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000100
+RUSH,Lone Star Township,President / Vice President,,Republican,"Romney, Mitt",100,000100
+RUSH,Pioneer Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+RUSH,Pioneer Township,President / Vice President,,Democratic,"Obama, Barack",32,000110
+RUSH,Pioneer Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+RUSH,Pioneer Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000110
+RUSH,Pioneer Township,President / Vice President,,Republican,"Romney, Mitt",130,000110
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,Democratic,"Obama, Barack",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000120
+RUSH,Pleasantdale Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,Republican,"Romney, Mitt",9,000120
+RUSH,Union Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+RUSH,Union Township,President / Vice President,,Democratic,"Obama, Barack",1,000130
+RUSH,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000130
+RUSH,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+RUSH,Union Township,President / Vice President,,Republican,"Romney, Mitt",28,000130
+RUSH,Alexander - Belle Prairie Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000010
+RUSH,Banner Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",63,000020
+RUSH,Big Timber Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,000030
+RUSH,Brookdale,United States House of Representatives,1,Republican,"Huelskamp, Tim",213,000040
+RUSH,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",111,000050
+RUSH,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000060
+RUSH,Hampton - Fairview Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",115,000070
+RUSH,Illinois Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000080
+RUSH,LaCrosse,United States House of Representatives,1,Republican,"Huelskamp, Tim",318,000090
+RUSH,Lone Star Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",116,000100
+RUSH,Pioneer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",146,000110
+RUSH,Pleasantdale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",10,000120
+RUSH,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000130

--- a/2012/20121106__ks__general__russell__precinct.csv
+++ b/2012/20121106__ks__general__russell__precinct.csv
@@ -1,0 +1,457 @@
+county,precinct,office,district,party,candidate,votes,vtd
+RUSSELL,Big Creek Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",190,000010
+RUSSELL,Center Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",115,000020
+RUSSELL,Fairfield Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",24,000030
+RUSSELL,Fairview Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",194,000040
+RUSSELL,Grant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",91,000050
+RUSSELL,Lincoln Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",62,000060
+RUSSELL,Luray Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",128,000070
+RUSSELL,Paradise Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",72,000080
+RUSSELL,Plymouth Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",114,000090
+RUSSELL,Russell Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",50,000100
+RUSSELL,Russell Ward 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",424,000110
+RUSSELL,Russell Ward 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",490,000120
+RUSSELL,Russell Ward 3,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",426,000130
+RUSSELL,Russell Ward 4,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",433,00014A
+RUSSELL,Russell Ward 4 Exclave,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",0,00014C
+RUSSELL,Waldo Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",49,000150
+RUSSELL,Winterset Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",40,000160
+RUSSELL,Russell Township Exclave,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",0,900010
+RUSSELL,Big Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",20,000010
+RUSSELL,Big Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",168,000010
+RUSSELL,Center Township,Kansas Senate,36,Democratic,"Clark, Marquis",25,000020
+RUSSELL,Center Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",96,000020
+RUSSELL,Fairfield Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000030
+RUSSELL,Fairfield Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",21,000030
+RUSSELL,Fairview Township,Kansas Senate,36,Democratic,"Clark, Marquis",58,000040
+RUSSELL,Fairview Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",152,000040
+RUSSELL,Grant Township,Kansas Senate,36,Democratic,"Clark, Marquis",14,000050
+RUSSELL,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",79,000050
+RUSSELL,Lincoln Township,Kansas Senate,36,Democratic,"Clark, Marquis",13,000060
+RUSSELL,Lincoln Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",50,000060
+RUSSELL,Luray Township,Kansas Senate,36,Democratic,"Clark, Marquis",40,000070
+RUSSELL,Luray Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",86,000070
+RUSSELL,Paradise Township,Kansas Senate,36,Democratic,"Clark, Marquis",13,000080
+RUSSELL,Paradise Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",58,000080
+RUSSELL,Plymouth Township,Kansas Senate,36,Democratic,"Clark, Marquis",30,000090
+RUSSELL,Plymouth Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",86,000090
+RUSSELL,Russell Township,Kansas Senate,36,Democratic,"Clark, Marquis",9,000100
+RUSSELL,Russell Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",39,000100
+RUSSELL,Russell Ward 1,Kansas Senate,36,Democratic,"Clark, Marquis",78,000110
+RUSSELL,Russell Ward 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",372,000110
+RUSSELL,Russell Ward 2,Kansas Senate,36,Democratic,"Clark, Marquis",116,000120
+RUSSELL,Russell Ward 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",394,000120
+RUSSELL,Russell Ward 3,Kansas Senate,36,Democratic,"Clark, Marquis",101,000130
+RUSSELL,Russell Ward 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",335,000130
+RUSSELL,Russell Ward 4,Kansas Senate,36,Democratic,"Clark, Marquis",98,00014A
+RUSSELL,Russell Ward 4,Kansas Senate,36,Republican,"Bowers, Elaine S.",344,00014A
+RUSSELL,Russell Ward 4 Exclave,Kansas Senate,36,Democratic,"Clark, Marquis",0,00014B
+RUSSELL,Russell Ward 4 Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,Kansas Senate,36,Democratic,"Clark, Marquis",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00014C
+RUSSELL,Waldo Township,Kansas Senate,36,Democratic,"Clark, Marquis",14,000150
+RUSSELL,Waldo Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",30,000150
+RUSSELL,Winterset Township,Kansas Senate,36,Democratic,"Clark, Marquis",6,000160
+RUSSELL,Winterset Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",32,000160
+RUSSELL,Russell Township Exclave,Kansas Senate,36,Democratic,"Clark, Marquis",0,900010
+RUSSELL,Russell Township Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,900010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,Democratic,"Obama, Barack",21,000010
+RUSSELL,Big Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+RUSSELL,Big Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+RUSSELL,Big Creek Township,President / Vice President,,Republican,"Romney, Mitt",190,000010
+RUSSELL,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+RUSSELL,Center Township,President / Vice President,,Democratic,"Obama, Barack",20,000020
+RUSSELL,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+RUSSELL,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+RUSSELL,Center Township,President / Vice President,,Republican,"Romney, Mitt",106,000020
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,Democratic,"Obama, Barack",3,000030
+RUSSELL,Fairfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,Republican,"Romney, Mitt",21,000030
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+RUSSELL,Fairview Township,President / Vice President,,Democratic,"Obama, Barack",65,000040
+RUSSELL,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000040
+RUSSELL,Fairview Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+RUSSELL,Fairview Township,President / Vice President,,Republican,"Romney, Mitt",161,000040
+RUSSELL,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+RUSSELL,Grant Township,President / Vice President,,Democratic,"Obama, Barack",9,000050
+RUSSELL,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+RUSSELL,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+RUSSELL,Grant Township,President / Vice President,,Republican,"Romney, Mitt",92,000050
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",9,000060
+RUSSELL,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",58,000060
+RUSSELL,Luray Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+RUSSELL,Luray Township,President / Vice President,,Democratic,"Obama, Barack",43,000070
+RUSSELL,Luray Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000070
+RUSSELL,Luray Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+RUSSELL,Luray Township,President / Vice President,,Republican,"Romney, Mitt",85,000070
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+RUSSELL,Paradise Township,President / Vice President,,Democratic,"Obama, Barack",11,000080
+RUSSELL,Paradise Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+RUSSELL,Paradise Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000080
+RUSSELL,Paradise Township,President / Vice President,,Republican,"Romney, Mitt",71,000080
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,Democratic,"Obama, Barack",21,000090
+RUSSELL,Plymouth Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,Republican,"Romney, Mitt",107,000090
+RUSSELL,Russell Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+RUSSELL,Russell Township,President / Vice President,,Democratic,"Obama, Barack",5,000100
+RUSSELL,Russell Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+RUSSELL,Russell Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+RUSSELL,Russell Township,President / Vice President,,Republican,"Romney, Mitt",46,000100
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,Democratic,"Obama, Barack",78,000110
+RUSSELL,Russell Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000110
+RUSSELL,Russell Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",3,000110
+RUSSELL,Russell Ward 1,President / Vice President,,Republican,"Romney, Mitt",376,000110
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,Democratic,"Obama, Barack",112,000120
+RUSSELL,Russell Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+RUSSELL,Russell Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000120
+RUSSELL,Russell Ward 2,President / Vice President,,Republican,"Romney, Mitt",423,000120
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,Democratic,"Obama, Barack",101,000130
+RUSSELL,Russell Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",2,000130
+RUSSELL,Russell Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",4,000130
+RUSSELL,Russell Ward 3,President / Vice President,,Republican,"Romney, Mitt",369,000130
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Christensen, Will",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,Democratic,"Obama, Barack",79,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",4,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",6,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,Republican,"Romney, Mitt",372,00014A
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Ayers, Avery L",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Barnett, Andre",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Barr, Roseanne C",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Bush, Kent W",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Christensen, Will",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Duncan, Richard A",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Goode, Virgil",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Hoefling, Tom",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Knill, Dennis J",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Reed, Jill A.",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Rogers, Rick L",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Stein, Jill E",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Thorne, Kevin M",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Warner, Gerald L.",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,Democratic,"Obama, Barack",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,Reform,"Baldwin, Chuck",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,Republican,"Romney, Mitt",0,00014C
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+RUSSELL,Waldo Township,President / Vice President,,Democratic,"Obama, Barack",10,000150
+RUSSELL,Waldo Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000150
+RUSSELL,Waldo Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+RUSSELL,Waldo Township,President / Vice President,,Republican,"Romney, Mitt",40,000150
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+RUSSELL,Winterset Township,President / Vice President,,Democratic,"Obama, Barack",6,000160
+RUSSELL,Winterset Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000160
+RUSSELL,Winterset Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+RUSSELL,Winterset Township,President / Vice President,,Republican,"Romney, Mitt",36,000160
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Christensen, Will",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900010
+RUSSELL,Big Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",189,000010
+RUSSELL,Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",105,000020
+RUSSELL,Fairfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000030
+RUSSELL,Fairview Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",176,000040
+RUSSELL,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",87,000050
+RUSSELL,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",61,000060
+RUSSELL,Luray Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",107,000070
+RUSSELL,Paradise Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",70,000080
+RUSSELL,Plymouth Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",101,000090
+RUSSELL,Russell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",46,000100
+RUSSELL,Russell Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",409,000110
+RUSSELL,Russell Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",451,000120
+RUSSELL,Russell Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",405,000130
+RUSSELL,Russell Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",415,00014A
+RUSSELL,Russell Ward 4 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00014C
+RUSSELL,Waldo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,000150
+RUSSELL,Winterset Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000160
+RUSSELL,Russell Township Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010

--- a/2012/20121106__ks__general__saline__precinct.csv
+++ b/2012/20121106__ks__general__saline__precinct.csv
@@ -1,0 +1,1613 @@
+county,precinct,office,district,party,candidate,votes,vtd
+SALINE,Cambria Township,Kansas House of Representatives,71,Democratic,"Jilka, Alan",74,000010
+SALINE,Cambria Township,Kansas House of Representatives,71,Republican,"Dierks, Diana",119,000010
+SALINE,Dayton Township,Kansas House of Representatives,71,Democratic,"Jilka, Alan",22,000020
+SALINE,Dayton Township,Kansas House of Representatives,71,Republican,"Dierks, Diana",27,000020
+SALINE,Eureka Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",231,000040
+SALINE,Falun Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",106,000050
+SALINE,Glendale Township,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",12,000060
+SALINE,Glendale Township,Kansas House of Representatives,69,Republican,"Claeys, J.R.",27,000060
+SALINE,Greeley Township,Kansas House of Representatives,71,Democratic,"Jilka, Alan",132,000070
+SALINE,Greeley Township,Kansas House of Representatives,71,Republican,"Dierks, Diana",314,000070
+SALINE,Gypsum Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",81,000080
+SALINE,Liberty Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",87,000090
+SALINE,Ohio Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",173,000100
+SALINE,Pleasant Valley Township,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",64,000110
+SALINE,Pleasant Valley Township,Kansas House of Representatives,69,Republican,"Claeys, J.R.",118,000110
+SALINE,Salina Precinct 01 Part A,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",197,00012A
+SALINE,Salina Precinct 01 Part A,Kansas House of Representatives,69,Republican,"Claeys, J.R.",135,00012A
+SALINE,Salina Precinct 02,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",170,00013A
+SALINE,Salina Precinct 02,Kansas House of Representatives,69,Republican,"Claeys, J.R.",144,00013A
+SALINE,Salina Precinct 03,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",124,000140
+SALINE,Salina Precinct 03,Kansas House of Representatives,69,Republican,"Claeys, J.R.",126,000140
+SALINE,Salina Precinct 04,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",186,000150
+SALINE,Salina Precinct 04,Kansas House of Representatives,69,Republican,"Claeys, J.R.",154,000150
+SALINE,Salina Precinct 05,Kansas House of Representatives,71,Democratic,"Jilka, Alan",32,000160
+SALINE,Salina Precinct 05,Kansas House of Representatives,71,Republican,"Dierks, Diana",42,000160
+SALINE,Salina Precinct 06,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",158,000170
+SALINE,Salina Precinct 06,Kansas House of Representatives,69,Republican,"Claeys, J.R.",144,000170
+SALINE,Salina Precinct 07,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",213,000180
+SALINE,Salina Precinct 07,Kansas House of Representatives,69,Republican,"Claeys, J.R.",183,000180
+SALINE,Salina Precinct 08,Kansas House of Representatives,71,Democratic,"Jilka, Alan",200,000190
+SALINE,Salina Precinct 08,Kansas House of Representatives,71,Republican,"Dierks, Diana",193,000190
+SALINE,Salina Precinct 09,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",187,000200
+SALINE,Salina Precinct 09,Kansas House of Representatives,69,Republican,"Claeys, J.R.",194,000200
+SALINE,Salina Precinct 10,Kansas House of Representatives,71,Democratic,"Jilka, Alan",160,000210
+SALINE,Salina Precinct 10,Kansas House of Representatives,71,Republican,"Dierks, Diana",199,000210
+SALINE,Salina Precinct 11,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",176,000220
+SALINE,Salina Precinct 11,Kansas House of Representatives,69,Republican,"Claeys, J.R.",173,000220
+SALINE,Salina Precinct 12,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",274,000230
+SALINE,Salina Precinct 12,Kansas House of Representatives,69,Republican,"Claeys, J.R.",256,000230
+SALINE,Salina Precinct 13,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",160,000240
+SALINE,Salina Precinct 13,Kansas House of Representatives,69,Republican,"Claeys, J.R.",179,000240
+SALINE,Salina Precinct 14 Part A,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",223,00025A
+SALINE,Salina Precinct 14 Part A,Kansas House of Representatives,69,Republican,"Claeys, J.R.",220,00025A
+SALINE,Salina Precinct 15 Part A,Kansas House of Representatives,71,Democratic,"Jilka, Alan",175,00026A
+SALINE,Salina Precinct 15 Part A,Kansas House of Representatives,71,Republican,"Dierks, Diana",151,00026A
+SALINE,Salina Precinct 16,Kansas House of Representatives,71,Democratic,"Jilka, Alan",105,000270
+SALINE,Salina Precinct 16,Kansas House of Representatives,71,Republican,"Dierks, Diana",169,000270
+SALINE,Salina Precinct 17,Kansas House of Representatives,71,Democratic,"Jilka, Alan",163,000280
+SALINE,Salina Precinct 17,Kansas House of Representatives,71,Republican,"Dierks, Diana",157,000280
+SALINE,Salina Precinct 18,Kansas House of Representatives,71,Democratic,"Jilka, Alan",164,000290
+SALINE,Salina Precinct 18,Kansas House of Representatives,71,Republican,"Dierks, Diana",218,000290
+SALINE,Salina Precinct 19,Kansas House of Representatives,71,Democratic,"Jilka, Alan",170,000300
+SALINE,Salina Precinct 19,Kansas House of Representatives,71,Republican,"Dierks, Diana",306,000300
+SALINE,Salina Precinct 20 Part A,Kansas House of Representatives,71,Democratic,"Jilka, Alan",319,00031A
+SALINE,Salina Precinct 20 Part A,Kansas House of Representatives,71,Republican,"Dierks, Diana",648,00031A
+SALINE,Salina Precinct 21 Part A,Kansas House of Representatives,71,Democratic,"Jilka, Alan",325,00032A
+SALINE,Salina Precinct 21 Part A,Kansas House of Representatives,71,Republican,"Dierks, Diana",577,00032A
+SALINE,Salina Precinct 22 Part A,Kansas House of Representatives,71,Democratic,"Jilka, Alan",234,00033A
+SALINE,Salina Precinct 22 Part A,Kansas House of Representatives,71,Republican,"Dierks, Diana",561,00033A
+SALINE,Salina Precinct 23,Kansas House of Representatives,71,Democratic,"Jilka, Alan",385,000340
+SALINE,Salina Precinct 23,Kansas House of Representatives,71,Republican,"Dierks, Diana",621,000340
+SALINE,Salina Precinct 24,Kansas House of Representatives,71,Democratic,"Jilka, Alan",151,000350
+SALINE,Salina Precinct 24,Kansas House of Representatives,71,Republican,"Dierks, Diana",209,000350
+SALINE,Salina Precinct 25,Kansas House of Representatives,71,Democratic,"Jilka, Alan",124,000360
+SALINE,Salina Precinct 25,Kansas House of Representatives,71,Republican,"Dierks, Diana",168,000360
+SALINE,Salina Precinct 26,Kansas House of Representatives,71,Democratic,"Jilka, Alan",138,000370
+SALINE,Salina Precinct 26,Kansas House of Representatives,71,Republican,"Dierks, Diana",214,000370
+SALINE,Salina Precinct 27,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",200,000380
+SALINE,Salina Precinct 27,Kansas House of Representatives,69,Republican,"Claeys, J.R.",287,000380
+SALINE,Salina Precinct 28,Kansas House of Representatives,71,Democratic,"Jilka, Alan",125,000390
+SALINE,Salina Precinct 28,Kansas House of Representatives,71,Republican,"Dierks, Diana",233,000390
+SALINE,Salina Precinct 29,Kansas House of Representatives,71,Democratic,"Jilka, Alan",194,000400
+SALINE,Salina Precinct 29,Kansas House of Representatives,71,Republican,"Dierks, Diana",351,000400
+SALINE,Salina Precinct 30,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",183,000410
+SALINE,Salina Precinct 30,Kansas House of Representatives,69,Republican,"Claeys, J.R.",237,000410
+SALINE,Salina Precinct 31 Part A,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",379,00042A
+SALINE,Salina Precinct 31 Part A,Kansas House of Representatives,69,Republican,"Claeys, J.R.",656,00042A
+SALINE,Salina Precinct 32,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",120,000430
+SALINE,Salina Precinct 32,Kansas House of Representatives,69,Republican,"Claeys, J.R.",189,000430
+SALINE,Salina Precinct 33,Kansas House of Representatives,108,Republican,"Johnson, Steven",520,000440
+SALINE,Salina Precinct 34,Kansas House of Representatives,108,Republican,"Johnson, Steven",796,000450
+SALINE,Salina Precinct 35,Kansas House of Representatives,108,Republican,"Johnson, Steven",533,00046A
+SALINE,Smokey Hill Township Part B,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",50,00047B
+SALINE,Smokey Hill Township Part B,Kansas House of Representatives,69,Republican,"Claeys, J.R.",66,00047B
+SALINE,Smoky View Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",354,000480
+SALINE,Smolan Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",329,000490
+SALINE,Solomon Township,Kansas House of Representatives,71,Democratic,"Jilka, Alan",54,000500
+SALINE,Solomon Township,Kansas House of Representatives,71,Republican,"Dierks, Diana",142,000500
+SALINE,Spring Creek Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",173,000510
+SALINE,Walnut Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",258,000520
+SALINE,Elm Creek Township H69,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",166,120020
+SALINE,Elm Creek Township H69,Kansas House of Representatives,69,Republican,"Claeys, J.R.",309,120020
+SALINE,Elm Creek Township H71,Kansas House of Representatives,71,Democratic,"Jilka, Alan",0,120030
+SALINE,Elm Creek Township H71,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,120030
+SALINE,Washington Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",75,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,Kansas House of Representatives,69,Republican,"Claeys, J.R.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,Kansas House of Representatives,69,Republican,"Claeys, J.R.",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,Kansas House of Representatives,71,Democratic,"Jilka, Alan",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,Kansas House of Representatives,71,Democratic,"Jilka, Alan",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,Kansas House of Representatives,71,Democratic,"Jilka, Alan",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,Kansas House of Representatives,71,Democratic,"Jilka, Alan",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,Kansas House of Representatives,71,Democratic,"Jilka, Alan",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900070
+SALINE,Salina Precinct 33 Exclave,Kansas House of Representatives,108,Republican,"Johnson, Steven",0,900080
+SALINE,Salina Precinct 35 Exclave,Kansas House of Representatives,108,Republican,"Johnson, Steven",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,Kansas House of Representatives,71,Democratic,"Jilka, Alan",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,Kansas House of Representatives,69,Republican,"Claeys, J.R.",0,900110
+SALINE,ADVANCED,Kansas House of Representatives,69,Democratic,"Swartzendruber, Gary",0,999998
+SALINE,ADVANCED,Kansas House of Representatives,69,Republican,"Claeys, J.R.",0,999998
+SALINE,Cambria Township,Kansas Senate,24,Democratic,"Norlin, Janice",75,000010
+SALINE,Cambria Township,Kansas Senate,24,Republican,"Arpke, Tom",119,000010
+SALINE,Dayton Township,Kansas Senate,24,Democratic,"Norlin, Janice",27,000020
+SALINE,Dayton Township,Kansas Senate,24,Republican,"Arpke, Tom",25,000020
+SALINE,Eureka Township,Kansas Senate,24,Democratic,"Norlin, Janice",93,000040
+SALINE,Eureka Township,Kansas Senate,24,Republican,"Arpke, Tom",162,000040
+SALINE,Falun Township,Kansas Senate,24,Democratic,"Norlin, Janice",37,000050
+SALINE,Falun Township,Kansas Senate,24,Republican,"Arpke, Tom",83,000050
+SALINE,Glendale Township,Kansas Senate,24,Democratic,"Norlin, Janice",12,000060
+SALINE,Glendale Township,Kansas Senate,24,Republican,"Arpke, Tom",28,000060
+SALINE,Greeley Township,Kansas Senate,24,Democratic,"Norlin, Janice",141,000070
+SALINE,Greeley Township,Kansas Senate,24,Republican,"Arpke, Tom",304,000070
+SALINE,Gypsum Township,Kansas Senate,24,Democratic,"Norlin, Janice",17,000080
+SALINE,Gypsum Township,Kansas Senate,24,Republican,"Arpke, Tom",67,000080
+SALINE,Liberty Township,Kansas Senate,24,Democratic,"Norlin, Janice",34,000090
+SALINE,Liberty Township,Kansas Senate,24,Republican,"Arpke, Tom",52,000090
+SALINE,Ohio Township,Kansas Senate,24,Democratic,"Norlin, Janice",67,000100
+SALINE,Ohio Township,Kansas Senate,24,Republican,"Arpke, Tom",129,000100
+SALINE,Pleasant Valley Township,Kansas Senate,24,Democratic,"Norlin, Janice",54,000110
+SALINE,Pleasant Valley Township,Kansas Senate,24,Republican,"Arpke, Tom",133,000110
+SALINE,Salina Precinct 01 Part A,Kansas Senate,24,Democratic,"Norlin, Janice",192,00012A
+SALINE,Salina Precinct 01 Part A,Kansas Senate,24,Republican,"Arpke, Tom",150,00012A
+SALINE,Salina Precinct 02,Kansas Senate,24,Democratic,"Norlin, Janice",163,00013A
+SALINE,Salina Precinct 02,Kansas Senate,24,Republican,"Arpke, Tom",165,00013A
+SALINE,Salina Precinct 03,Kansas Senate,24,Democratic,"Norlin, Janice",144,000140
+SALINE,Salina Precinct 03,Kansas Senate,24,Republican,"Arpke, Tom",112,000140
+SALINE,Salina Precinct 04,Kansas Senate,24,Democratic,"Norlin, Janice",184,000150
+SALINE,Salina Precinct 04,Kansas Senate,24,Republican,"Arpke, Tom",173,000150
+SALINE,Salina Precinct 05,Kansas Senate,24,Democratic,"Norlin, Janice",176,000160
+SALINE,Salina Precinct 05,Kansas Senate,24,Republican,"Arpke, Tom",176,000160
+SALINE,Salina Precinct 06,Kansas Senate,24,Democratic,"Norlin, Janice",162,000170
+SALINE,Salina Precinct 06,Kansas Senate,24,Republican,"Arpke, Tom",147,000170
+SALINE,Salina Precinct 07,Kansas Senate,24,Democratic,"Norlin, Janice",202,000180
+SALINE,Salina Precinct 07,Kansas Senate,24,Republican,"Arpke, Tom",214,000180
+SALINE,Salina Precinct 08,Kansas Senate,24,Democratic,"Norlin, Janice",201,000190
+SALINE,Salina Precinct 08,Kansas Senate,24,Republican,"Arpke, Tom",192,000190
+SALINE,Salina Precinct 09,Kansas Senate,24,Democratic,"Norlin, Janice",194,000200
+SALINE,Salina Precinct 09,Kansas Senate,24,Republican,"Arpke, Tom",202,000200
+SALINE,Salina Precinct 10,Kansas Senate,24,Democratic,"Norlin, Janice",184,000210
+SALINE,Salina Precinct 10,Kansas Senate,24,Republican,"Arpke, Tom",179,000210
+SALINE,Salina Precinct 11,Kansas Senate,24,Democratic,"Norlin, Janice",173,000220
+SALINE,Salina Precinct 11,Kansas Senate,24,Republican,"Arpke, Tom",190,000220
+SALINE,Salina Precinct 12,Kansas Senate,24,Democratic,"Norlin, Janice",303,000230
+SALINE,Salina Precinct 12,Kansas Senate,24,Republican,"Arpke, Tom",255,000230
+SALINE,Salina Precinct 13,Kansas Senate,24,Democratic,"Norlin, Janice",166,000240
+SALINE,Salina Precinct 13,Kansas Senate,24,Republican,"Arpke, Tom",182,000240
+SALINE,Salina Precinct 14 Part A,Kansas Senate,24,Democratic,"Norlin, Janice",212,00025A
+SALINE,Salina Precinct 14 Part A,Kansas Senate,24,Republican,"Arpke, Tom",250,00025A
+SALINE,Salina Precinct 15 Part A,Kansas Senate,24,Democratic,"Norlin, Janice",191,00026A
+SALINE,Salina Precinct 15 Part A,Kansas Senate,24,Republican,"Arpke, Tom",133,00026A
+SALINE,Salina Precinct 16,Kansas Senate,24,Democratic,"Norlin, Janice",133,000270
+SALINE,Salina Precinct 16,Kansas Senate,24,Republican,"Arpke, Tom",145,000270
+SALINE,Salina Precinct 17,Kansas Senate,24,Democratic,"Norlin, Janice",167,000280
+SALINE,Salina Precinct 17,Kansas Senate,24,Republican,"Arpke, Tom",156,000280
+SALINE,Salina Precinct 18,Kansas Senate,24,Democratic,"Norlin, Janice",195,000290
+SALINE,Salina Precinct 18,Kansas Senate,24,Republican,"Arpke, Tom",189,000290
+SALINE,Salina Precinct 19,Kansas Senate,24,Democratic,"Norlin, Janice",206,000300
+SALINE,Salina Precinct 19,Kansas Senate,24,Republican,"Arpke, Tom",262,000300
+SALINE,Salina Precinct 20 Part A,Kansas Senate,24,Democratic,"Norlin, Janice",495,00031A
+SALINE,Salina Precinct 20 Part A,Kansas Senate,24,Republican,"Arpke, Tom",464,00031A
+SALINE,Salina Precinct 21 Part A,Kansas Senate,24,Democratic,"Norlin, Janice",461,00032A
+SALINE,Salina Precinct 21 Part A,Kansas Senate,24,Republican,"Arpke, Tom",447,00032A
+SALINE,Salina Precinct 22 Part A,Kansas Senate,24,Democratic,"Norlin, Janice",355,00033A
+SALINE,Salina Precinct 22 Part A,Kansas Senate,24,Republican,"Arpke, Tom",436,00033A
+SALINE,Salina Precinct 23,Kansas Senate,24,Democratic,"Norlin, Janice",464,000340
+SALINE,Salina Precinct 23,Kansas Senate,24,Republican,"Arpke, Tom",545,000340
+SALINE,Salina Precinct 24,Kansas Senate,24,Democratic,"Norlin, Janice",180,000350
+SALINE,Salina Precinct 24,Kansas Senate,24,Republican,"Arpke, Tom",181,000350
+SALINE,Salina Precinct 25,Kansas Senate,24,Democratic,"Norlin, Janice",160,000360
+SALINE,Salina Precinct 25,Kansas Senate,24,Republican,"Arpke, Tom",134,000360
+SALINE,Salina Precinct 26,Kansas Senate,24,Democratic,"Norlin, Janice",199,000370
+SALINE,Salina Precinct 26,Kansas Senate,24,Republican,"Arpke, Tom",152,000370
+SALINE,Salina Precinct 27,Kansas Senate,24,Democratic,"Norlin, Janice",246,000380
+SALINE,Salina Precinct 27,Kansas Senate,24,Republican,"Arpke, Tom",269,000380
+SALINE,Salina Precinct 28,Kansas Senate,24,Democratic,"Norlin, Janice",144,000390
+SALINE,Salina Precinct 28,Kansas Senate,24,Republican,"Arpke, Tom",214,000390
+SALINE,Salina Precinct 29,Kansas Senate,24,Democratic,"Norlin, Janice",247,000400
+SALINE,Salina Precinct 29,Kansas Senate,24,Republican,"Arpke, Tom",292,000400
+SALINE,Salina Precinct 30,Kansas Senate,24,Democratic,"Norlin, Janice",193,000410
+SALINE,Salina Precinct 30,Kansas Senate,24,Republican,"Arpke, Tom",245,000410
+SALINE,Salina Precinct 31 Part A,Kansas Senate,24,Democratic,"Norlin, Janice",452,00042A
+SALINE,Salina Precinct 31 Part A,Kansas Senate,24,Republican,"Arpke, Tom",631,00042A
+SALINE,Salina Precinct 32,Kansas Senate,24,Democratic,"Norlin, Janice",125,000430
+SALINE,Salina Precinct 32,Kansas Senate,24,Republican,"Arpke, Tom",197,000430
+SALINE,Salina Precinct 33,Kansas Senate,24,Democratic,"Norlin, Janice",263,000440
+SALINE,Salina Precinct 33,Kansas Senate,24,Republican,"Arpke, Tom",344,000440
+SALINE,Salina Precinct 34,Kansas Senate,24,Democratic,"Norlin, Janice",438,000450
+SALINE,Salina Precinct 34,Kansas Senate,24,Republican,"Arpke, Tom",520,000450
+SALINE,Salina Precinct 35,Kansas Senate,24,Democratic,"Norlin, Janice",307,00046A
+SALINE,Salina Precinct 35,Kansas Senate,24,Republican,"Arpke, Tom",371,00046A
+SALINE,Smokey Hill Township Part B,Kansas Senate,24,Democratic,"Norlin, Janice",47,00047B
+SALINE,Smokey Hill Township Part B,Kansas Senate,24,Republican,"Arpke, Tom",74,00047B
+SALINE,Smoky View Township,Kansas Senate,24,Democratic,"Norlin, Janice",156,000480
+SALINE,Smoky View Township,Kansas Senate,24,Republican,"Arpke, Tom",215,000480
+SALINE,Smolan Township,Kansas Senate,24,Democratic,"Norlin, Janice",162,000490
+SALINE,Smolan Township,Kansas Senate,24,Republican,"Arpke, Tom",205,000490
+SALINE,Solomon Township,Kansas Senate,24,Democratic,"Norlin, Janice",68,000500
+SALINE,Solomon Township,Kansas Senate,24,Republican,"Arpke, Tom",135,000500
+SALINE,Spring Creek Township,Kansas Senate,24,Democratic,"Norlin, Janice",55,000510
+SALINE,Spring Creek Township,Kansas Senate,24,Republican,"Arpke, Tom",134,000510
+SALINE,Walnut Township,Kansas Senate,24,Democratic,"Norlin, Janice",109,000520
+SALINE,Walnut Township,Kansas Senate,24,Republican,"Arpke, Tom",178,000520
+SALINE,Elm Creek Township H69,Kansas Senate,24,Democratic,"Norlin, Janice",177,120020
+SALINE,Elm Creek Township H69,Kansas Senate,24,Republican,"Arpke, Tom",312,120020
+SALINE,Elm Creek Township H71,Kansas Senate,24,Democratic,"Norlin, Janice",0,120030
+SALINE,Elm Creek Township H71,Kansas Senate,24,Republican,"Arpke, Tom",0,120030
+SALINE,Washington Township,Kansas Senate,24,Democratic,"Norlin, Janice",30,300010
+SALINE,Washington Township,Kansas Senate,24,Republican,"Arpke, Tom",51,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,Kansas Senate,24,Democratic,"Norlin, Janice",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,Kansas Senate,24,Republican,"Arpke, Tom",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,Kansas Senate,24,Democratic,"Norlin, Janice",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,Kansas Senate,24,Republican,"Arpke, Tom",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,Kansas Senate,24,Democratic,"Norlin, Janice",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,Kansas Senate,24,Republican,"Arpke, Tom",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,Kansas Senate,24,Democratic,"Norlin, Janice",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,Kansas Senate,24,Republican,"Arpke, Tom",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,Kansas Senate,24,Democratic,"Norlin, Janice",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,Kansas Senate,24,Republican,"Arpke, Tom",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,Kansas Senate,24,Democratic,"Norlin, Janice",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,Kansas Senate,24,Republican,"Arpke, Tom",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,Kansas Senate,24,Democratic,"Norlin, Janice",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,Kansas Senate,24,Republican,"Arpke, Tom",0,900070
+SALINE,Salina Precinct 33 Exclave,Kansas Senate,24,Democratic,"Norlin, Janice",0,900080
+SALINE,Salina Precinct 33 Exclave,Kansas Senate,24,Republican,"Arpke, Tom",0,900080
+SALINE,Salina Precinct 35 Exclave,Kansas Senate,24,Democratic,"Norlin, Janice",0,900090
+SALINE,Salina Precinct 35 Exclave,Kansas Senate,24,Republican,"Arpke, Tom",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,Kansas Senate,24,Democratic,"Norlin, Janice",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,Kansas Senate,24,Republican,"Arpke, Tom",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,Kansas Senate,24,Democratic,"Norlin, Janice",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,Kansas Senate,24,Republican,"Arpke, Tom",0,900110
+SALINE,Cambria Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+SALINE,Cambria Township,President / Vice President,,Democratic,"Obama, Barack",46,000010
+SALINE,Cambria Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000010
+SALINE,Cambria Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+SALINE,Cambria Township,President / Vice President,,Republican,"Romney, Mitt",145,000010
+SALINE,Dayton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+SALINE,Dayton Township,President / Vice President,,Democratic,"Obama, Barack",19,000020
+SALINE,Dayton Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000020
+SALINE,Dayton Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+SALINE,Dayton Township,President / Vice President,,Republican,"Romney, Mitt",30,000020
+SALINE,Eureka Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+SALINE,Eureka Township,President / Vice President,,Democratic,"Obama, Barack",61,000040
+SALINE,Eureka Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000040
+SALINE,Eureka Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000040
+SALINE,Eureka Township,President / Vice President,,Republican,"Romney, Mitt",199,000040
+SALINE,Falun Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+SALINE,Falun Township,President / Vice President,,Democratic,"Obama, Barack",19,000050
+SALINE,Falun Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000050
+SALINE,Falun Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+SALINE,Falun Township,President / Vice President,,Republican,"Romney, Mitt",102,000050
+SALINE,Glendale Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+SALINE,Glendale Township,President / Vice President,,Democratic,"Obama, Barack",11,000060
+SALINE,Glendale Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+SALINE,Glendale Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+SALINE,Glendale Township,President / Vice President,,Republican,"Romney, Mitt",31,000060
+SALINE,Greeley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+SALINE,Greeley Township,President / Vice President,,Democratic,"Obama, Barack",83,000070
+SALINE,Greeley Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+SALINE,Greeley Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+SALINE,Greeley Township,President / Vice President,,Republican,"Romney, Mitt",374,000070
+SALINE,Gypsum Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+SALINE,Gypsum Township,President / Vice President,,Democratic,"Obama, Barack",6,000080
+SALINE,Gypsum Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+SALINE,Gypsum Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+SALINE,Gypsum Township,President / Vice President,,Republican,"Romney, Mitt",78,000080
+SALINE,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+SALINE,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",15,000090
+SALINE,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000090
+SALINE,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000090
+SALINE,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",68,000090
+SALINE,Ohio Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+SALINE,Ohio Township,President / Vice President,,Democratic,"Obama, Barack",35,000100
+SALINE,Ohio Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000100
+SALINE,Ohio Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+SALINE,Ohio Township,President / Vice President,,Republican,"Romney, Mitt",159,000100
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,Democratic,"Obama, Barack",24,000110
+SALINE,Pleasant Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000110
+SALINE,Pleasant Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+SALINE,Pleasant Valley Township,President / Vice President,,Republican,"Romney, Mitt",154,000110
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Barnett, Andre",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Bush, Kent W",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Christensen, Will",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Goode, Virgil",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Stein, Jill E",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,Democratic,"Obama, Barack",161,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,Libertarian,"Johnson, Gary",10,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,Reform,"Baldwin, Chuck",4,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,Republican,"Romney, Mitt",178,00012A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Barnett, Andre",1,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,Democratic,"Obama, Barack",134,00013A
+SALINE,Salina Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",17,00013A
+SALINE,Salina Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",1,00013A
+SALINE,Salina Precinct 02,President / Vice President,,Republican,"Romney, Mitt",172,00013A
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Stein, Jill E",1,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,Democratic,"Obama, Barack",118,000140
+SALINE,Salina Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",6,000140
+SALINE,Salina Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+SALINE,Salina Precinct 03,President / Vice President,,Republican,"Romney, Mitt",140,000140
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,Democratic,"Obama, Barack",160,000150
+SALINE,Salina Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",13,000150
+SALINE,Salina Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",4,000150
+SALINE,Salina Precinct 04,President / Vice President,,Republican,"Romney, Mitt",188,000150
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,Democratic,"Obama, Barack",154,000160
+SALINE,Salina Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",19,000160
+SALINE,Salina Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",5,000160
+SALINE,Salina Precinct 05,President / Vice President,,Republican,"Romney, Mitt",180,000160
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Barnett, Andre",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Bush, Kent W",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Christensen, Will",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Goode, Virgil",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Stein, Jill E",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,Democratic,"Obama, Barack",143,000170
+SALINE,Salina Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",15,000170
+SALINE,Salina Precinct 06,President / Vice President,,Reform,"Baldwin, Chuck",5,000170
+SALINE,Salina Precinct 06,President / Vice President,,Republican,"Romney, Mitt",159,000170
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Barnett, Andre",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Bush, Kent W",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Christensen, Will",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Goode, Virgil",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Stein, Jill E",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,Democratic,"Obama, Barack",181,000180
+SALINE,Salina Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",17,000180
+SALINE,Salina Precinct 07,President / Vice President,,Reform,"Baldwin, Chuck",3,000180
+SALINE,Salina Precinct 07,President / Vice President,,Republican,"Romney, Mitt",224,000180
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Barnett, Andre",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Bush, Kent W",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Christensen, Will",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Goode, Virgil",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Stein, Jill E",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,Democratic,"Obama, Barack",182,000190
+SALINE,Salina Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",7,000190
+SALINE,Salina Precinct 08,President / Vice President,,Reform,"Baldwin, Chuck",1,000190
+SALINE,Salina Precinct 08,President / Vice President,,Republican,"Romney, Mitt",210,000190
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Barnett, Andre",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Bush, Kent W",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Christensen, Will",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Goode, Virgil",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Stein, Jill E",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,Democratic,"Obama, Barack",154,000200
+SALINE,Salina Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",23,000200
+SALINE,Salina Precinct 09,President / Vice President,,Reform,"Baldwin, Chuck",2,000200
+SALINE,Salina Precinct 09,President / Vice President,,Republican,"Romney, Mitt",227,000200
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Barnett, Andre",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Bush, Kent W",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Christensen, Will",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Goode, Virgil",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Stein, Jill E",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,Democratic,"Obama, Barack",152,000210
+SALINE,Salina Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",13,000210
+SALINE,Salina Precinct 10,President / Vice President,,Reform,"Baldwin, Chuck",3,000210
+SALINE,Salina Precinct 10,President / Vice President,,Republican,"Romney, Mitt",199,000210
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Barnett, Andre",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Bush, Kent W",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Christensen, Will",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Goode, Virgil",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Stein, Jill E",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,Democratic,"Obama, Barack",146,000220
+SALINE,Salina Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",6,000220
+SALINE,Salina Precinct 11,President / Vice President,,Reform,"Baldwin, Chuck",1,000220
+SALINE,Salina Precinct 11,President / Vice President,,Republican,"Romney, Mitt",222,000220
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Barnett, Andre",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Bush, Kent W",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Christensen, Will",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Goode, Virgil",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Stein, Jill E",1,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,Democratic,"Obama, Barack",238,000230
+SALINE,Salina Precinct 12,President / Vice President,,Libertarian,"Johnson, Gary",22,000230
+SALINE,Salina Precinct 12,President / Vice President,,Reform,"Baldwin, Chuck",3,000230
+SALINE,Salina Precinct 12,President / Vice President,,Republican,"Romney, Mitt",294,000230
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Barnett, Andre",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Bush, Kent W",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Christensen, Will",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Goode, Virgil",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Stein, Jill E",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,Democratic,"Obama, Barack",134,000240
+SALINE,Salina Precinct 13,President / Vice President,,Libertarian,"Johnson, Gary",6,000240
+SALINE,Salina Precinct 13,President / Vice President,,Reform,"Baldwin, Chuck",1,000240
+SALINE,Salina Precinct 13,President / Vice President,,Republican,"Romney, Mitt",210,000240
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Barnett, Andre",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Bush, Kent W",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Christensen, Will",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Goode, Virgil",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Stein, Jill E",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,Democratic,"Obama, Barack",183,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,Libertarian,"Johnson, Gary",15,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,Reform,"Baldwin, Chuck",3,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,Republican,"Romney, Mitt",275,00025A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Barnett, Andre",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Bush, Kent W",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Christensen, Will",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Goode, Virgil",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Stein, Jill E",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,Democratic,"Obama, Barack",181,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,Libertarian,"Johnson, Gary",6,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,Reform,"Baldwin, Chuck",2,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,Republican,"Romney, Mitt",157,00026A
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Ayers, Avery L",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Barnett, Andre",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Barr, Roseanne C",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Bush, Kent W",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Christensen, Will",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Duncan, Richard A",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Goode, Virgil",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Knill, Dennis J",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Reed, Jill A.",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Rogers, Rick L",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Stein, Jill E",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Thorne, Kevin M",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Warner, Gerald L.",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,Democratic,"Obama, Barack",105,000270
+SALINE,Salina Precinct 16,President / Vice President,,Libertarian,"Johnson, Gary",6,000270
+SALINE,Salina Precinct 16,President / Vice President,,Reform,"Baldwin, Chuck",1,000270
+SALINE,Salina Precinct 16,President / Vice President,,Republican,"Romney, Mitt",170,000270
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Barnett, Andre",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Bush, Kent W",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Christensen, Will",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Goode, Virgil",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Stein, Jill E",1,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,Democratic,"Obama, Barack",150,000280
+SALINE,Salina Precinct 17,President / Vice President,,Libertarian,"Johnson, Gary",9,000280
+SALINE,Salina Precinct 17,President / Vice President,,Reform,"Baldwin, Chuck",2,000280
+SALINE,Salina Precinct 17,President / Vice President,,Republican,"Romney, Mitt",169,000280
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Barnett, Andre",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Bush, Kent W",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Christensen, Will",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Goode, Virgil",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Stein, Jill E",1,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,Democratic,"Obama, Barack",137,000290
+SALINE,Salina Precinct 18,President / Vice President,,Libertarian,"Johnson, Gary",5,000290
+SALINE,Salina Precinct 18,President / Vice President,,Reform,"Baldwin, Chuck",2,000290
+SALINE,Salina Precinct 18,President / Vice President,,Republican,"Romney, Mitt",247,000290
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Barnett, Andre",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Bush, Kent W",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Christensen, Will",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Goode, Virgil",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Stein, Jill E",2,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,Democratic,"Obama, Barack",127,000300
+SALINE,Salina Precinct 19,President / Vice President,,Libertarian,"Johnson, Gary",7,000300
+SALINE,Salina Precinct 19,President / Vice President,,Reform,"Baldwin, Chuck",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,Republican,"Romney, Mitt",348,000300
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Barnett, Andre",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Bush, Kent W",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Christensen, Will",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Goode, Virgil",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Stein, Jill E",1,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,Democratic,"Obama, Barack",267,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,Libertarian,"Johnson, Gary",9,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,Reform,"Baldwin, Chuck",2,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,Republican,"Romney, Mitt",709,00031A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Barnett, Andre",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Bush, Kent W",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Christensen, Will",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Goode, Virgil",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Stein, Jill E",1,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,Democratic,"Obama, Barack",282,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,Libertarian,"Johnson, Gary",14,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,Reform,"Baldwin, Chuck",1,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,Republican,"Romney, Mitt",634,00032A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Barnett, Andre",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Bush, Kent W",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Christensen, Will",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Goode, Virgil",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Stein, Jill E",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,Democratic,"Obama, Barack",198,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,Libertarian,"Johnson, Gary",10,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,Reform,"Baldwin, Chuck",2,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,Republican,"Romney, Mitt",607,00033A
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Ayers, Avery L",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Barnett, Andre",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Barr, Roseanne C",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Bush, Kent W",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Christensen, Will",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Duncan, Richard A",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Goode, Virgil",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Knill, Dennis J",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Reed, Jill A.",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Rogers, Rick L",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Stein, Jill E",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Thorne, Kevin M",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Warner, Gerald L.",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,Democratic,"Obama, Barack",342,000340
+SALINE,Salina Precinct 23,President / Vice President,,Libertarian,"Johnson, Gary",10,000340
+SALINE,Salina Precinct 23,President / Vice President,,Reform,"Baldwin, Chuck",9,000340
+SALINE,Salina Precinct 23,President / Vice President,,Republican,"Romney, Mitt",678,000340
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Ayers, Avery L",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Barnett, Andre",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Barr, Roseanne C",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Bush, Kent W",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Christensen, Will",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Duncan, Richard A",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Goode, Virgil",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Knill, Dennis J",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Reed, Jill A.",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Rogers, Rick L",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Stein, Jill E",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Thorne, Kevin M",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Warner, Gerald L.",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,Democratic,"Obama, Barack",141,000350
+SALINE,Salina Precinct 24,President / Vice President,,Libertarian,"Johnson, Gary",7,000350
+SALINE,Salina Precinct 24,President / Vice President,,Reform,"Baldwin, Chuck",1,000350
+SALINE,Salina Precinct 24,President / Vice President,,Republican,"Romney, Mitt",216,000350
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Ayers, Avery L",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Barnett, Andre",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Barr, Roseanne C",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Bush, Kent W",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Christensen, Will",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Duncan, Richard A",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Goode, Virgil",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Knill, Dennis J",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Reed, Jill A.",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Rogers, Rick L",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Stein, Jill E",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Thorne, Kevin M",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Warner, Gerald L.",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,Democratic,"Obama, Barack",123,000360
+SALINE,Salina Precinct 25,President / Vice President,,Libertarian,"Johnson, Gary",18,000360
+SALINE,Salina Precinct 25,President / Vice President,,Reform,"Baldwin, Chuck",3,000360
+SALINE,Salina Precinct 25,President / Vice President,,Republican,"Romney, Mitt",152,000360
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Ayers, Avery L",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Barnett, Andre",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Barr, Roseanne C",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Bush, Kent W",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Christensen, Will",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Duncan, Richard A",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Goode, Virgil",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Knill, Dennis J",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Reed, Jill A.",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Rogers, Rick L",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Stein, Jill E",1,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Thorne, Kevin M",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Warner, Gerald L.",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,Democratic,"Obama, Barack",131,000370
+SALINE,Salina Precinct 26,President / Vice President,,Libertarian,"Johnson, Gary",7,000370
+SALINE,Salina Precinct 26,President / Vice President,,Reform,"Baldwin, Chuck",1,000370
+SALINE,Salina Precinct 26,President / Vice President,,Republican,"Romney, Mitt",218,000370
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Ayers, Avery L",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Barnett, Andre",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Barr, Roseanne C",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Bush, Kent W",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Christensen, Will",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Duncan, Richard A",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Goode, Virgil",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Knill, Dennis J",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Reed, Jill A.",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Rogers, Rick L",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Stein, Jill E",1,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Thorne, Kevin M",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Warner, Gerald L.",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,Democratic,"Obama, Barack",176,000380
+SALINE,Salina Precinct 27,President / Vice President,,Libertarian,"Johnson, Gary",17,000380
+SALINE,Salina Precinct 27,President / Vice President,,Reform,"Baldwin, Chuck",2,000380
+SALINE,Salina Precinct 27,President / Vice President,,Republican,"Romney, Mitt",328,000380
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Ayers, Avery L",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Barnett, Andre",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Barr, Roseanne C",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Bush, Kent W",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Christensen, Will",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Duncan, Richard A",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Goode, Virgil",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Hoefling, Tom",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Knill, Dennis J",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Reed, Jill A.",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Rogers, Rick L",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Stein, Jill E",1,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Thorne, Kevin M",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Warner, Gerald L.",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,Democratic,"Obama, Barack",108,000390
+SALINE,Salina Precinct 28,President / Vice President,,Libertarian,"Johnson, Gary",8,000390
+SALINE,Salina Precinct 28,President / Vice President,,Reform,"Baldwin, Chuck",3,000390
+SALINE,Salina Precinct 28,President / Vice President,,Republican,"Romney, Mitt",251,000390
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Ayers, Avery L",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Barnett, Andre",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Barr, Roseanne C",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Bush, Kent W",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Christensen, Will",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Duncan, Richard A",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Goode, Virgil",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Knill, Dennis J",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Reed, Jill A.",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Rogers, Rick L",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Stein, Jill E",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Thorne, Kevin M",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Warner, Gerald L.",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,Democratic,"Obama, Barack",173,000400
+SALINE,Salina Precinct 29,President / Vice President,,Libertarian,"Johnson, Gary",7,000400
+SALINE,Salina Precinct 29,President / Vice President,,Reform,"Baldwin, Chuck",2,000400
+SALINE,Salina Precinct 29,President / Vice President,,Republican,"Romney, Mitt",373,000400
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Ayers, Avery L",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Barnett, Andre",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Barr, Roseanne C",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Bush, Kent W",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Christensen, Will",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Duncan, Richard A",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Goode, Virgil",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Hoefling, Tom",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Knill, Dennis J",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Reed, Jill A.",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Rogers, Rick L",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Stein, Jill E",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Thorne, Kevin M",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Warner, Gerald L.",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,Democratic,"Obama, Barack",150,000410
+SALINE,Salina Precinct 30,President / Vice President,,Libertarian,"Johnson, Gary",6,000410
+SALINE,Salina Precinct 30,President / Vice President,,Reform,"Baldwin, Chuck",1,000410
+SALINE,Salina Precinct 30,President / Vice President,,Republican,"Romney, Mitt",297,000410
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Ayers, Avery L",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Barnett, Andre",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Barr, Roseanne C",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Bush, Kent W",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Christensen, Will",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Duncan, Richard A",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Goode, Virgil",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Knill, Dennis J",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Reed, Jill A.",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Rogers, Rick L",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Stein, Jill E",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Thorne, Kevin M",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Warner, Gerald L.",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,Democratic,"Obama, Barack",317,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,Libertarian,"Johnson, Gary",18,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,Reform,"Baldwin, Chuck",2,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,Republican,"Romney, Mitt",777,00042A
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Ayers, Avery L",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Barnett, Andre",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Barr, Roseanne C",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Bush, Kent W",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Christensen, Will",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Duncan, Richard A",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Goode, Virgil",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Hoefling, Tom",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Knill, Dennis J",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Reed, Jill A.",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Rogers, Rick L",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Stein, Jill E",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Thorne, Kevin M",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Warner, Gerald L.",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,Democratic,"Obama, Barack",105,000430
+SALINE,Salina Precinct 32,President / Vice President,,Libertarian,"Johnson, Gary",9,000430
+SALINE,Salina Precinct 32,President / Vice President,,Reform,"Baldwin, Chuck",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,Republican,"Romney, Mitt",214,000430
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Ayers, Avery L",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Barnett, Andre",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Barr, Roseanne C",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Bush, Kent W",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Christensen, Will",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Duncan, Richard A",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Goode, Virgil",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Hoefling, Tom",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Knill, Dennis J",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Reed, Jill A.",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Rogers, Rick L",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Stein, Jill E",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Thorne, Kevin M",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Warner, Gerald L.",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,Democratic,"Obama, Barack",192,000440
+SALINE,Salina Precinct 33,President / Vice President,,Libertarian,"Johnson, Gary",21,000440
+SALINE,Salina Precinct 33,President / Vice President,,Reform,"Baldwin, Chuck",1,000440
+SALINE,Salina Precinct 33,President / Vice President,,Republican,"Romney, Mitt",417,000440
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Ayers, Avery L",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Barnett, Andre",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Barr, Roseanne C",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Bush, Kent W",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Christensen, Will",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Duncan, Richard A",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Goode, Virgil",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Knill, Dennis J",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Reed, Jill A.",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Rogers, Rick L",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Stein, Jill E",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Thorne, Kevin M",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Warner, Gerald L.",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,Democratic,"Obama, Barack",321,000450
+SALINE,Salina Precinct 34,President / Vice President,,Libertarian,"Johnson, Gary",21,000450
+SALINE,Salina Precinct 34,President / Vice President,,Reform,"Baldwin, Chuck",4,000450
+SALINE,Salina Precinct 34,President / Vice President,,Republican,"Romney, Mitt",647,000450
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Ayers, Avery L",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Barnett, Andre",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Barr, Roseanne C",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Bush, Kent W",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Christensen, Will",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Duncan, Richard A",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Goode, Virgil",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Hoefling, Tom",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Knill, Dennis J",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Reed, Jill A.",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Rogers, Rick L",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Stein, Jill E",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Thorne, Kevin M",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Warner, Gerald L.",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,Democratic,"Obama, Barack",248,00046A
+SALINE,Salina Precinct 35,President / Vice President,,Libertarian,"Johnson, Gary",26,00046A
+SALINE,Salina Precinct 35,President / Vice President,,Reform,"Baldwin, Chuck",1,00046A
+SALINE,Salina Precinct 35,President / Vice President,,Republican,"Romney, Mitt",410,00046A
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Ayers, Avery L",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Barnett, Andre",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Bush, Kent W",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Christensen, Will",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Duncan, Richard A",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Goode, Virgil",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Knill, Dennis J",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Reed, Jill A.",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Rogers, Rick L",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Stein, Jill E",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,Democratic,"Obama, Barack",30,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,Libertarian,"Johnson, Gary",4,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,Reform,"Baldwin, Chuck",2,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,Republican,"Romney, Mitt",89,00047B
+SALINE,Smoky View Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Ayers, Avery L",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Barnett, Andre",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Bush, Kent W",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Christensen, Will",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Duncan, Richard A",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Goode, Virgil",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Hoefling, Tom",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Knill, Dennis J",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Reed, Jill A.",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Rogers, Rick L",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Stein, Jill E",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000480
+SALINE,Smoky View Township,President / Vice President,,Democratic,"Obama, Barack",108,000480
+SALINE,Smoky View Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000480
+SALINE,Smoky View Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000480
+SALINE,Smoky View Township,President / Vice President,,Republican,"Romney, Mitt",264,000480
+SALINE,Smolan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Barnett, Andre",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Bush, Kent W",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Christensen, Will",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Goode, Virgil",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Stein, Jill E",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000490
+SALINE,Smolan Township,President / Vice President,,Democratic,"Obama, Barack",101,000490
+SALINE,Smolan Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000490
+SALINE,Smolan Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000490
+SALINE,Smolan Township,President / Vice President,,Republican,"Romney, Mitt",260,000490
+SALINE,Solomon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Barnett, Andre",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Bush, Kent W",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Christensen, Will",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Goode, Virgil",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Stein, Jill E",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000500
+SALINE,Solomon Township,President / Vice President,,Democratic,"Obama, Barack",43,000500
+SALINE,Solomon Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000500
+SALINE,Solomon Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000500
+SALINE,Solomon Township,President / Vice President,,Republican,"Romney, Mitt",160,000500
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000510
+SALINE,Spring Creek Township,President / Vice President,,Democratic,"Obama, Barack",35,000510
+SALINE,Spring Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000510
+SALINE,Spring Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000510
+SALINE,Spring Creek Township,President / Vice President,,Republican,"Romney, Mitt",154,000510
+SALINE,Walnut Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Ayers, Avery L",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Barnett, Andre",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Bush, Kent W",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Christensen, Will",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Duncan, Richard A",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Goode, Virgil",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Knill, Dennis J",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Reed, Jill A.",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Rogers, Rick L",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Stein, Jill E",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000520
+SALINE,Walnut Township,President / Vice President,,Democratic,"Obama, Barack",73,000520
+SALINE,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000520
+SALINE,Walnut Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000520
+SALINE,Walnut Township,President / Vice President,,Republican,"Romney, Mitt",217,000520
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Barnett, Andre",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Bush, Kent W",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Christensen, Will",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Goode, Virgil",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Stein, Jill E",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,Democratic,"Obama, Barack",102,120020
+SALINE,Elm Creek Township H69,President / Vice President,,Libertarian,"Johnson, Gary",6,120020
+SALINE,Elm Creek Township H69,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,Republican,"Romney, Mitt",394,120020
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Barnett, Andre",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Bush, Kent W",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Christensen, Will",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Goode, Virgil",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Stein, Jill E",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,Democratic,"Obama, Barack",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,Republican,"Romney, Mitt",0,120030
+SALINE,Washington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Ayers, Avery L",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Barnett, Andre",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Bush, Kent W",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Christensen, Will",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Duncan, Richard A",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Goode, Virgil",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Knill, Dennis J",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Reed, Jill A.",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Rogers, Rick L",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Stein, Jill E",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,300010
+SALINE,Washington Township,President / Vice President,,Democratic,"Obama, Barack",15,300010
+SALINE,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",1,300010
+SALINE,Washington Township,President / Vice President,,Reform,"Baldwin, Chuck",1,300010
+SALINE,Washington Township,President / Vice President,,Republican,"Romney, Mitt",65,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Christensen, Will",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Christensen, Will",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Christensen, Will",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Christensen, Will",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Ayers, Avery L",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Barnett, Andre",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Barr, Roseanne C",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Bush, Kent W",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Christensen, Will",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Duncan, Richard A",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Goode, Virgil",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Knill, Dennis J",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Reed, Jill A.",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Rogers, Rick L",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Stein, Jill E",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Thorne, Kevin M",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Warner, Gerald L.",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,Democratic,"Obama, Barack",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,Reform,"Baldwin, Chuck",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,Republican,"Romney, Mitt",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Ayers, Avery L",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Barnett, Andre",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Barr, Roseanne C",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Bush, Kent W",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Christensen, Will",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Duncan, Richard A",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Goode, Virgil",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Knill, Dennis J",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Reed, Jill A.",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Rogers, Rick L",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Stein, Jill E",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Thorne, Kevin M",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Warner, Gerald L.",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,Democratic,"Obama, Barack",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,Reform,"Baldwin, Chuck",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,Republican,"Romney, Mitt",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Christensen, Will",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900070
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900080
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Christensen, Will",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Christensen, Will",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900110
+SALINE,Cambria Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",164,000010
+SALINE,Dayton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",41,000020
+SALINE,Eureka Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",223,000040
+SALINE,Falun Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",102,000050
+SALINE,Glendale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000060
+SALINE,Greeley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",378,000070
+SALINE,Gypsum Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",81,000080
+SALINE,Liberty Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",74,000090
+SALINE,Ohio Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",166,000100
+SALINE,Pleasant Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",165,000110
+SALINE,Salina Precinct 01 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",260,00012A
+SALINE,Salina Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",239,00013A
+SALINE,Salina Precinct 03,United States House of Representatives,1,Republican,"Huelskamp, Tim",189,000140
+SALINE,Salina Precinct 04,United States House of Representatives,1,Republican,"Huelskamp, Tim",248,000150
+SALINE,Salina Precinct 05,United States House of Representatives,1,Republican,"Huelskamp, Tim",272,000160
+SALINE,Salina Precinct 06,United States House of Representatives,1,Republican,"Huelskamp, Tim",241,000170
+SALINE,Salina Precinct 07,United States House of Representatives,1,Republican,"Huelskamp, Tim",318,000180
+SALINE,Salina Precinct 08,United States House of Representatives,1,Republican,"Huelskamp, Tim",280,000190
+SALINE,Salina Precinct 09,United States House of Representatives,1,Republican,"Huelskamp, Tim",298,000200
+SALINE,Salina Precinct 10,United States House of Representatives,1,Republican,"Huelskamp, Tim",270,000210
+SALINE,Salina Precinct 11,United States House of Representatives,1,Republican,"Huelskamp, Tim",294,000220
+SALINE,Salina Precinct 12,United States House of Representatives,1,Republican,"Huelskamp, Tim",407,000230
+SALINE,Salina Precinct 13,United States House of Representatives,1,Republican,"Huelskamp, Tim",271,000240
+SALINE,Salina Precinct 14 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",392,00025A
+SALINE,Salina Precinct 15 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",203,00026A
+SALINE,Salina Precinct 16,United States House of Representatives,1,Republican,"Huelskamp, Tim",217,000270
+SALINE,Salina Precinct 17,United States House of Representatives,1,Republican,"Huelskamp, Tim",228,000280
+SALINE,Salina Precinct 18,United States House of Representatives,1,Republican,"Huelskamp, Tim",311,000290
+SALINE,Salina Precinct 19,United States House of Representatives,1,Republican,"Huelskamp, Tim",359,000300
+SALINE,Salina Precinct 20 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",706,00031A
+SALINE,Salina Precinct 21 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",670,00032A
+SALINE,Salina Precinct 22 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",599,00033A
+SALINE,Salina Precinct 23,United States House of Representatives,1,Republican,"Huelskamp, Tim",795,000340
+SALINE,Salina Precinct 24,United States House of Representatives,1,Republican,"Huelskamp, Tim",266,000350
+SALINE,Salina Precinct 25,United States House of Representatives,1,Republican,"Huelskamp, Tim",220,000360
+SALINE,Salina Precinct 26,United States House of Representatives,1,Republican,"Huelskamp, Tim",268,000370
+SALINE,Salina Precinct 27,United States House of Representatives,1,Republican,"Huelskamp, Tim",412,000380
+SALINE,Salina Precinct 28,United States House of Representatives,1,Republican,"Huelskamp, Tim",293,000390
+SALINE,Salina Precinct 29,United States House of Representatives,1,Republican,"Huelskamp, Tim",430,000400
+SALINE,Salina Precinct 30,United States House of Representatives,1,Republican,"Huelskamp, Tim",356,000410
+SALINE,Salina Precinct 31 Part A,United States House of Representatives,1,Republican,"Huelskamp, Tim",893,00042A
+SALINE,Salina Precinct 32,United States House of Representatives,1,Republican,"Huelskamp, Tim",265,000430
+SALINE,Salina Precinct 33,United States House of Representatives,1,Republican,"Huelskamp, Tim",493,000440
+SALINE,Salina Precinct 34,United States House of Representatives,1,Republican,"Huelskamp, Tim",770,000450
+SALINE,Salina Precinct 35,United States House of Representatives,1,Republican,"Huelskamp, Tim",525,00046A
+SALINE,Smokey Hill Township Part B,United States House of Representatives,1,Republican,"Huelskamp, Tim",106,00047B
+SALINE,Smoky View Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",317,000480
+SALINE,Smolan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",309,000490
+SALINE,Solomon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",168,000500
+SALINE,Spring Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",170,000510
+SALINE,Walnut Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",244,000520
+SALINE,Elm Creek Township H69,United States House of Representatives,1,Republican,"Huelskamp, Tim",434,120020
+SALINE,Elm Creek Township H71,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120030
+SALINE,Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",69,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900070
+SALINE,Salina Precinct 33 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900080
+SALINE,Salina Precinct 35 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900110

--- a/2012/20121106__ks__general__scott__precinct.csv
+++ b/2012/20121106__ks__general__scott__precinct.csv
@@ -1,0 +1,254 @@
+county,precinct,office,district,party,candidate,votes,vtd
+SCOTT,Beaver Township,Kansas House of Representatives,118,Republican,"Hineman, Don",81,000010
+SCOTT,Isbel Township,Kansas House of Representatives,118,Republican,"Hineman, Don",46,000020
+SCOTT,Keystone Township,Kansas House of Representatives,118,Republican,"Hineman, Don",46,000030
+SCOTT,Lake Township,Kansas House of Representatives,118,Republican,"Hineman, Don",29,000040
+SCOTT,Michigan Township,Kansas House of Representatives,118,Republican,"Hineman, Don",34,000050
+SCOTT,Scott City Ward 1,Kansas House of Representatives,118,Republican,"Hineman, Don",258,000060
+SCOTT,Scott City Ward 2,Kansas House of Representatives,118,Republican,"Hineman, Don",455,000070
+SCOTT,Scott City Ward 3,Kansas House of Representatives,118,Republican,"Hineman, Don",357,000080
+SCOTT,Scott City Ward 4,Kansas House of Representatives,118,Republican,"Hineman, Don",374,000090
+SCOTT,Scott Township,Kansas House of Representatives,118,Republican,"Hineman, Don",105,00010A
+SCOTT,Valley Township,Kansas House of Representatives,118,Republican,"Hineman, Don",75,000110
+SCOTT,Beaver Township,Kansas Senate,33,Republican,"Holmes, Mitch",79,000010
+SCOTT,Isbel Township,Kansas Senate,33,Republican,"Holmes, Mitch",45,000020
+SCOTT,Keystone Township,Kansas Senate,33,Republican,"Holmes, Mitch",47,000030
+SCOTT,Lake Township,Kansas Senate,33,Republican,"Holmes, Mitch",30,000040
+SCOTT,Michigan Township,Kansas Senate,33,Republican,"Holmes, Mitch",32,000050
+SCOTT,Scott City Ward 1,Kansas Senate,33,Republican,"Holmes, Mitch",241,000060
+SCOTT,Scott City Ward 2,Kansas Senate,33,Republican,"Holmes, Mitch",444,000070
+SCOTT,Scott City Ward 3,Kansas Senate,33,Republican,"Holmes, Mitch",351,000080
+SCOTT,Scott City Ward 4,Kansas Senate,33,Republican,"Holmes, Mitch",352,000090
+SCOTT,Scott Township,Kansas Senate,33,Republican,"Holmes, Mitch",102,00010A
+SCOTT,Valley Township,Kansas Senate,33,Republican,"Holmes, Mitch",70,000110
+SCOTT,Beaver Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+SCOTT,Beaver Township,President / Vice President,,Democratic,"Obama, Barack",9,000010
+SCOTT,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+SCOTT,Beaver Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+SCOTT,Beaver Township,President / Vice President,,Republican,"Romney, Mitt",80,000010
+SCOTT,Isbel Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+SCOTT,Isbel Township,President / Vice President,,Democratic,"Obama, Barack",4,000020
+SCOTT,Isbel Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+SCOTT,Isbel Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+SCOTT,Isbel Township,President / Vice President,,Republican,"Romney, Mitt",43,000020
+SCOTT,Keystone Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+SCOTT,Keystone Township,President / Vice President,,Democratic,"Obama, Barack",6,000030
+SCOTT,Keystone Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+SCOTT,Keystone Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+SCOTT,Keystone Township,President / Vice President,,Republican,"Romney, Mitt",42,000030
+SCOTT,Lake Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+SCOTT,Lake Township,President / Vice President,,Democratic,"Obama, Barack",0,000040
+SCOTT,Lake Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+SCOTT,Lake Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+SCOTT,Lake Township,President / Vice President,,Republican,"Romney, Mitt",31,000040
+SCOTT,Michigan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+SCOTT,Michigan Township,President / Vice President,,Democratic,"Obama, Barack",0,000050
+SCOTT,Michigan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+SCOTT,Michigan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+SCOTT,Michigan Township,President / Vice President,,Republican,"Romney, Mitt",36,000050
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,Democratic,"Obama, Barack",61,000060
+SCOTT,Scott City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000060
+SCOTT,Scott City Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000060
+SCOTT,Scott City Ward 1,President / Vice President,,Republican,"Romney, Mitt",215,000060
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,Democratic,"Obama, Barack",50,000070
+SCOTT,Scott City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000070
+SCOTT,Scott City Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+SCOTT,Scott City Ward 2,President / Vice President,,Republican,"Romney, Mitt",441,000070
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,Democratic,"Obama, Barack",54,000080
+SCOTT,Scott City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",14,000080
+SCOTT,Scott City Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",3,000080
+SCOTT,Scott City Ward 3,President / Vice President,,Republican,"Romney, Mitt",322,000080
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,Democratic,"Obama, Barack",79,000090
+SCOTT,Scott City Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",3,000090
+SCOTT,Scott City Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",3,000090
+SCOTT,Scott City Ward 4,President / Vice President,,Republican,"Romney, Mitt",340,000090
+SCOTT,Scott Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Ayers, Avery L",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Barnett, Andre",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Bush, Kent W",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Christensen, Will",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Duncan, Richard A",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Goode, Virgil",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Knill, Dennis J",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Reed, Jill A.",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Rogers, Rick L",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Stein, Jill E",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00010A
+SCOTT,Scott Township,President / Vice President,,Democratic,"Obama, Barack",8,00010A
+SCOTT,Scott Township,President / Vice President,,Libertarian,"Johnson, Gary",3,00010A
+SCOTT,Scott Township,President / Vice President,,Reform,"Baldwin, Chuck",0,00010A
+SCOTT,Scott Township,President / Vice President,,Republican,"Romney, Mitt",101,00010A
+SCOTT,Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+SCOTT,Valley Township,President / Vice President,,Democratic,"Obama, Barack",6,000110
+SCOTT,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000110
+SCOTT,Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+SCOTT,Valley Township,President / Vice President,,Republican,"Romney, Mitt",77,000110
+SCOTT,Beaver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",81,000010
+SCOTT,Isbel Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",45,000020
+SCOTT,Keystone Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000030
+SCOTT,Lake Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000040
+SCOTT,Michigan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000050
+SCOTT,Scott City Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",250,000060
+SCOTT,Scott City Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",454,000070
+SCOTT,Scott City Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",356,000080
+SCOTT,Scott City Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",366,000090
+SCOTT,Scott Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",104,00010A
+SCOTT,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",72,000110

--- a/2012/20121106__ks__general__sedgwick__precinct.csv
+++ b/2012/20121106__ks__general__sedgwick__precinct.csv
@@ -1,0 +1,3144 @@
+county,precinct,office,district,candidate,candidate_first,candidate_middle,candidate_last,candidate_suffix,party,votes
+Sedgwick,101,President,,Barack Obama,Barack,,Obama,,Democratic,527
+Sedgwick,101,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,101,President,,Gary Johnson,Gary,,Johnson,,Libertarian,36
+Sedgwick,101,President,,Mitt Romney,Mitt,,Romney,,Republican,458
+Sedgwick,101,President,,WRITE-IN,,,,,,7
+Sedgwick,102,President,,Barack Obama,Barack,,Obama,,Democratic,205
+Sedgwick,102,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,102,President,,Gary Johnson,Gary,,Johnson,,Libertarian,6
+Sedgwick,102,President,,Mitt Romney,Mitt,,Romney,,Republican,153
+Sedgwick,102,President,,WRITE-IN,,,,,,2
+Sedgwick,103,President,,Barack Obama,Barack,,Obama,,Democratic,58
+Sedgwick,103,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,103,President,,Gary Johnson,Gary,,Johnson,,Libertarian,1
+Sedgwick,103,President,,Mitt Romney,Mitt,,Romney,,Republican,47
+Sedgwick,103,President,,WRITE-IN,,,,,,0
+Sedgwick,104,President,,Barack Obama,Barack,,Obama,,Democratic,15
+Sedgwick,104,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,104,President,,Gary Johnson,Gary,,Johnson,,Libertarian,1
+Sedgwick,104,President,,Mitt Romney,Mitt,,Romney,,Republican,20
+Sedgwick,104,President,,WRITE-IN,,,,,,1
+Sedgwick,105,President,,Barack Obama,Barack,,Obama,,Democratic,370
+Sedgwick,105,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,105,President,,Gary Johnson,Gary,,Johnson,,Libertarian,23
+Sedgwick,105,President,,Mitt Romney,Mitt,,Romney,,Republican,181
+Sedgwick,105,President,,WRITE-IN,,,,,,7
+Sedgwick,106,President,,Barack Obama,Barack,,Obama,,Democratic,164
+Sedgwick,106,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,106,President,,Gary Johnson,Gary,,Johnson,,Libertarian,12
+Sedgwick,106,President,,Mitt Romney,Mitt,,Romney,,Republican,108
+Sedgwick,106,President,,WRITE-IN,,,,,,9
+Sedgwick,107,President,,Barack Obama,Barack,,Obama,,Democratic,578
+Sedgwick,107,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,107,President,,Gary Johnson,Gary,,Johnson,,Libertarian,15
+Sedgwick,107,President,,Mitt Romney,Mitt,,Romney,,Republican,111
+Sedgwick,107,President,,WRITE-IN,,,,,,6
+Sedgwick,108,President,,Barack Obama,Barack,,Obama,,Democratic,467
+Sedgwick,108,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,108,President,,Gary Johnson,Gary,,Johnson,,Libertarian,25
+Sedgwick,108,President,,Mitt Romney,Mitt,,Romney,,Republican,271
+Sedgwick,108,President,,WRITE-IN,,,,,,7
+Sedgwick,109,President,,Barack Obama,Barack,,Obama,,Democratic,765
+Sedgwick,109,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,109,President,,Gary Johnson,Gary,,Johnson,,Libertarian,25
+Sedgwick,109,President,,Mitt Romney,Mitt,,Romney,,Republican,290
+Sedgwick,109,President,,WRITE-IN,,,,,,8
+Sedgwick,110 & 111,President,,Barack Obama,Barack,,Obama,,Democratic,139
+Sedgwick,110 & 111,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,110 & 111,President,,Gary Johnson,Gary,,Johnson,,Libertarian,4
+Sedgwick,110 & 111,President,,Mitt Romney,Mitt,,Romney,,Republican,186
+Sedgwick,110 & 111,President,,WRITE-IN,,,,,,1
+Sedgwick,112,President,,Barack Obama,Barack,,Obama,,Democratic,772
+Sedgwick,112,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,112,President,,Gary Johnson,Gary,,Johnson,,Libertarian,16
+Sedgwick,112,President,,Mitt Romney,Mitt,,Romney,,Republican,336
+Sedgwick,112,President,,WRITE-IN,,,,,,4
+Sedgwick,113,President,,Barack Obama,Barack,,Obama,,Democratic,718
+Sedgwick,113,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,113,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,113,President,,Mitt Romney,Mitt,,Romney,,Republican,63
+Sedgwick,113,President,,WRITE-IN,,,,,,4
+Sedgwick,114,President,,Barack Obama,Barack,,Obama,,Democratic,768
+Sedgwick,114,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,114,President,,Gary Johnson,Gary,,Johnson,,Libertarian,8
+Sedgwick,114,President,,Mitt Romney,Mitt,,Romney,,Republican,19
+Sedgwick,114,President,,WRITE-IN,,,,,,0
+Sedgwick,116,President,,Barack Obama,Barack,,Obama,,Democratic,1159
+Sedgwick,116,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,116,President,,Gary Johnson,Gary,,Johnson,,Libertarian,10
+Sedgwick,116,President,,Mitt Romney,Mitt,,Romney,,Republican,53
+Sedgwick,116,President,,WRITE-IN,,,,,,2
+Sedgwick,117,President,,Barack Obama,Barack,,Obama,,Democratic,1050
+Sedgwick,117,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,117,President,,Gary Johnson,Gary,,Johnson,,Libertarian,4
+Sedgwick,117,President,,Mitt Romney,Mitt,,Romney,,Republican,49
+Sedgwick,117,President,,WRITE-IN,,,,,,2
+Sedgwick,118,President,,Barack Obama,Barack,,Obama,,Democratic,956
+Sedgwick,118,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,118,President,,Gary Johnson,Gary,,Johnson,,Libertarian,11
+Sedgwick,118,President,,Mitt Romney,Mitt,,Romney,,Republican,149
+Sedgwick,118,President,,WRITE-IN,,,,,,5
+Sedgwick,119,President,,Barack Obama,Barack,,Obama,,Democratic,651
+Sedgwick,119,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,119,President,,Gary Johnson,Gary,,Johnson,,Libertarian,10
+Sedgwick,119,President,,Mitt Romney,Mitt,,Romney,,Republican,242
+Sedgwick,119,President,,WRITE-IN,,,,,,5
+Sedgwick,120,President,,Barack Obama,Barack,,Obama,,Democratic,565
+Sedgwick,120,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,120,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,120,President,,Mitt Romney,Mitt,,Romney,,Republican,291
+Sedgwick,120,President,,WRITE-IN,,,,,,7
+Sedgwick,121,President,,Barack Obama,Barack,,Obama,,Democratic,384
+Sedgwick,121,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,121,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,121,President,,Mitt Romney,Mitt,,Romney,,Republican,437
+Sedgwick,121,President,,WRITE-IN,,,,,,3
+Sedgwick,122,President,,Barack Obama,Barack,,Obama,,Democratic,785
+Sedgwick,122,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,122,President,,Gary Johnson,Gary,,Johnson,,Libertarian,22
+Sedgwick,122,President,,Mitt Romney,Mitt,,Romney,,Republican,633
+Sedgwick,122,President,,WRITE-IN,,,,,,13
+Sedgwick,123,President,,Barack Obama,Barack,,Obama,,Democratic,50
+Sedgwick,123,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,123,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,123,President,,Mitt Romney,Mitt,,Romney,,Republican,59
+Sedgwick,123,President,,WRITE-IN,,,,,,1
+Sedgwick,126,President,,Barack Obama,Barack,,Obama,,Democratic,93
+Sedgwick,126,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,126,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,126,President,,Mitt Romney,Mitt,,Romney,,Republican,125
+Sedgwick,126,President,,WRITE-IN,,,,,,1
+Sedgwick,127,President,,Barack Obama,Barack,,Obama,,Democratic,85
+Sedgwick,127,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,127,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,127,President,,Mitt Romney,Mitt,,Romney,,Republican,152
+Sedgwick,127,President,,WRITE-IN,,,,,,3
+Sedgwick,128,President,,Barack Obama,Barack,,Obama,,Democratic,122
+Sedgwick,128,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,128,President,,Gary Johnson,Gary,,Johnson,,Libertarian,4
+Sedgwick,128,President,,Mitt Romney,Mitt,,Romney,,Republican,54
+Sedgwick,128,President,,WRITE-IN,,,,,,1
+Sedgwick,129,President,,Barack Obama,Barack,,Obama,,Democratic,133
+Sedgwick,129,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,129,President,,Gary Johnson,Gary,,Johnson,,Libertarian,16
+Sedgwick,129,President,,Mitt Romney,Mitt,,Romney,,Republican,94
+Sedgwick,129,President,,WRITE-IN,,,,,,1
+Sedgwick,130,President,,Barack Obama,Barack,,Obama,,Democratic,361
+Sedgwick,130,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,130,President,,Gary Johnson,Gary,,Johnson,,Libertarian,24
+Sedgwick,130,President,,Mitt Romney,Mitt,,Romney,,Republican,222
+Sedgwick,130,President,,WRITE-IN,,,,,,5
+Sedgwick,131,President,,Barack Obama,Barack,,Obama,,Democratic,4
+Sedgwick,131,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,131,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,131,President,,Mitt Romney,Mitt,,Romney,,Republican,10
+Sedgwick,131,President,,WRITE-IN,,,,,,0
+Sedgwick,132 & 124,President,,Barack Obama,Barack,,Obama,,Democratic,14
+Sedgwick,132 & 124,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,132 & 124,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,132 & 124,President,,Mitt Romney,Mitt,,Romney,,Republican,4
+Sedgwick,132 & 124,President,,WRITE-IN,,,,,,1
+Sedgwick,201,President,,Barack Obama,Barack,,Obama,,Democratic,627
+Sedgwick,201,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,201,President,,Gary Johnson,Gary,,Johnson,,Libertarian,49
+Sedgwick,201,President,,Mitt Romney,Mitt,,Romney,,Republican,632
+Sedgwick,201,President,,WRITE-IN,,,,,,9
+Sedgwick,202,President,,Barack Obama,Barack,,Obama,,Democratic,591
+Sedgwick,202,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,202,President,,Gary Johnson,Gary,,Johnson,,Libertarian,21
+Sedgwick,202,President,,Mitt Romney,Mitt,,Romney,,Republican,666
+Sedgwick,202,President,,WRITE-IN,,,,,,11
+Sedgwick,203,President,,Barack Obama,Barack,,Obama,,Democratic,473
+Sedgwick,203,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,203,President,,Gary Johnson,Gary,,Johnson,,Libertarian,19
+Sedgwick,203,President,,Mitt Romney,Mitt,,Romney,,Republican,513
+Sedgwick,203,President,,WRITE-IN,,,,,,6
+Sedgwick,204,President,,Barack Obama,Barack,,Obama,,Democratic,380
+Sedgwick,204,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,204,President,,Gary Johnson,Gary,,Johnson,,Libertarian,19
+Sedgwick,204,President,,Mitt Romney,Mitt,,Romney,,Republican,491
+Sedgwick,204,President,,WRITE-IN,,,,,,6
+Sedgwick,205,President,,Barack Obama,Barack,,Obama,,Democratic,244
+Sedgwick,205,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,205,President,,Gary Johnson,Gary,,Johnson,,Libertarian,17
+Sedgwick,205,President,,Mitt Romney,Mitt,,Romney,,Republican,113
+Sedgwick,205,President,,WRITE-IN,,,,,,2
+Sedgwick,206,President,,Barack Obama,Barack,,Obama,,Democratic,181
+Sedgwick,206,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,206,President,,Gary Johnson,Gary,,Johnson,,Libertarian,5
+Sedgwick,206,President,,Mitt Romney,Mitt,,Romney,,Republican,139
+Sedgwick,206,President,,WRITE-IN,,,,,,1
+Sedgwick,207,President,,Barack Obama,Barack,,Obama,,Democratic,622
+Sedgwick,207,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,207,President,,Gary Johnson,Gary,,Johnson,,Libertarian,12
+Sedgwick,207,President,,Mitt Romney,Mitt,,Romney,,Republican,621
+Sedgwick,207,President,,WRITE-IN,,,,,,1
+Sedgwick,208,President,,Barack Obama,Barack,,Obama,,Democratic,191
+Sedgwick,208,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,208,President,,Gary Johnson,Gary,,Johnson,,Libertarian,7
+Sedgwick,208,President,,Mitt Romney,Mitt,,Romney,,Republican,178
+Sedgwick,208,President,,WRITE-IN,,,,,,4
+Sedgwick,209,President,,Barack Obama,Barack,,Obama,,Democratic,480
+Sedgwick,209,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,209,President,,Gary Johnson,Gary,,Johnson,,Libertarian,18
+Sedgwick,209,President,,Mitt Romney,Mitt,,Romney,,Republican,419
+Sedgwick,209,President,,WRITE-IN,,,,,,3
+Sedgwick,210,President,,Barack Obama,Barack,,Obama,,Democratic,543
+Sedgwick,210,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,210,President,,Gary Johnson,Gary,,Johnson,,Libertarian,22
+Sedgwick,210,President,,Mitt Romney,Mitt,,Romney,,Republican,515
+Sedgwick,210,President,,WRITE-IN,,,,,,6
+Sedgwick,211,President,,Barack Obama,Barack,,Obama,,Democratic,253
+Sedgwick,211,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,211,President,,Gary Johnson,Gary,,Johnson,,Libertarian,10
+Sedgwick,211,President,,Mitt Romney,Mitt,,Romney,,Republican,381
+Sedgwick,211,President,,WRITE-IN,,,,,,4
+Sedgwick,212,President,,Barack Obama,Barack,,Obama,,Democratic,501
+Sedgwick,212,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,212,President,,Gary Johnson,Gary,,Johnson,,Libertarian,14
+Sedgwick,212,President,,Mitt Romney,Mitt,,Romney,,Republican,718
+Sedgwick,212,President,,WRITE-IN,,,,,,6
+Sedgwick,213,President,,Barack Obama,Barack,,Obama,,Democratic,453
+Sedgwick,213,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,213,President,,Gary Johnson,Gary,,Johnson,,Libertarian,24
+Sedgwick,213,President,,Mitt Romney,Mitt,,Romney,,Republican,892
+Sedgwick,213,President,,WRITE-IN,,,,,,6
+Sedgwick,214,President,,Barack Obama,Barack,,Obama,,Democratic,356
+Sedgwick,214,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,214,President,,Gary Johnson,Gary,,Johnson,,Libertarian,19
+Sedgwick,214,President,,Mitt Romney,Mitt,,Romney,,Republican,872
+Sedgwick,214,President,,WRITE-IN,,,,,,3
+Sedgwick,215,President,,Barack Obama,Barack,,Obama,,Democratic,637
+Sedgwick,215,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,215,President,,Gary Johnson,Gary,,Johnson,,Libertarian,18
+Sedgwick,215,President,,Mitt Romney,Mitt,,Romney,,Republican,1054
+Sedgwick,215,President,,WRITE-IN,,,,,,5
+Sedgwick,216,President,,Barack Obama,Barack,,Obama,,Democratic,413
+Sedgwick,216,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,216,President,,Gary Johnson,Gary,,Johnson,,Libertarian,9
+Sedgwick,216,President,,Mitt Romney,Mitt,,Romney,,Republican,622
+Sedgwick,216,President,,WRITE-IN,,,,,,5
+Sedgwick,217,President,,Barack Obama,Barack,,Obama,,Democratic,384
+Sedgwick,217,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,217,President,,Gary Johnson,Gary,,Johnson,,Libertarian,17
+Sedgwick,217,President,,Mitt Romney,Mitt,,Romney,,Republican,935
+Sedgwick,217,President,,WRITE-IN,,,,,,2
+Sedgwick,218 & 220,President,,Barack Obama,Barack,,Obama,,Democratic,693
+Sedgwick,218 & 220,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,218 & 220,President,,Gary Johnson,Gary,,Johnson,,Libertarian,26
+Sedgwick,218 & 220,President,,Mitt Romney,Mitt,,Romney,,Republican,1233
+Sedgwick,218 & 220,President,,WRITE-IN,,,,,,15
+Sedgwick,221,President,,Barack Obama,Barack,,Obama,,Democratic,262
+Sedgwick,221,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,221,President,,Gary Johnson,Gary,,Johnson,,Libertarian,10
+Sedgwick,221,President,,Mitt Romney,Mitt,,Romney,,Republican,530
+Sedgwick,221,President,,WRITE-IN,,,,,,2
+Sedgwick,222,President,,Barack Obama,Barack,,Obama,,Democratic,315
+Sedgwick,222,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,222,President,,Gary Johnson,Gary,,Johnson,,Libertarian,17
+Sedgwick,222,President,,Mitt Romney,Mitt,,Romney,,Republican,685
+Sedgwick,222,President,,WRITE-IN,,,,,,1
+Sedgwick,223,President,,Barack Obama,Barack,,Obama,,Democratic,369
+Sedgwick,223,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,223,President,,Gary Johnson,Gary,,Johnson,,Libertarian,16
+Sedgwick,223,President,,Mitt Romney,Mitt,,Romney,,Republican,904
+Sedgwick,223,President,,WRITE-IN,,,,,,2
+Sedgwick,224,President,,Barack Obama,Barack,,Obama,,Democratic,604
+Sedgwick,224,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,224,President,,Gary Johnson,Gary,,Johnson,,Libertarian,19
+Sedgwick,224,President,,Mitt Romney,Mitt,,Romney,,Republican,716
+Sedgwick,224,President,,WRITE-IN,,,,,,9
+Sedgwick,225,President,,Barack Obama,Barack,,Obama,,Democratic,626
+Sedgwick,225,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,8
+Sedgwick,225,President,,Gary Johnson,Gary,,Johnson,,Libertarian,28
+Sedgwick,225,President,,Mitt Romney,Mitt,,Romney,,Republican,787
+Sedgwick,225,President,,WRITE-IN,,,,,,11
+Sedgwick,226,President,,Barack Obama,Barack,,Obama,,Democratic,557
+Sedgwick,226,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,226,President,,Gary Johnson,Gary,,Johnson,,Libertarian,23
+Sedgwick,226,President,,Mitt Romney,Mitt,,Romney,,Republican,1154
+Sedgwick,226,President,,WRITE-IN,,,,,,13
+Sedgwick,227,President,,Barack Obama,Barack,,Obama,,Democratic,336
+Sedgwick,227,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,227,President,,Gary Johnson,Gary,,Johnson,,Libertarian,14
+Sedgwick,227,President,,Mitt Romney,Mitt,,Romney,,Republican,902
+Sedgwick,227,President,,WRITE-IN,,,,,,6
+Sedgwick,228,President,,Barack Obama,Barack,,Obama,,Democratic,220
+Sedgwick,228,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,228,President,,Gary Johnson,Gary,,Johnson,,Libertarian,22
+Sedgwick,228,President,,Mitt Romney,Mitt,,Romney,,Republican,924
+Sedgwick,228,President,,WRITE-IN,,,,,,0
+Sedgwick,231,President,,Barack Obama,Barack,,Obama,,Democratic,295
+Sedgwick,231,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,231,President,,Gary Johnson,Gary,,Johnson,,Libertarian,10
+Sedgwick,231,President,,Mitt Romney,Mitt,,Romney,,Republican,202
+Sedgwick,231,President,,WRITE-IN,,,,,,4
+Sedgwick,233,President,,Barack Obama,Barack,,Obama,,Democratic,190
+Sedgwick,233,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,233,President,,Gary Johnson,Gary,,Johnson,,Libertarian,3
+Sedgwick,233,President,,Mitt Romney,Mitt,,Romney,,Republican,278
+Sedgwick,233,President,,WRITE-IN,,,,,,3
+Sedgwick,234,President,,Barack Obama,Barack,,Obama,,Democratic,100
+Sedgwick,234,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,234,President,,Gary Johnson,Gary,,Johnson,,Libertarian,8
+Sedgwick,234,President,,Mitt Romney,Mitt,,Romney,,Republican,91
+Sedgwick,234,President,,WRITE-IN,,,,,,0
+Sedgwick,235,President,,Barack Obama,Barack,,Obama,,Democratic,179
+Sedgwick,235,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,235,President,,Gary Johnson,Gary,,Johnson,,Libertarian,8
+Sedgwick,235,President,,Mitt Romney,Mitt,,Romney,,Republican,132
+Sedgwick,235,President,,WRITE-IN,,,,,,1
+Sedgwick,236,President,,Barack Obama,Barack,,Obama,,Democratic,208
+Sedgwick,236,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,236,President,,Gary Johnson,Gary,,Johnson,,Libertarian,9
+Sedgwick,236,President,,Mitt Romney,Mitt,,Romney,,Republican,584
+Sedgwick,236,President,,WRITE-IN,,,,,,2
+Sedgwick,301,President,,Barack Obama,Barack,,Obama,,Democratic,247
+Sedgwick,301,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,301,President,,Gary Johnson,Gary,,Johnson,,Libertarian,12
+Sedgwick,301,President,,Mitt Romney,Mitt,,Romney,,Republican,195
+Sedgwick,301,President,,WRITE-IN,,,,,,9
+Sedgwick,302,President,,Barack Obama,Barack,,Obama,,Democratic,470
+Sedgwick,302,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,302,President,,Gary Johnson,Gary,,Johnson,,Libertarian,35
+Sedgwick,302,President,,Mitt Romney,Mitt,,Romney,,Republican,361
+Sedgwick,302,President,,WRITE-IN,,,,,,4
+Sedgwick,303,President,,Barack Obama,Barack,,Obama,,Democratic,182
+Sedgwick,303,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,303,President,,Gary Johnson,Gary,,Johnson,,Libertarian,12
+Sedgwick,303,President,,Mitt Romney,Mitt,,Romney,,Republican,210
+Sedgwick,303,President,,WRITE-IN,,,,,,3
+Sedgwick,304,President,,Barack Obama,Barack,,Obama,,Democratic,205
+Sedgwick,304,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,304,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,304,President,,Mitt Romney,Mitt,,Romney,,Republican,210
+Sedgwick,304,President,,WRITE-IN,,,,,,4
+Sedgwick,305,President,,Barack Obama,Barack,,Obama,,Democratic,687
+Sedgwick,305,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,305,President,,Gary Johnson,Gary,,Johnson,,Libertarian,31
+Sedgwick,305,President,,Mitt Romney,Mitt,,Romney,,Republican,645
+Sedgwick,305,President,,WRITE-IN,,,,,,5
+Sedgwick,306,President,,Barack Obama,Barack,,Obama,,Democratic,739
+Sedgwick,306,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,7
+Sedgwick,306,President,,Gary Johnson,Gary,,Johnson,,Libertarian,34
+Sedgwick,306,President,,Mitt Romney,Mitt,,Romney,,Republican,551
+Sedgwick,306,President,,WRITE-IN,,,,,,8
+Sedgwick,307,President,,Barack Obama,Barack,,Obama,,Democratic,378
+Sedgwick,307,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,307,President,,Gary Johnson,Gary,,Johnson,,Libertarian,9
+Sedgwick,307,President,,Mitt Romney,Mitt,,Romney,,Republican,204
+Sedgwick,307,President,,WRITE-IN,,,,,,6
+Sedgwick,308,President,,Barack Obama,Barack,,Obama,,Democratic,601
+Sedgwick,308,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,308,President,,Gary Johnson,Gary,,Johnson,,Libertarian,22
+Sedgwick,308,President,,Mitt Romney,Mitt,,Romney,,Republican,395
+Sedgwick,308,President,,WRITE-IN,,,,,,7
+Sedgwick,309,President,,Barack Obama,Barack,,Obama,,Democratic,535
+Sedgwick,309,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,309,President,,Gary Johnson,Gary,,Johnson,,Libertarian,22
+Sedgwick,309,President,,Mitt Romney,Mitt,,Romney,,Republican,381
+Sedgwick,309,President,,WRITE-IN,,,,,,16
+Sedgwick,310,President,,Barack Obama,Barack,,Obama,,Democratic,245
+Sedgwick,310,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,310,President,,Gary Johnson,Gary,,Johnson,,Libertarian,7
+Sedgwick,310,President,,Mitt Romney,Mitt,,Romney,,Republican,117
+Sedgwick,310,President,,WRITE-IN,,,,,,1
+Sedgwick,311,President,,Barack Obama,Barack,,Obama,,Democratic,215
+Sedgwick,311,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,7
+Sedgwick,311,President,,Gary Johnson,Gary,,Johnson,,Libertarian,8
+Sedgwick,311,President,,Mitt Romney,Mitt,,Romney,,Republican,236
+Sedgwick,311,President,,WRITE-IN,,,,,,1
+Sedgwick,312,President,,Barack Obama,Barack,,Obama,,Democratic,207
+Sedgwick,312,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,312,President,,Gary Johnson,Gary,,Johnson,,Libertarian,6
+Sedgwick,312,President,,Mitt Romney,Mitt,,Romney,,Republican,190
+Sedgwick,312,President,,WRITE-IN,,,,,,10
+Sedgwick,313,President,,Barack Obama,Barack,,Obama,,Democratic,505
+Sedgwick,313,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,7
+Sedgwick,313,President,,Gary Johnson,Gary,,Johnson,,Libertarian,24
+Sedgwick,313,President,,Mitt Romney,Mitt,,Romney,,Republican,430
+Sedgwick,313,President,,WRITE-IN,,,,,,9
+Sedgwick,314,President,,Barack Obama,Barack,,Obama,,Democratic,505
+Sedgwick,314,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,314,President,,Gary Johnson,Gary,,Johnson,,Libertarian,20
+Sedgwick,314,President,,Mitt Romney,Mitt,,Romney,,Republican,509
+Sedgwick,314,President,,WRITE-IN,,,,,,8
+Sedgwick,315,President,,Barack Obama,Barack,,Obama,,Democratic,415
+Sedgwick,315,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,9
+Sedgwick,315,President,,Gary Johnson,Gary,,Johnson,,Libertarian,29
+Sedgwick,315,President,,Mitt Romney,Mitt,,Romney,,Republican,391
+Sedgwick,315,President,,WRITE-IN,,,,,,12
+Sedgwick,316,President,,Barack Obama,Barack,,Obama,,Democratic,404
+Sedgwick,316,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,8
+Sedgwick,316,President,,Gary Johnson,Gary,,Johnson,,Libertarian,27
+Sedgwick,316,President,,Mitt Romney,Mitt,,Romney,,Republican,613
+Sedgwick,316,President,,WRITE-IN,,,,,,7
+Sedgwick,317,President,,Barack Obama,Barack,,Obama,,Democratic,9
+Sedgwick,317,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,317,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,317,President,,Mitt Romney,Mitt,,Romney,,Republican,6
+Sedgwick,317,President,,WRITE-IN,,,,,,0
+Sedgwick,318,President,,Barack Obama,Barack,,Obama,,Democratic,6
+Sedgwick,318,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,318,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,318,President,,Mitt Romney,Mitt,,Romney,,Republican,22
+Sedgwick,318,President,,WRITE-IN,,,,,,1
+Sedgwick,319,President,,Barack Obama,Barack,,Obama,,Democratic,148
+Sedgwick,319,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,319,President,,Gary Johnson,Gary,,Johnson,,Libertarian,3
+Sedgwick,319,President,,Mitt Romney,Mitt,,Romney,,Republican,105
+Sedgwick,319,President,,WRITE-IN,,,,,,1
+Sedgwick,320,President,,Barack Obama,Barack,,Obama,,Democratic,63
+Sedgwick,320,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,320,President,,Gary Johnson,Gary,,Johnson,,Libertarian,3
+Sedgwick,320,President,,Mitt Romney,Mitt,,Romney,,Republican,95
+Sedgwick,320,President,,WRITE-IN,,,,,,0
+Sedgwick,321,President,,Barack Obama,Barack,,Obama,,Democratic,27
+Sedgwick,321,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,321,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,321,President,,Mitt Romney,Mitt,,Romney,,Republican,2
+Sedgwick,321,President,,WRITE-IN,,,,,,0
+Sedgwick,323,President,,Barack Obama,Barack,,Obama,,Democratic,167
+Sedgwick,323,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,323,President,,Gary Johnson,Gary,,Johnson,,Libertarian,3
+Sedgwick,323,President,,Mitt Romney,Mitt,,Romney,,Republican,80
+Sedgwick,323,President,,WRITE-IN,,,,,,1
+Sedgwick,324,President,,Barack Obama,Barack,,Obama,,Democratic,163
+Sedgwick,324,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,324,President,,Gary Johnson,Gary,,Johnson,,Libertarian,6
+Sedgwick,324,President,,Mitt Romney,Mitt,,Romney,,Republican,121
+Sedgwick,324,President,,WRITE-IN,,,,,,3
+Sedgwick,325,President,,Barack Obama,Barack,,Obama,,Democratic,47
+Sedgwick,325,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,325,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,325,President,,Mitt Romney,Mitt,,Romney,,Republican,10
+Sedgwick,325,President,,WRITE-IN,,,,,,0
+Sedgwick,326,President,,Barack Obama,Barack,,Obama,,Democratic,26
+Sedgwick,326,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,326,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,326,President,,Mitt Romney,Mitt,,Romney,,Republican,44
+Sedgwick,326,President,,WRITE-IN,,,,,,0
+Sedgwick,401,President,,Barack Obama,Barack,,Obama,,Democratic,243
+Sedgwick,401,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,401,President,,Gary Johnson,Gary,,Johnson,,Libertarian,23
+Sedgwick,401,President,,Mitt Romney,Mitt,,Romney,,Republican,221
+Sedgwick,401,President,,WRITE-IN,,,,,,9
+Sedgwick,402,President,,Barack Obama,Barack,,Obama,,Democratic,110
+Sedgwick,402,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,402,President,,Gary Johnson,Gary,,Johnson,,Libertarian,6
+Sedgwick,402,President,,Mitt Romney,Mitt,,Romney,,Republican,131
+Sedgwick,402,President,,WRITE-IN,,,,,,0
+Sedgwick,403,President,,Barack Obama,Barack,,Obama,,Democratic,185
+Sedgwick,403,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,403,President,,Gary Johnson,Gary,,Johnson,,Libertarian,16
+Sedgwick,403,President,,Mitt Romney,Mitt,,Romney,,Republican,238
+Sedgwick,403,President,,WRITE-IN,,,,,,3
+Sedgwick,404,President,,Barack Obama,Barack,,Obama,,Democratic,490
+Sedgwick,404,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,404,President,,Gary Johnson,Gary,,Johnson,,Libertarian,19
+Sedgwick,404,President,,Mitt Romney,Mitt,,Romney,,Republican,465
+Sedgwick,404,President,,WRITE-IN,,,,,,6
+Sedgwick,405,President,,Barack Obama,Barack,,Obama,,Democratic,403
+Sedgwick,405,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,405,President,,Gary Johnson,Gary,,Johnson,,Libertarian,29
+Sedgwick,405,President,,Mitt Romney,Mitt,,Romney,,Republican,471
+Sedgwick,405,President,,WRITE-IN,,,,,,5
+Sedgwick,406,President,,Barack Obama,Barack,,Obama,,Democratic,395
+Sedgwick,406,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,406,President,,Gary Johnson,Gary,,Johnson,,Libertarian,21
+Sedgwick,406,President,,Mitt Romney,Mitt,,Romney,,Republican,364
+Sedgwick,406,President,,WRITE-IN,,,,,,6
+Sedgwick,407,President,,Barack Obama,Barack,,Obama,,Democratic,41
+Sedgwick,407,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,407,President,,Gary Johnson,Gary,,Johnson,,Libertarian,8
+Sedgwick,407,President,,Mitt Romney,Mitt,,Romney,,Republican,47
+Sedgwick,407,President,,WRITE-IN,,,,,,0
+Sedgwick,408,President,,Barack Obama,Barack,,Obama,,Democratic,385
+Sedgwick,408,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,8
+Sedgwick,408,President,,Gary Johnson,Gary,,Johnson,,Libertarian,21
+Sedgwick,408,President,,Mitt Romney,Mitt,,Romney,,Republican,361
+Sedgwick,408,President,,WRITE-IN,,,,,,9
+Sedgwick,409,President,,Barack Obama,Barack,,Obama,,Democratic,220
+Sedgwick,409,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,409,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,409,President,,Mitt Romney,Mitt,,Romney,,Republican,224
+Sedgwick,409,President,,WRITE-IN,,,,,,2
+Sedgwick,410,President,,Barack Obama,Barack,,Obama,,Democratic,265
+Sedgwick,410,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,410,President,,Gary Johnson,Gary,,Johnson,,Libertarian,15
+Sedgwick,410,President,,Mitt Romney,Mitt,,Romney,,Republican,252
+Sedgwick,410,President,,WRITE-IN,,,,,,3
+Sedgwick,411 & 505,President,,Barack Obama,Barack,,Obama,,Democratic,217
+Sedgwick,411 & 505,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,411 & 505,President,,Gary Johnson,Gary,,Johnson,,Libertarian,10
+Sedgwick,411 & 505,President,,Mitt Romney,Mitt,,Romney,,Republican,354
+Sedgwick,411 & 505,President,,WRITE-IN,,,,,,4
+Sedgwick,412,President,,Barack Obama,Barack,,Obama,,Democratic,490
+Sedgwick,412,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,7
+Sedgwick,412,President,,Gary Johnson,Gary,,Johnson,,Libertarian,40
+Sedgwick,412,President,,Mitt Romney,Mitt,,Romney,,Republican,1216
+Sedgwick,412,President,,WRITE-IN,,,,,,15
+Sedgwick,413,President,,Barack Obama,Barack,,Obama,,Democratic,401
+Sedgwick,413,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,413,President,,Gary Johnson,Gary,,Johnson,,Libertarian,29
+Sedgwick,413,President,,Mitt Romney,Mitt,,Romney,,Republican,900
+Sedgwick,413,President,,WRITE-IN,,,,,,11
+Sedgwick,414 & 415 & 537,President,,Barack Obama,Barack,,Obama,,Democratic,74
+Sedgwick,414 & 415 & 537,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,414 & 415 & 537,President,,Gary Johnson,Gary,,Johnson,,Libertarian,3
+Sedgwick,414 & 415 & 537,President,,Mitt Romney,Mitt,,Romney,,Republican,157
+Sedgwick,414 & 415 & 537,President,,WRITE-IN,,,,,,3
+Sedgwick,416 & 428,President,,Barack Obama,Barack,,Obama,,Democratic,270
+Sedgwick,416 & 428,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,9
+Sedgwick,416 & 428,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,416 & 428,President,,Mitt Romney,Mitt,,Romney,,Republican,616
+Sedgwick,416 & 428,President,,WRITE-IN,,,,,,5
+Sedgwick,417,President,,Barack Obama,Barack,,Obama,,Democratic,304
+Sedgwick,417,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,417,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,417,President,,Mitt Romney,Mitt,,Romney,,Republican,369
+Sedgwick,417,President,,WRITE-IN,,,,,,5
+Sedgwick,418,President,,Barack Obama,Barack,,Obama,,Democratic,411
+Sedgwick,418,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,11
+Sedgwick,418,President,,Gary Johnson,Gary,,Johnson,,Libertarian,15
+Sedgwick,418,President,,Mitt Romney,Mitt,,Romney,,Republican,553
+Sedgwick,418,President,,WRITE-IN,,,,,,9
+Sedgwick,419,President,,Barack Obama,Barack,,Obama,,Democratic,386
+Sedgwick,419,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,419,President,,Gary Johnson,Gary,,Johnson,,Libertarian,29
+Sedgwick,419,President,,Mitt Romney,Mitt,,Romney,,Republican,467
+Sedgwick,419,President,,WRITE-IN,,,,,,10
+Sedgwick,420,President,,Barack Obama,Barack,,Obama,,Democratic,378
+Sedgwick,420,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,420,President,,Gary Johnson,Gary,,Johnson,,Libertarian,22
+Sedgwick,420,President,,Mitt Romney,Mitt,,Romney,,Republican,510
+Sedgwick,420,President,,WRITE-IN,,,,,,3
+Sedgwick,421,President,,Barack Obama,Barack,,Obama,,Democratic,435
+Sedgwick,421,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,421,President,,Gary Johnson,Gary,,Johnson,,Libertarian,20
+Sedgwick,421,President,,Mitt Romney,Mitt,,Romney,,Republican,426
+Sedgwick,421,President,,WRITE-IN,,,,,,1
+Sedgwick,422,President,,Barack Obama,Barack,,Obama,,Democratic,241
+Sedgwick,422,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,422,President,,Gary Johnson,Gary,,Johnson,,Libertarian,15
+Sedgwick,422,President,,Mitt Romney,Mitt,,Romney,,Republican,325
+Sedgwick,422,President,,WRITE-IN,,,,,,3
+Sedgwick,423,President,,Barack Obama,Barack,,Obama,,Democratic,349
+Sedgwick,423,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,423,President,,Gary Johnson,Gary,,Johnson,,Libertarian,21
+Sedgwick,423,President,,Mitt Romney,Mitt,,Romney,,Republican,421
+Sedgwick,423,President,,WRITE-IN,,,,,,11
+Sedgwick,424,President,,Barack Obama,Barack,,Obama,,Democratic,292
+Sedgwick,424,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,424,President,,Gary Johnson,Gary,,Johnson,,Libertarian,28
+Sedgwick,424,President,,Mitt Romney,Mitt,,Romney,,Republican,498
+Sedgwick,424,President,,WRITE-IN,,,,,,5
+Sedgwick,425,President,,Barack Obama,Barack,,Obama,,Democratic,356
+Sedgwick,425,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,425,President,,Gary Johnson,Gary,,Johnson,,Libertarian,16
+Sedgwick,425,President,,Mitt Romney,Mitt,,Romney,,Republican,660
+Sedgwick,425,President,,WRITE-IN,,,,,,5
+Sedgwick,426,President,,Barack Obama,Barack,,Obama,,Democratic,120
+Sedgwick,426,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,426,President,,Gary Johnson,Gary,,Johnson,,Libertarian,9
+Sedgwick,426,President,,Mitt Romney,Mitt,,Romney,,Republican,159
+Sedgwick,426,President,,WRITE-IN,,,,,,3
+Sedgwick,429,President,,Barack Obama,Barack,,Obama,,Democratic,260
+Sedgwick,429,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,429,President,,Gary Johnson,Gary,,Johnson,,Libertarian,8
+Sedgwick,429,President,,Mitt Romney,Mitt,,Romney,,Republican,253
+Sedgwick,429,President,,WRITE-IN,,,,,,1
+Sedgwick,501,President,,Barack Obama,Barack,,Obama,,Democratic,18
+Sedgwick,501,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,501,President,,Gary Johnson,Gary,,Johnson,,Libertarian,3
+Sedgwick,501,President,,Mitt Romney,Mitt,,Romney,,Republican,77
+Sedgwick,501,President,,WRITE-IN,,,,,,0
+Sedgwick,502,President,,Barack Obama,Barack,,Obama,,Democratic,120
+Sedgwick,502,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,502,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,502,President,,Mitt Romney,Mitt,,Romney,,Republican,337
+Sedgwick,502,President,,WRITE-IN,,,,,,1
+Sedgwick,503,President,,Barack Obama,Barack,,Obama,,Democratic,454
+Sedgwick,503,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,503,President,,Gary Johnson,Gary,,Johnson,,Libertarian,24
+Sedgwick,503,President,,Mitt Romney,Mitt,,Romney,,Republican,623
+Sedgwick,503,President,,WRITE-IN,,,,,,11
+Sedgwick,504,President,,Barack Obama,Barack,,Obama,,Democratic,394
+Sedgwick,504,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,504,President,,Gary Johnson,Gary,,Johnson,,Libertarian,18
+Sedgwick,504,President,,Mitt Romney,Mitt,,Romney,,Republican,487
+Sedgwick,504,President,,WRITE-IN,,,,,,8
+Sedgwick,506,President,,Barack Obama,Barack,,Obama,,Democratic,423
+Sedgwick,506,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,7
+Sedgwick,506,President,,Gary Johnson,Gary,,Johnson,,Libertarian,26
+Sedgwick,506,President,,Mitt Romney,Mitt,,Romney,,Republican,822
+Sedgwick,506,President,,WRITE-IN,,,,,,4
+Sedgwick,507,President,,Barack Obama,Barack,,Obama,,Democratic,449
+Sedgwick,507,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,507,President,,Gary Johnson,Gary,,Johnson,,Libertarian,33
+Sedgwick,507,President,,Mitt Romney,Mitt,,Romney,,Republican,793
+Sedgwick,507,President,,WRITE-IN,,,,,,7
+Sedgwick,508,President,,Barack Obama,Barack,,Obama,,Democratic,412
+Sedgwick,508,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,508,President,,Gary Johnson,Gary,,Johnson,,Libertarian,27
+Sedgwick,508,President,,Mitt Romney,Mitt,,Romney,,Republican,668
+Sedgwick,508,President,,WRITE-IN,,,,,,3
+Sedgwick,509,President,,Barack Obama,Barack,,Obama,,Democratic,344
+Sedgwick,509,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,509,President,,Gary Johnson,Gary,,Johnson,,Libertarian,17
+Sedgwick,509,President,,Mitt Romney,Mitt,,Romney,,Republican,702
+Sedgwick,509,President,,WRITE-IN,,,,,,6
+Sedgwick,510,President,,Barack Obama,Barack,,Obama,,Democratic,302
+Sedgwick,510,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,510,President,,Gary Johnson,Gary,,Johnson,,Libertarian,10
+Sedgwick,510,President,,Mitt Romney,Mitt,,Romney,,Republican,1009
+Sedgwick,510,President,,WRITE-IN,,,,,,2
+Sedgwick,511,President,,Barack Obama,Barack,,Obama,,Democratic,19
+Sedgwick,511,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,511,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,511,President,,Mitt Romney,Mitt,,Romney,,Republican,91
+Sedgwick,511,President,,WRITE-IN,,,,,,0
+Sedgwick,512,President,,Barack Obama,Barack,,Obama,,Democratic,612
+Sedgwick,512,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,512,President,,Gary Johnson,Gary,,Johnson,,Libertarian,37
+Sedgwick,512,President,,Mitt Romney,Mitt,,Romney,,Republican,1585
+Sedgwick,512,President,,WRITE-IN,,,,,,16
+Sedgwick,513,President,,Barack Obama,Barack,,Obama,,Democratic,91
+Sedgwick,513,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,513,President,,Gary Johnson,Gary,,Johnson,,Libertarian,9
+Sedgwick,513,President,,Mitt Romney,Mitt,,Romney,,Republican,461
+Sedgwick,513,President,,WRITE-IN,,,,,,1
+Sedgwick,514,President,,Barack Obama,Barack,,Obama,,Democratic,454
+Sedgwick,514,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,514,President,,Gary Johnson,Gary,,Johnson,,Libertarian,28
+Sedgwick,514,President,,Mitt Romney,Mitt,,Romney,,Republican,1046
+Sedgwick,514,President,,WRITE-IN,,,,,,14
+Sedgwick,515,President,,Barack Obama,Barack,,Obama,,Democratic,401
+Sedgwick,515,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,515,President,,Gary Johnson,Gary,,Johnson,,Libertarian,18
+Sedgwick,515,President,,Mitt Romney,Mitt,,Romney,,Republican,846
+Sedgwick,515,President,,WRITE-IN,,,,,,12
+Sedgwick,516,President,,Barack Obama,Barack,,Obama,,Democratic,281
+Sedgwick,516,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,516,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,516,President,,Mitt Romney,Mitt,,Romney,,Republican,572
+Sedgwick,516,President,,WRITE-IN,,,,,,8
+Sedgwick,517,President,,Barack Obama,Barack,,Obama,,Democratic,324
+Sedgwick,517,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,517,President,,Gary Johnson,Gary,,Johnson,,Libertarian,22
+Sedgwick,517,President,,Mitt Romney,Mitt,,Romney,,Republican,553
+Sedgwick,517,President,,WRITE-IN,,,,,,15
+Sedgwick,518,President,,Barack Obama,Barack,,Obama,,Democratic,394
+Sedgwick,518,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,518,President,,Gary Johnson,Gary,,Johnson,,Libertarian,20
+Sedgwick,518,President,,Mitt Romney,Mitt,,Romney,,Republican,742
+Sedgwick,518,President,,WRITE-IN,,,,,,10
+Sedgwick,519,President,,Barack Obama,Barack,,Obama,,Democratic,447
+Sedgwick,519,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,519,President,,Gary Johnson,Gary,,Johnson,,Libertarian,18
+Sedgwick,519,President,,Mitt Romney,Mitt,,Romney,,Republican,726
+Sedgwick,519,President,,WRITE-IN,,,,,,5
+Sedgwick,520,President,,Barack Obama,Barack,,Obama,,Democratic,194
+Sedgwick,520,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,520,President,,Gary Johnson,Gary,,Johnson,,Libertarian,5
+Sedgwick,520,President,,Mitt Romney,Mitt,,Romney,,Republican,323
+Sedgwick,520,President,,WRITE-IN,,,,,,0
+Sedgwick,521,President,,Barack Obama,Barack,,Obama,,Democratic,180
+Sedgwick,521,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,521,President,,Gary Johnson,Gary,,Johnson,,Libertarian,9
+Sedgwick,521,President,,Mitt Romney,Mitt,,Romney,,Republican,577
+Sedgwick,521,President,,WRITE-IN,,,,,,1
+Sedgwick,522,President,,Barack Obama,Barack,,Obama,,Democratic,319
+Sedgwick,522,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,522,President,,Gary Johnson,Gary,,Johnson,,Libertarian,18
+Sedgwick,522,President,,Mitt Romney,Mitt,,Romney,,Republican,776
+Sedgwick,522,President,,WRITE-IN,,,,,,3
+Sedgwick,523,President,,Barack Obama,Barack,,Obama,,Democratic,320
+Sedgwick,523,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,523,President,,Gary Johnson,Gary,,Johnson,,Libertarian,18
+Sedgwick,523,President,,Mitt Romney,Mitt,,Romney,,Republican,788
+Sedgwick,523,President,,WRITE-IN,,,,,,6
+Sedgwick,524,President,,Barack Obama,Barack,,Obama,,Democratic,569
+Sedgwick,524,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,7
+Sedgwick,524,President,,Gary Johnson,Gary,,Johnson,,Libertarian,21
+Sedgwick,524,President,,Mitt Romney,Mitt,,Romney,,Republican,1190
+Sedgwick,524,President,,WRITE-IN,,,,,,12
+Sedgwick,525,President,,Barack Obama,Barack,,Obama,,Democratic,474
+Sedgwick,525,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,525,President,,Gary Johnson,Gary,,Johnson,,Libertarian,20
+Sedgwick,525,President,,Mitt Romney,Mitt,,Romney,,Republican,770
+Sedgwick,525,President,,WRITE-IN,,,,,,10
+Sedgwick,526,President,,Barack Obama,Barack,,Obama,,Democratic,392
+Sedgwick,526,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,526,President,,Gary Johnson,Gary,,Johnson,,Libertarian,21
+Sedgwick,526,President,,Mitt Romney,Mitt,,Romney,,Republican,788
+Sedgwick,526,President,,WRITE-IN,,,,,,9
+Sedgwick,527,President,,Barack Obama,Barack,,Obama,,Democratic,355
+Sedgwick,527,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,527,President,,Gary Johnson,Gary,,Johnson,,Libertarian,35
+Sedgwick,527,President,,Mitt Romney,Mitt,,Romney,,Republican,926
+Sedgwick,527,President,,WRITE-IN,,,,,,7
+Sedgwick,529,President,,Barack Obama,Barack,,Obama,,Democratic,201
+Sedgwick,529,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,529,President,,Gary Johnson,Gary,,Johnson,,Libertarian,16
+Sedgwick,529,President,,Mitt Romney,Mitt,,Romney,,Republican,521
+Sedgwick,529,President,,WRITE-IN,,,,,,1
+Sedgwick,530,President,,Barack Obama,Barack,,Obama,,Democratic,260
+Sedgwick,530,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,530,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,530,President,,Mitt Romney,Mitt,,Romney,,Republican,904
+Sedgwick,530,President,,WRITE-IN,,,,,,5
+Sedgwick,531,President,,Barack Obama,Barack,,Obama,,Democratic,509
+Sedgwick,531,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,531,President,,Gary Johnson,Gary,,Johnson,,Libertarian,22
+Sedgwick,531,President,,Mitt Romney,Mitt,,Romney,,Republican,1357
+Sedgwick,531,President,,WRITE-IN,,,,,,9
+Sedgwick,532,President,,Barack Obama,Barack,,Obama,,Democratic,305
+Sedgwick,532,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,532,President,,Gary Johnson,Gary,,Johnson,,Libertarian,20
+Sedgwick,532,President,,Mitt Romney,Mitt,,Romney,,Republican,1078
+Sedgwick,532,President,,WRITE-IN,,,,,,5
+Sedgwick,533,President,,Barack Obama,Barack,,Obama,,Democratic,58
+Sedgwick,533,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,533,President,,Gary Johnson,Gary,,Johnson,,Libertarian,4
+Sedgwick,533,President,,Mitt Romney,Mitt,,Romney,,Republican,201
+Sedgwick,533,President,,WRITE-IN,,,,,,4
+Sedgwick,534,President,,Barack Obama,Barack,,Obama,,Democratic,29
+Sedgwick,534,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,534,President,,Gary Johnson,Gary,,Johnson,,Libertarian,1
+Sedgwick,534,President,,Mitt Romney,Mitt,,Romney,,Republican,90
+Sedgwick,534,President,,WRITE-IN,,,,,,0
+Sedgwick,535,President,,Barack Obama,Barack,,Obama,,Democratic,6
+Sedgwick,535,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,535,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,535,President,,Mitt Romney,Mitt,,Romney,,Republican,14
+Sedgwick,535,President,,WRITE-IN,,,,,,0
+Sedgwick,538,President,,Barack Obama,Barack,,Obama,,Democratic,57
+Sedgwick,538,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,538,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,538,President,,Mitt Romney,Mitt,,Romney,,Republican,167
+Sedgwick,538,President,,WRITE-IN,,,,,,0
+Sedgwick,601,President,,Barack Obama,Barack,,Obama,,Democratic,483
+Sedgwick,601,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,601,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,601,President,,Mitt Romney,Mitt,,Romney,,Republican,227
+Sedgwick,601,President,,WRITE-IN,,,,,,6
+Sedgwick,602,President,,Barack Obama,Barack,,Obama,,Democratic,231
+Sedgwick,602,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,602,President,,Gary Johnson,Gary,,Johnson,,Libertarian,21
+Sedgwick,602,President,,Mitt Romney,Mitt,,Romney,,Republican,244
+Sedgwick,602,President,,WRITE-IN,,,,,,11
+Sedgwick,603,President,,Barack Obama,Barack,,Obama,,Democratic,298
+Sedgwick,603,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,603,President,,Gary Johnson,Gary,,Johnson,,Libertarian,17
+Sedgwick,603,President,,Mitt Romney,Mitt,,Romney,,Republican,368
+Sedgwick,603,President,,WRITE-IN,,,,,,4
+Sedgwick,604,President,,Barack Obama,Barack,,Obama,,Democratic,490
+Sedgwick,604,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,8
+Sedgwick,604,President,,Gary Johnson,Gary,,Johnson,,Libertarian,52
+Sedgwick,604,President,,Mitt Romney,Mitt,,Romney,,Republican,704
+Sedgwick,604,President,,WRITE-IN,,,,,,13
+Sedgwick,605,President,,Barack Obama,Barack,,Obama,,Democratic,192
+Sedgwick,605,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,605,President,,Gary Johnson,Gary,,Johnson,,Libertarian,11
+Sedgwick,605,President,,Mitt Romney,Mitt,,Romney,,Republican,261
+Sedgwick,605,President,,WRITE-IN,,,,,,1
+Sedgwick,606,President,,Barack Obama,Barack,,Obama,,Democratic,177
+Sedgwick,606,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,606,President,,Gary Johnson,Gary,,Johnson,,Libertarian,9
+Sedgwick,606,President,,Mitt Romney,Mitt,,Romney,,Republican,182
+Sedgwick,606,President,,WRITE-IN,,,,,,3
+Sedgwick,607,President,,Barack Obama,Barack,,Obama,,Democratic,795
+Sedgwick,607,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,607,President,,Gary Johnson,Gary,,Johnson,,Libertarian,34
+Sedgwick,607,President,,Mitt Romney,Mitt,,Romney,,Republican,549
+Sedgwick,607,President,,WRITE-IN,,,,,,10
+Sedgwick,608,President,,Barack Obama,Barack,,Obama,,Democratic,576
+Sedgwick,608,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,608,President,,Gary Johnson,Gary,,Johnson,,Libertarian,25
+Sedgwick,608,President,,Mitt Romney,Mitt,,Romney,,Republican,261
+Sedgwick,608,President,,WRITE-IN,,,,,,10
+Sedgwick,609,President,,Barack Obama,Barack,,Obama,,Democratic,876
+Sedgwick,609,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,609,President,,Gary Johnson,Gary,,Johnson,,Libertarian,40
+Sedgwick,609,President,,Mitt Romney,Mitt,,Romney,,Republican,677
+Sedgwick,609,President,,WRITE-IN,,,,,,13
+Sedgwick,610,President,,Barack Obama,Barack,,Obama,,Democratic,496
+Sedgwick,610,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,8
+Sedgwick,610,President,,Gary Johnson,Gary,,Johnson,,Libertarian,34
+Sedgwick,610,President,,Mitt Romney,Mitt,,Romney,,Republican,672
+Sedgwick,610,President,,WRITE-IN,,,,,,5
+Sedgwick,611,President,,Barack Obama,Barack,,Obama,,Democratic,316
+Sedgwick,611,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,611,President,,Gary Johnson,Gary,,Johnson,,Libertarian,24
+Sedgwick,611,President,,Mitt Romney,Mitt,,Romney,,Republican,307
+Sedgwick,611,President,,WRITE-IN,,,,,,1
+Sedgwick,612,President,,Barack Obama,Barack,,Obama,,Democratic,504
+Sedgwick,612,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,612,President,,Gary Johnson,Gary,,Johnson,,Libertarian,31
+Sedgwick,612,President,,Mitt Romney,Mitt,,Romney,,Republican,715
+Sedgwick,612,President,,WRITE-IN,,,,,,7
+Sedgwick,613,President,,Barack Obama,Barack,,Obama,,Democratic,492
+Sedgwick,613,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,613,President,,Gary Johnson,Gary,,Johnson,,Libertarian,19
+Sedgwick,613,President,,Mitt Romney,Mitt,,Romney,,Republican,662
+Sedgwick,613,President,,WRITE-IN,,,,,,9
+Sedgwick,614,President,,Barack Obama,Barack,,Obama,,Democratic,533
+Sedgwick,614,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,614,President,,Gary Johnson,Gary,,Johnson,,Libertarian,12
+Sedgwick,614,President,,Mitt Romney,Mitt,,Romney,,Republican,226
+Sedgwick,614,President,,WRITE-IN,,,,,,3
+Sedgwick,615,President,,Barack Obama,Barack,,Obama,,Democratic,327
+Sedgwick,615,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,615,President,,Gary Johnson,Gary,,Johnson,,Libertarian,8
+Sedgwick,615,President,,Mitt Romney,Mitt,,Romney,,Republican,92
+Sedgwick,615,President,,WRITE-IN,,,,,,5
+Sedgwick,616 & 617,President,,Barack Obama,Barack,,Obama,,Democratic,252
+Sedgwick,616 & 617,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,616 & 617,President,,Gary Johnson,Gary,,Johnson,,Libertarian,6
+Sedgwick,616 & 617,President,,Mitt Romney,Mitt,,Romney,,Republican,145
+Sedgwick,616 & 617,President,,WRITE-IN,,,,,,0
+Sedgwick,618,President,,Barack Obama,Barack,,Obama,,Democratic,177
+Sedgwick,618,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,618,President,,Gary Johnson,Gary,,Johnson,,Libertarian,11
+Sedgwick,618,President,,Mitt Romney,Mitt,,Romney,,Republican,252
+Sedgwick,618,President,,WRITE-IN,,,,,,1
+Sedgwick,619,President,,Barack Obama,Barack,,Obama,,Democratic,513
+Sedgwick,619,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,619,President,,Gary Johnson,Gary,,Johnson,,Libertarian,26
+Sedgwick,619,President,,Mitt Romney,Mitt,,Romney,,Republican,632
+Sedgwick,619,President,,WRITE-IN,,,,,,5
+Sedgwick,620,President,,Barack Obama,Barack,,Obama,,Democratic,255
+Sedgwick,620,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,620,President,,Gary Johnson,Gary,,Johnson,,Libertarian,8
+Sedgwick,620,President,,Mitt Romney,Mitt,,Romney,,Republican,345
+Sedgwick,620,President,,WRITE-IN,,,,,,1
+Sedgwick,621,President,,Barack Obama,Barack,,Obama,,Democratic,6
+Sedgwick,621,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,621,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,621,President,,Mitt Romney,Mitt,,Romney,,Republican,16
+Sedgwick,621,President,,WRITE-IN,,,,,,0
+Sedgwick,622,President,,Barack Obama,Barack,,Obama,,Democratic,147
+Sedgwick,622,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,622,President,,Gary Johnson,Gary,,Johnson,,Libertarian,7
+Sedgwick,622,President,,Mitt Romney,Mitt,,Romney,,Republican,442
+Sedgwick,622,President,,WRITE-IN,,,,,,4
+Sedgwick,623,President,,Barack Obama,Barack,,Obama,,Democratic,303
+Sedgwick,623,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,623,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,623,President,,Mitt Romney,Mitt,,Romney,,Republican,714
+Sedgwick,623,President,,WRITE-IN,,,,,,3
+Sedgwick,624,President,,Barack Obama,Barack,,Obama,,Democratic,53
+Sedgwick,624,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,624,President,,Gary Johnson,Gary,,Johnson,,Libertarian,4
+Sedgwick,624,President,,Mitt Romney,Mitt,,Romney,,Republican,43
+Sedgwick,624,President,,WRITE-IN,,,,,,0
+Sedgwick,625,President,,Barack Obama,Barack,,Obama,,Democratic,89
+Sedgwick,625,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,625,President,,Gary Johnson,Gary,,Johnson,,Libertarian,5
+Sedgwick,625,President,,Mitt Romney,Mitt,,Romney,,Republican,155
+Sedgwick,625,President,,WRITE-IN,,,,,,2
+Sedgwick,626,President,,Barack Obama,Barack,,Obama,,Democratic,2
+Sedgwick,626,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,626,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,626,President,,Mitt Romney,Mitt,,Romney,,Republican,4
+Sedgwick,626,President,,WRITE-IN,,,,,,0
+Sedgwick,627,President,,Barack Obama,Barack,,Obama,,Democratic,44
+Sedgwick,627,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,627,President,,Gary Johnson,Gary,,Johnson,,Libertarian,1
+Sedgwick,627,President,,Mitt Romney,Mitt,,Romney,,Republican,58
+Sedgwick,627,President,,WRITE-IN,,,,,,2
+Sedgwick,628,President,,Barack Obama,Barack,,Obama,,Democratic,205
+Sedgwick,628,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,628,President,,Gary Johnson,Gary,,Johnson,,Libertarian,18
+Sedgwick,628,President,,Mitt Romney,Mitt,,Romney,,Republican,460
+Sedgwick,628,President,,WRITE-IN,,,,,,0
+Sedgwick,AF,President,,Barack Obama,Barack,,Obama,,Democratic,154
+Sedgwick,AF,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,AF,President,,Gary Johnson,Gary,,Johnson,,Libertarian,9
+Sedgwick,AF,President,,Mitt Romney,Mitt,,Romney,,Republican,591
+Sedgwick,AF,President,,WRITE-IN,,,,,,1
+Sedgwick,AT01,President,,Barack Obama,Barack,,Obama,,Democratic,8
+Sedgwick,AT01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,AT01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,AT01,President,,Mitt Romney,Mitt,,Romney,,Republican,55
+Sedgwick,AT01,President,,WRITE-IN,,,,,,1
+Sedgwick,AT02,President,,Barack Obama,Barack,,Obama,,Democratic,47
+Sedgwick,AT02,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,AT02,President,,Gary Johnson,Gary,,Johnson,,Libertarian,6
+Sedgwick,AT02,President,,Mitt Romney,Mitt,,Romney,,Republican,83
+Sedgwick,AT02,President,,WRITE-IN,,,,,,3
+Sedgwick,AT03,President,,Barack Obama,Barack,,Obama,,Democratic,54
+Sedgwick,AT03,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,AT03,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,AT03,President,,Mitt Romney,Mitt,,Romney,,Republican,284
+Sedgwick,AT03,President,,WRITE-IN,,,,,,0
+Sedgwick,AT05,President,,Barack Obama,Barack,,Obama,,Democratic,58
+Sedgwick,AT05,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,AT05,President,,Gary Johnson,Gary,,Johnson,,Libertarian,1
+Sedgwick,AT05,President,,Mitt Romney,Mitt,,Romney,,Republican,197
+Sedgwick,AT05,President,,WRITE-IN,,,,,,0
+Sedgwick,AT06,President,,Barack Obama,Barack,,Obama,,Democratic,3
+Sedgwick,AT06,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,AT06,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,AT06,President,,Mitt Romney,Mitt,,Romney,,Republican,39
+Sedgwick,AT06,President,,WRITE-IN,,,,,,0
+Sedgwick,AT07,President,,Barack Obama,Barack,,Obama,,Democratic,39
+Sedgwick,AT07,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,AT07,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,AT07,President,,Mitt Romney,Mitt,,Romney,,Republican,95
+Sedgwick,AT07,President,,WRITE-IN,,,,,,0
+Sedgwick,AT08,President,,Barack Obama,Barack,,Obama,,Democratic,18
+Sedgwick,AT08,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,AT08,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,AT08,President,,Mitt Romney,Mitt,,Romney,,Republican,37
+Sedgwick,AT08,President,,WRITE-IN,,,,,,0
+Sedgwick,BA01,President,,Barack Obama,Barack,,Obama,,Democratic,477
+Sedgwick,BA01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,BA01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,23
+Sedgwick,BA01,President,,Mitt Romney,Mitt,,Romney,,Republican,878
+Sedgwick,BA01,President,,WRITE-IN,,,,,,9
+Sedgwick,BA02,President,,Barack Obama,Barack,,Obama,,Democratic,464
+Sedgwick,BA02,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,BA02,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,BA02,President,,Mitt Romney,Mitt,,Romney,,Republican,732
+Sedgwick,BA02,President,,WRITE-IN,,,,,,9
+Sedgwick,BA03,President,,Barack Obama,Barack,,Obama,,Democratic,313
+Sedgwick,BA03,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,BA03,President,,Gary Johnson,Gary,,Johnson,,Libertarian,12
+Sedgwick,BA03,President,,Mitt Romney,Mitt,,Romney,,Republican,495
+Sedgwick,BA03,President,,WRITE-IN,,,,,,3
+Sedgwick,DB11,President,,Barack Obama,Barack,,Obama,,Democratic,366
+Sedgwick,DB11,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,DB11,President,,Gary Johnson,Gary,,Johnson,,Libertarian,16
+Sedgwick,DB11,President,,Mitt Romney,Mitt,,Romney,,Republican,872
+Sedgwick,DB11,President,,WRITE-IN,,,,,,6
+Sedgwick,DB12,President,,Barack Obama,Barack,,Obama,,Democratic,222
+Sedgwick,DB12,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,DB12,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,DB12,President,,Mitt Romney,Mitt,,Romney,,Republican,489
+Sedgwick,DB12,President,,WRITE-IN,,,,,,1
+Sedgwick,DB13 & 24 & 27,President,,Barack Obama,Barack,,Obama,,Democratic,53
+Sedgwick,DB13 & 24 & 27,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,DB13 & 24 & 27,President,,Gary Johnson,Gary,,Johnson,,Libertarian,3
+Sedgwick,DB13 & 24 & 27,President,,Mitt Romney,Mitt,,Romney,,Republican,111
+Sedgwick,DB13 & 24 & 27,President,,WRITE-IN,,,,,,4
+Sedgwick,DB14,President,,Barack Obama,Barack,,Obama,,Democratic,130
+Sedgwick,DB14,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,DB14,President,,Gary Johnson,Gary,,Johnson,,Libertarian,7
+Sedgwick,DB14,President,,Mitt Romney,Mitt,,Romney,,Republican,279
+Sedgwick,DB14,President,,WRITE-IN,,,,,,3
+Sedgwick,DB15,President,,Barack Obama,Barack,,Obama,,Democratic,12
+Sedgwick,DB15,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,DB15,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,DB15,President,,Mitt Romney,Mitt,,Romney,,Republican,30
+Sedgwick,DB15,President,,WRITE-IN,,,,,,0
+Sedgwick,DB21,President,,Barack Obama,Barack,,Obama,,Democratic,236
+Sedgwick,DB21,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,DB21,President,,Gary Johnson,Gary,,Johnson,,Libertarian,18
+Sedgwick,DB21,President,,Mitt Romney,Mitt,,Romney,,Republican,474
+Sedgwick,DB21,President,,WRITE-IN,,,,,,1
+Sedgwick,DB22,President,,Barack Obama,Barack,,Obama,,Democratic,203
+Sedgwick,DB22,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,DB22,President,,Gary Johnson,Gary,,Johnson,,Libertarian,8
+Sedgwick,DB22,President,,Mitt Romney,Mitt,,Romney,,Republican,469
+Sedgwick,DB22,President,,WRITE-IN,,,,,,3
+Sedgwick,DB23,President,,Barack Obama,Barack,,Obama,,Democratic,83
+Sedgwick,DB23,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,DB23,President,,Gary Johnson,Gary,,Johnson,,Libertarian,5
+Sedgwick,DB23,President,,Mitt Romney,Mitt,,Romney,,Republican,279
+Sedgwick,DB23,President,,WRITE-IN,,,,,,0
+Sedgwick,DB25,President,,Barack Obama,Barack,,Obama,,Democratic,29
+Sedgwick,DB25,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,DB25,President,,Gary Johnson,Gary,,Johnson,,Libertarian,7
+Sedgwick,DB25,President,,Mitt Romney,Mitt,,Romney,,Republican,33
+Sedgwick,DB25,President,,WRITE-IN,,,,,,0
+Sedgwick,DB26,President,,Barack Obama,Barack,,Obama,,Democratic,137
+Sedgwick,DB26,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,DB26,President,,Gary Johnson,Gary,,Johnson,,Libertarian,9
+Sedgwick,DB26,President,,Mitt Romney,Mitt,,Romney,,Republican,322
+Sedgwick,DB26,President,,WRITE-IN,,,,,,3
+Sedgwick,DB31,President,,Barack Obama,Barack,,Obama,,Democratic,129
+Sedgwick,DB31,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,DB31,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,DB31,President,,Mitt Romney,Mitt,,Romney,,Republican,215
+Sedgwick,DB31,President,,WRITE-IN,,,,,,2
+Sedgwick,DB32,President,,Barack Obama,Barack,,Obama,,Democratic,80
+Sedgwick,DB32,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,DB32,President,,Gary Johnson,Gary,,Johnson,,Libertarian,7
+Sedgwick,DB32,President,,Mitt Romney,Mitt,,Romney,,Republican,151
+Sedgwick,DB32,President,,WRITE-IN,,,,,,1
+Sedgwick,DB34,President,,Barack Obama,Barack,,Obama,,Democratic,60
+Sedgwick,DB34,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,DB34,President,,Gary Johnson,Gary,,Johnson,,Libertarian,7
+Sedgwick,DB34,President,,Mitt Romney,Mitt,,Romney,,Republican,141
+Sedgwick,DB34,President,,WRITE-IN,,,,,,1
+Sedgwick,DB35,President,,Barack Obama,Barack,,Obama,,Democratic,118
+Sedgwick,DB35,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,DB35,President,,Gary Johnson,Gary,,Johnson,,Libertarian,4
+Sedgwick,DB35,President,,Mitt Romney,Mitt,,Romney,,Republican,236
+Sedgwick,DB35,President,,WRITE-IN,,,,,,1
+Sedgwick,DB36,President,,Barack Obama,Barack,,Obama,,Democratic,357
+Sedgwick,DB36,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,DB36,President,,Gary Johnson,Gary,,Johnson,,Libertarian,23
+Sedgwick,DB36,President,,Mitt Romney,Mitt,,Romney,,Republican,762
+Sedgwick,DB36,President,,WRITE-IN,,,,,,6
+Sedgwick,DB37,President,,Barack Obama,Barack,,Obama,,Democratic,68
+Sedgwick,DB37,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,DB37,President,,Gary Johnson,Gary,,Johnson,,Libertarian,7
+Sedgwick,DB37,President,,Mitt Romney,Mitt,,Romney,,Republican,103
+Sedgwick,DB37,President,,WRITE-IN,,,,,,1
+Sedgwick,DB41,President,,Barack Obama,Barack,,Obama,,Democratic,170
+Sedgwick,DB41,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,DB41,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,DB41,President,,Mitt Romney,Mitt,,Romney,,Republican,330
+Sedgwick,DB41,President,,WRITE-IN,,,,,,2
+Sedgwick,DB42,President,,Barack Obama,Barack,,Obama,,Democratic,264
+Sedgwick,DB42,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,DB42,President,,Gary Johnson,Gary,,Johnson,,Libertarian,18
+Sedgwick,DB42,President,,Mitt Romney,Mitt,,Romney,,Republican,871
+Sedgwick,DB42,President,,WRITE-IN,,,,,,2
+Sedgwick,DB43,President,,Barack Obama,Barack,,Obama,,Democratic,18
+Sedgwick,DB43,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,DB43,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,DB43,President,,Mitt Romney,Mitt,,Romney,,Republican,16
+Sedgwick,DB43,President,,WRITE-IN,,,,,,0
+Sedgwick,DB44,President,,Barack Obama,Barack,,Obama,,Democratic,224
+Sedgwick,DB44,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,DB44,President,,Gary Johnson,Gary,,Johnson,,Libertarian,15
+Sedgwick,DB44,President,,Mitt Romney,Mitt,,Romney,,Republican,441
+Sedgwick,DB44,President,,WRITE-IN,,,,,,5
+Sedgwick,DL02,President,,Barack Obama,Barack,,Obama,,Democratic,1
+Sedgwick,DL02,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,DL02,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,DL02,President,,Mitt Romney,Mitt,,Romney,,Republican,2
+Sedgwick,DL02,President,,WRITE-IN,,,,,,0
+Sedgwick,DL03,President,,Barack Obama,Barack,,Obama,,Democratic,0
+Sedgwick,DL03,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,DL03,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,DL03,President,,Mitt Romney,Mitt,,Romney,,Republican,1
+Sedgwick,DL03,President,,WRITE-IN,,,,,,0
+Sedgwick,DL04,President,,Barack Obama,Barack,,Obama,,Democratic,0
+Sedgwick,DL04,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,DL04,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,DL04,President,,Mitt Romney,Mitt,,Romney,,Republican,1
+Sedgwick,DL04,President,,WRITE-IN,,,,,,0
+Sedgwick,EA,President,,Barack Obama,Barack,,Obama,,Democratic,144
+Sedgwick,EA,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,EA,President,,Gary Johnson,Gary,,Johnson,,Libertarian,8
+Sedgwick,EA,President,,Mitt Romney,Mitt,,Romney,,Republican,305
+Sedgwick,EA,President,,WRITE-IN,,,,,,2
+Sedgwick,ER,President,,Barack Obama,Barack,,Obama,,Democratic,16
+Sedgwick,ER,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,ER,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,ER,President,,Mitt Romney,Mitt,,Romney,,Republican,36
+Sedgwick,ER,President,,WRITE-IN,,,,,,0
+Sedgwick,GA,President,,Barack Obama,Barack,,Obama,,Democratic,142
+Sedgwick,GA,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,GA,President,,Gary Johnson,Gary,,Johnson,,Libertarian,10
+Sedgwick,GA,President,,Mitt Romney,Mitt,,Romney,,Republican,751
+Sedgwick,GA,President,,WRITE-IN,,,,,,3
+Sedgwick,GD,President,,Barack Obama,Barack,,Obama,,Democratic,40
+Sedgwick,GD,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,GD,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,GD,President,,Mitt Romney,Mitt,,Romney,,Republican,237
+Sedgwick,GD,President,,WRITE-IN,,,,,,1
+Sedgwick,GN01,President,,Barack Obama,Barack,,Obama,,Democratic,98
+Sedgwick,GN01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,GN01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,12
+Sedgwick,GN01,President,,Mitt Romney,Mitt,,Romney,,Republican,394
+Sedgwick,GN01,President,,WRITE-IN,,,,,,3
+Sedgwick,GN02,President,,Barack Obama,Barack,,Obama,,Democratic,53
+Sedgwick,GN02,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,GN02,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,GN02,President,,Mitt Romney,Mitt,,Romney,,Republican,154
+Sedgwick,GN02,President,,WRITE-IN,,,,,,4
+Sedgwick,GO,President,,Barack Obama,Barack,,Obama,,Democratic,393
+Sedgwick,GO,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,GO,President,,Gary Johnson,Gary,,Johnson,,Libertarian,28
+Sedgwick,GO,President,,Mitt Romney,Mitt,,Romney,,Republican,1204
+Sedgwick,GO,President,,WRITE-IN,,,,,,11
+Sedgwick,GO01,President,,Barack Obama,Barack,,Obama,,Democratic,4
+Sedgwick,GO01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,GO01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,GO01,President,,Mitt Romney,Mitt,,Romney,,Republican,30
+Sedgwick,GO01,President,,WRITE-IN,,,,,,0
+Sedgwick,GR,President,,Barack Obama,Barack,,Obama,,Democratic,100
+Sedgwick,GR,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,GR,President,,Gary Johnson,Gary,,Johnson,,Libertarian,11
+Sedgwick,GR,President,,Mitt Romney,Mitt,,Romney,,Republican,348
+Sedgwick,GR,President,,WRITE-IN,,,,,,1
+Sedgwick,GY01,President,,Barack Obama,Barack,,Obama,,Democratic,415
+Sedgwick,GY01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,GY01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,33
+Sedgwick,GY01,President,,Mitt Romney,Mitt,,Romney,,Republican,1155
+Sedgwick,GY01,President,,WRITE-IN,,,,,,4
+Sedgwick,GY02,President,,Barack Obama,Barack,,Obama,,Democratic,22
+Sedgwick,GY02,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,GY02,President,,Gary Johnson,Gary,,Johnson,,Libertarian,1
+Sedgwick,GY02,President,,Mitt Romney,Mitt,,Romney,,Republican,39
+Sedgwick,GY02,President,,WRITE-IN,,,,,,0
+Sedgwick,GY03,President,,Barack Obama,Barack,,Obama,,Democratic,14
+Sedgwick,GY03,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,GY03,President,,Gary Johnson,Gary,,Johnson,,Libertarian,1
+Sedgwick,GY03,President,,Mitt Romney,Mitt,,Romney,,Republican,31
+Sedgwick,GY03,President,,WRITE-IN,,,,,,0
+Sedgwick,GY04,President,,Barack Obama,Barack,,Obama,,Democratic,3
+Sedgwick,GY04,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,GY04,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,GY04,President,,Mitt Romney,Mitt,,Romney,,Republican,6
+Sedgwick,GY04,President,,WRITE-IN,,,,,,0
+Sedgwick,HA11,President,,Barack Obama,Barack,,Obama,,Democratic,273
+Sedgwick,HA11,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,HA11,President,,Gary Johnson,Gary,,Johnson,,Libertarian,11
+Sedgwick,HA11,President,,Mitt Romney,Mitt,,Romney,,Republican,528
+Sedgwick,HA11,President,,WRITE-IN,,,,,,7
+Sedgwick,HA21 & HA23,President,,Barack Obama,Barack,,Obama,,Democratic,322
+Sedgwick,HA21 & HA23,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,HA21 & HA23,President,,Gary Johnson,Gary,,Johnson,,Libertarian,26
+Sedgwick,HA21 & HA23,President,,Mitt Romney,Mitt,,Romney,,Republican,505
+Sedgwick,HA21 & HA23,President,,WRITE-IN,,,,,,8
+Sedgwick,HA22,President,,Barack Obama,Barack,,Obama,,Democratic,22
+Sedgwick,HA22,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,HA22,President,,Gary Johnson,Gary,,Johnson,,Libertarian,5
+Sedgwick,HA22,President,,Mitt Romney,Mitt,,Romney,,Republican,71
+Sedgwick,HA22,President,,WRITE-IN,,,,,,0
+Sedgwick,HA31,President,,Barack Obama,Barack,,Obama,,Democratic,334
+Sedgwick,HA31,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,8
+Sedgwick,HA31,President,,Gary Johnson,Gary,,Johnson,,Libertarian,34
+Sedgwick,HA31,President,,Mitt Romney,Mitt,,Romney,,Republican,631
+Sedgwick,HA31,President,,WRITE-IN,,,,,,6
+Sedgwick,HA32,President,,Barack Obama,Barack,,Obama,,Democratic,7
+Sedgwick,HA32,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,HA32,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,HA32,President,,Mitt Romney,Mitt,,Romney,,Republican,21
+Sedgwick,HA32,President,,WRITE-IN,,,,,,0
+Sedgwick,HA41,President,,Barack Obama,Barack,,Obama,,Democratic,277
+Sedgwick,HA41,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,HA41,President,,Gary Johnson,Gary,,Johnson,,Libertarian,16
+Sedgwick,HA41,President,,Mitt Romney,Mitt,,Romney,,Republican,524
+Sedgwick,HA41,President,,WRITE-IN,,,,,,7
+Sedgwick,HA42,President,,Barack Obama,Barack,,Obama,,Democratic,52
+Sedgwick,HA42,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,HA42,President,,Gary Johnson,Gary,,Johnson,,Libertarian,6
+Sedgwick,HA42,President,,Mitt Romney,Mitt,,Romney,,Republican,146
+Sedgwick,HA42,President,,WRITE-IN,,,,,,0
+Sedgwick,IL01,President,,Barack Obama,Barack,,Obama,,Democratic,82
+Sedgwick,IL01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,IL01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,4
+Sedgwick,IL01,President,,Mitt Romney,Mitt,,Romney,,Republican,385
+Sedgwick,IL01,President,,WRITE-IN,,,,,,1
+Sedgwick,IL02,President,,Barack Obama,Barack,,Obama,,Democratic,97
+Sedgwick,IL02,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,IL02,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,IL02,President,,Mitt Romney,Mitt,,Romney,,Republican,285
+Sedgwick,IL02,President,,WRITE-IN,,,,,,2
+Sedgwick,KE01 & 02 & 06,President,,Barack Obama,Barack,,Obama,,Democratic,3
+Sedgwick,KE01 & 02 & 06,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,KE01 & 02 & 06,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,KE01 & 02 & 06,President,,Mitt Romney,Mitt,,Romney,,Republican,6
+Sedgwick,KE01 & 02 & 06,President,,WRITE-IN,,,,,,0
+Sedgwick,KE03,President,,Barack Obama,Barack,,Obama,,Democratic,269
+Sedgwick,KE03,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,KE03,President,,Gary Johnson,Gary,,Johnson,,Libertarian,21
+Sedgwick,KE03,President,,Mitt Romney,Mitt,,Romney,,Republican,572
+Sedgwick,KE03,President,,WRITE-IN,,,,,,5
+Sedgwick,KE04,President,,Barack Obama,Barack,,Obama,,Democratic,13
+Sedgwick,KE04,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,KE04,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,KE04,President,,Mitt Romney,Mitt,,Romney,,Republican,23
+Sedgwick,KE04,President,,WRITE-IN,,,,,,0
+Sedgwick,KE07,President,,Barack Obama,Barack,,Obama,,Democratic,8
+Sedgwick,KE07,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,KE07,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,KE07,President,,Mitt Romney,Mitt,,Romney,,Republican,13
+Sedgwick,KE07,President,,WRITE-IN,,,,,,1
+Sedgwick,KE08,President,,Barack Obama,Barack,,Obama,,Democratic,2
+Sedgwick,KE08,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,KE08,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,KE08,President,,Mitt Romney,Mitt,,Romney,,Republican,13
+Sedgwick,KE08,President,,WRITE-IN,,,,,,0
+Sedgwick,LI,President,,Barack Obama,Barack,,Obama,,Democratic,57
+Sedgwick,LI,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,LI,President,,Gary Johnson,Gary,,Johnson,,Libertarian,3
+Sedgwick,LI,President,,Mitt Romney,Mitt,,Romney,,Republican,198
+Sedgwick,LI,President,,WRITE-IN,,,,,,5
+Sedgwick,MI01,President,,Barack Obama,Barack,,Obama,,Democratic,233
+Sedgwick,MI01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,MI01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,14
+Sedgwick,MI01,President,,Mitt Romney,Mitt,,Romney,,Republican,944
+Sedgwick,MI01,President,,WRITE-IN,,,,,,5
+Sedgwick,MI02,President,,Barack Obama,Barack,,Obama,,Democratic,138
+Sedgwick,MI02,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,MI02,President,,Gary Johnson,Gary,,Johnson,,Libertarian,7
+Sedgwick,MI02,President,,Mitt Romney,Mitt,,Romney,,Republican,334
+Sedgwick,MI02,President,,WRITE-IN,,,,,,0
+Sedgwick,MI03,President,,Barack Obama,Barack,,Obama,,Democratic,36
+Sedgwick,MI03,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,MI03,President,,Gary Johnson,Gary,,Johnson,,Libertarian,1
+Sedgwick,MI03,President,,Mitt Romney,Mitt,,Romney,,Republican,92
+Sedgwick,MI03,President,,WRITE-IN,,,,,,0
+Sedgwick,MI04 & MI05,President,,Barack Obama,Barack,,Obama,,Democratic,1
+Sedgwick,MI04 & MI05,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,MI04 & MI05,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,MI04 & MI05,President,,Mitt Romney,Mitt,,Romney,,Republican,3
+Sedgwick,MI04 & MI05,President,,WRITE-IN,,,,,,0
+Sedgwick,MI07,President,,Barack Obama,Barack,,Obama,,Democratic,5
+Sedgwick,MI07,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,MI07,President,,Gary Johnson,Gary,,Johnson,,Libertarian,3
+Sedgwick,MI07,President,,Mitt Romney,Mitt,,Romney,,Republican,7
+Sedgwick,MI07,President,,WRITE-IN,,,,,,0
+Sedgwick,MI08,President,,Barack Obama,Barack,,Obama,,Democratic,15
+Sedgwick,MI08,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,MI08,President,,Gary Johnson,Gary,,Johnson,,Libertarian,4
+Sedgwick,MI08,President,,Mitt Romney,Mitt,,Romney,,Republican,13
+Sedgwick,MI08,President,,WRITE-IN,,,,,,1
+Sedgwick,MI09,President,,Barack Obama,Barack,,Obama,,Democratic,73
+Sedgwick,MI09,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,MI09,President,,Gary Johnson,Gary,,Johnson,,Libertarian,7
+Sedgwick,MI09,President,,Mitt Romney,Mitt,,Romney,,Republican,143
+Sedgwick,MI09,President,,WRITE-IN,,,,,,1
+Sedgwick,MI11,President,,Barack Obama,Barack,,Obama,,Democratic,1
+Sedgwick,MI11,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,MI11,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,MI11,President,,Mitt Romney,Mitt,,Romney,,Republican,0
+Sedgwick,MI11,President,,WRITE-IN,,,,,,0
+Sedgwick,MI12,President,,Barack Obama,Barack,,Obama,,Democratic,48
+Sedgwick,MI12,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,MI12,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,MI12,President,,Mitt Romney,Mitt,,Romney,,Republican,60
+Sedgwick,MI12,President,,WRITE-IN,,,,,,1
+Sedgwick,MO,President,,Barack Obama,Barack,,Obama,,Democratic,234
+Sedgwick,MO,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,6
+Sedgwick,MO,President,,Gary Johnson,Gary,,Johnson,,Libertarian,14
+Sedgwick,MO,President,,Mitt Romney,Mitt,,Romney,,Republican,707
+Sedgwick,MO,President,,WRITE-IN,,,,,,5
+Sedgwick,MV01,President,,Barack Obama,Barack,,Obama,,Democratic,202
+Sedgwick,MV01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,MV01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,MV01,President,,Mitt Romney,Mitt,,Romney,,Republican,422
+Sedgwick,MV01,President,,WRITE-IN,,,,,,2
+Sedgwick,MV02,President,,Barack Obama,Barack,,Obama,,Democratic,487
+Sedgwick,MV02,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,MV02,President,,Gary Johnson,Gary,,Johnson,,Libertarian,29
+Sedgwick,MV02,President,,Mitt Romney,Mitt,,Romney,,Republican,1099
+Sedgwick,MV02,President,,WRITE-IN,,,,,,11
+Sedgwick,NI,President,,Barack Obama,Barack,,Obama,,Democratic,300
+Sedgwick,NI,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,NI,President,,Gary Johnson,Gary,,Johnson,,Libertarian,8
+Sedgwick,NI,President,,Mitt Romney,Mitt,,Romney,,Republican,832
+Sedgwick,NI,President,,WRITE-IN,,,,,,3
+Sedgwick,NI01,President,,Barack Obama,Barack,,Obama,,Democratic,47
+Sedgwick,NI01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,NI01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,5
+Sedgwick,NI01,President,,Mitt Romney,Mitt,,Romney,,Republican,177
+Sedgwick,NI01,President,,WRITE-IN,,,,,,0
+Sedgwick,OH01,President,,Barack Obama,Barack,,Obama,,Democratic,154
+Sedgwick,OH01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,OH01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,12
+Sedgwick,OH01,President,,Mitt Romney,Mitt,,Romney,,Republican,477
+Sedgwick,OH01,President,,WRITE-IN,,,,,,5
+Sedgwick,PA01,President,,Barack Obama,Barack,,Obama,,Democratic,50
+Sedgwick,PA01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,PA01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,3
+Sedgwick,PA01,President,,Mitt Romney,Mitt,,Romney,,Republican,200
+Sedgwick,PA01,President,,WRITE-IN,,,,,,0
+Sedgwick,PA02 & PA03,President,,Barack Obama,Barack,,Obama,,Democratic,46
+Sedgwick,PA02 & PA03,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,PA02 & PA03,President,,Gary Johnson,Gary,,Johnson,,Libertarian,3
+Sedgwick,PA02 & PA03,President,,Mitt Romney,Mitt,,Romney,,Republican,103
+Sedgwick,PA02 & PA03,President,,WRITE-IN,,,,,,1
+Sedgwick,PA04,President,,Barack Obama,Barack,,Obama,,Democratic,0
+Sedgwick,PA04,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,PA04,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,PA04,President,,Mitt Romney,Mitt,,Romney,,Republican,2
+Sedgwick,PA04,President,,WRITE-IN,,,,,,0
+Sedgwick,PA05,President,,Barack Obama,Barack,,Obama,,Democratic,391
+Sedgwick,PA05,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,PA05,President,,Gary Johnson,Gary,,Johnson,,Libertarian,25
+Sedgwick,PA05,President,,Mitt Romney,Mitt,,Romney,,Republican,952
+Sedgwick,PA05,President,,WRITE-IN,,,,,,9
+Sedgwick,PA06,President,,Barack Obama,Barack,,Obama,,Democratic,22
+Sedgwick,PA06,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,PA06,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,PA06,President,,Mitt Romney,Mitt,,Romney,,Republican,38
+Sedgwick,PA06,President,,WRITE-IN,,,,,,0
+Sedgwick,PC11,President,,Barack Obama,Barack,,Obama,,Democratic,165
+Sedgwick,PC11,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,PC11,President,,Gary Johnson,Gary,,Johnson,,Libertarian,18
+Sedgwick,PC11,President,,Mitt Romney,Mitt,,Romney,,Republican,349
+Sedgwick,PC11,President,,WRITE-IN,,,,,,2
+Sedgwick,PC12 & 14 & 15,President,,Barack Obama,Barack,,Obama,,Democratic,33
+Sedgwick,PC12 & 14 & 15,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,PC12 & 14 & 15,President,,Gary Johnson,Gary,,Johnson,,Libertarian,6
+Sedgwick,PC12 & 14 & 15,President,,Mitt Romney,Mitt,,Romney,,Republican,65
+Sedgwick,PC12 & 14 & 15,President,,WRITE-IN,,,,,,0
+Sedgwick,PC13,President,,Barack Obama,Barack,,Obama,,Democratic,58
+Sedgwick,PC13,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,PC13,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,PC13,President,,Mitt Romney,Mitt,,Romney,,Republican,123
+Sedgwick,PC13,President,,WRITE-IN,,,,,,0
+Sedgwick,PC21,President,,Barack Obama,Barack,,Obama,,Democratic,253
+Sedgwick,PC21,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,PC21,President,,Gary Johnson,Gary,,Johnson,,Libertarian,16
+Sedgwick,PC21,President,,Mitt Romney,Mitt,,Romney,,Republican,501
+Sedgwick,PC21,President,,WRITE-IN,,,,,,6
+Sedgwick,PC22 & PC23,President,,Barack Obama,Barack,,Obama,,Democratic,2
+Sedgwick,PC22 & PC23,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,PC22 & PC23,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,PC22 & PC23,President,,Mitt Romney,Mitt,,Romney,,Republican,6
+Sedgwick,PC22 & PC23,President,,WRITE-IN,,,,,,0
+Sedgwick,PC31,President,,Barack Obama,Barack,,Obama,,Democratic,171
+Sedgwick,PC31,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,PC31,President,,Gary Johnson,Gary,,Johnson,,Libertarian,13
+Sedgwick,PC31,President,,Mitt Romney,Mitt,,Romney,,Republican,271
+Sedgwick,PC31,President,,WRITE-IN,,,,,,9
+Sedgwick,PC41,President,,Barack Obama,Barack,,Obama,,Democratic,141
+Sedgwick,PC41,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,PC41,President,,Gary Johnson,Gary,,Johnson,,Libertarian,7
+Sedgwick,PC41,President,,Mitt Romney,Mitt,,Romney,,Republican,217
+Sedgwick,PC41,President,,WRITE-IN,,,,,,2
+Sedgwick,PC43,President,,Barack Obama,Barack,,Obama,,Democratic,108
+Sedgwick,PC43,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,PC43,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,PC43,President,,Mitt Romney,Mitt,,Romney,,Republican,145
+Sedgwick,PC43,President,,WRITE-IN,,,,,,0
+Sedgwick,PY01,President,,Barack Obama,Barack,,Obama,,Democratic,99
+Sedgwick,PY01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,PY01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,4
+Sedgwick,PY01,President,,Mitt Romney,Mitt,,Romney,,Republican,362
+Sedgwick,PY01,President,,WRITE-IN,,,,,,5
+Sedgwick,PY02,President,,Barack Obama,Barack,,Obama,,Democratic,16
+Sedgwick,PY02,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,PY02,President,,Gary Johnson,Gary,,Johnson,,Libertarian,1
+Sedgwick,PY02,President,,Mitt Romney,Mitt,,Romney,,Republican,59
+Sedgwick,PY02,President,,WRITE-IN,,,,,,0
+Sedgwick,RI01,President,,Barack Obama,Barack,,Obama,,Democratic,8
+Sedgwick,RI01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,RI01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,RI01,President,,Mitt Romney,Mitt,,Romney,,Republican,4
+Sedgwick,RI01,President,,WRITE-IN,,,,,,0
+Sedgwick,RI02,President,,Barack Obama,Barack,,Obama,,Democratic,12
+Sedgwick,RI02,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,RI02,President,,Gary Johnson,Gary,,Johnson,,Libertarian,1
+Sedgwick,RI02,President,,Mitt Romney,Mitt,,Romney,,Republican,23
+Sedgwick,RI02,President,,WRITE-IN,,,,,,0
+Sedgwick,RI03,President,,Barack Obama,Barack,,Obama,,Democratic,70
+Sedgwick,RI03,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,RI03,President,,Gary Johnson,Gary,,Johnson,,Libertarian,6
+Sedgwick,RI03,President,,Mitt Romney,Mitt,,Romney,,Republican,90
+Sedgwick,RI03,President,,WRITE-IN,,,,,,2
+Sedgwick,RI04,President,,Barack Obama,Barack,,Obama,,Democratic,122
+Sedgwick,RI04,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,RI04,President,,Gary Johnson,Gary,,Johnson,,Libertarian,10
+Sedgwick,RI04,President,,Mitt Romney,Mitt,,Romney,,Republican,71
+Sedgwick,RI04,President,,WRITE-IN,,,,,,3
+Sedgwick,RI06,President,,Barack Obama,Barack,,Obama,,Democratic,45
+Sedgwick,RI06,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,RI06,President,,Gary Johnson,Gary,,Johnson,,Libertarian,1
+Sedgwick,RI06,President,,Mitt Romney,Mitt,,Romney,,Republican,93
+Sedgwick,RI06,President,,WRITE-IN,,,,,,1
+Sedgwick,RI07,President,,Barack Obama,Barack,,Obama,,Democratic,164
+Sedgwick,RI07,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,RI07,President,,Gary Johnson,Gary,,Johnson,,Libertarian,12
+Sedgwick,RI07,President,,Mitt Romney,Mitt,,Romney,,Republican,141
+Sedgwick,RI07,President,,WRITE-IN,,,,,,3
+Sedgwick,RO01,President,,Barack Obama,Barack,,Obama,,Democratic,86
+Sedgwick,RO01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,RO01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,7
+Sedgwick,RO01,President,,Mitt Romney,Mitt,,Romney,,Republican,275
+Sedgwick,RO01,President,,WRITE-IN,,,,,,0
+Sedgwick,RO02,President,,Barack Obama,Barack,,Obama,,Democratic,11
+Sedgwick,RO02,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,RO02,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,RO02,President,,Mitt Romney,Mitt,,Romney,,Republican,51
+Sedgwick,RO02,President,,WRITE-IN,,,,,,0
+Sedgwick,RO03,President,,Barack Obama,Barack,,Obama,,Democratic,70
+Sedgwick,RO03,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,RO03,President,,Gary Johnson,Gary,,Johnson,,Libertarian,2
+Sedgwick,RO03,President,,Mitt Romney,Mitt,,Romney,,Republican,224
+Sedgwick,RO03,President,,WRITE-IN,,,,,,2
+Sedgwick,RO04,President,,Barack Obama,Barack,,Obama,,Democratic,12
+Sedgwick,RO04,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,RO04,President,,Gary Johnson,Gary,,Johnson,,Libertarian,1
+Sedgwick,RO04,President,,Mitt Romney,Mitt,,Romney,,Republican,19
+Sedgwick,RO04,President,,WRITE-IN,,,,,,0
+Sedgwick,SA01,President,,Barack Obama,Barack,,Obama,,Democratic,296
+Sedgwick,SA01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,SA01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,32
+Sedgwick,SA01,President,,Mitt Romney,Mitt,,Romney,,Republican,656
+Sedgwick,SA01,President,,WRITE-IN,,,,,,8
+Sedgwick,SA02,President,,Barack Obama,Barack,,Obama,,Democratic,233
+Sedgwick,SA02,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,5
+Sedgwick,SA02,President,,Gary Johnson,Gary,,Johnson,,Libertarian,12
+Sedgwick,SA02,President,,Mitt Romney,Mitt,,Romney,,Republican,483
+Sedgwick,SA02,President,,WRITE-IN,,,,,,3
+Sedgwick,SH,President,,Barack Obama,Barack,,Obama,,Democratic,126
+Sedgwick,SH,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,SH,President,,Gary Johnson,Gary,,Johnson,,Libertarian,4
+Sedgwick,SH,President,,Mitt Romney,Mitt,,Romney,,Republican,636
+Sedgwick,SH,President,,WRITE-IN,,,,,,3
+Sedgwick,UN01,President,,Barack Obama,Barack,,Obama,,Democratic,148
+Sedgwick,UN01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,4
+Sedgwick,UN01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,7
+Sedgwick,UN01,President,,Mitt Romney,Mitt,,Romney,,Republican,851
+Sedgwick,UN01,President,,WRITE-IN,,,,,,1
+Sedgwick,UN02,President,,Barack Obama,Barack,,Obama,,Democratic,8
+Sedgwick,UN02,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,UN02,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,UN02,President,,Mitt Romney,Mitt,,Romney,,Republican,74
+Sedgwick,UN02,President,,WRITE-IN,,,,,,0
+Sedgwick,VA,President,,Barack Obama,Barack,,Obama,,Democratic,140
+Sedgwick,VA,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,VA,President,,Gary Johnson,Gary,,Johnson,,Libertarian,15
+Sedgwick,VA,President,,Mitt Romney,Mitt,,Romney,,Republican,326
+Sedgwick,VA,President,,WRITE-IN,,,,,,4
+Sedgwick,VC11,President,,Barack Obama,Barack,,Obama,,Democratic,182
+Sedgwick,VC11,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,VC11,President,,Gary Johnson,Gary,,Johnson,,Libertarian,20
+Sedgwick,VC11,President,,Mitt Romney,Mitt,,Romney,,Republican,555
+Sedgwick,VC11,President,,WRITE-IN,,,,,,3
+Sedgwick,VC21,President,,Barack Obama,Barack,,Obama,,Democratic,201
+Sedgwick,VC21,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,VC21,President,,Gary Johnson,Gary,,Johnson,,Libertarian,17
+Sedgwick,VC21,President,,Mitt Romney,Mitt,,Romney,,Republican,525
+Sedgwick,VC21,President,,WRITE-IN,,,,,,4
+Sedgwick,VC31,President,,Barack Obama,Barack,,Obama,,Democratic,162
+Sedgwick,VC31,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,3
+Sedgwick,VC31,President,,Gary Johnson,Gary,,Johnson,,Libertarian,15
+Sedgwick,VC31,President,,Mitt Romney,Mitt,,Romney,,Republican,484
+Sedgwick,VC31,President,,WRITE-IN,,,,,,3
+Sedgwick,VC32 & 42 & 43,President,,Barack Obama,Barack,,Obama,,Democratic,62
+Sedgwick,VC32 & 42 & 43,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,VC32 & 42 & 43,President,,Gary Johnson,Gary,,Johnson,,Libertarian,3
+Sedgwick,VC32 & 42 & 43,President,,Mitt Romney,Mitt,,Romney,,Republican,173
+Sedgwick,VC32 & 42 & 43,President,,WRITE-IN,,,,,,1
+Sedgwick,VC41,President,,Barack Obama,Barack,,Obama,,Democratic,138
+Sedgwick,VC41,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,VC41,President,,Gary Johnson,Gary,,Johnson,,Libertarian,8
+Sedgwick,VC41,President,,Mitt Romney,Mitt,,Romney,,Republican,400
+Sedgwick,VC41,President,,WRITE-IN,,,,,,5
+Sedgwick,VI,President,,Barack Obama,Barack,,Obama,,Democratic,63
+Sedgwick,VI,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,2
+Sedgwick,VI,President,,Gary Johnson,Gary,,Johnson,,Libertarian,3
+Sedgwick,VI,President,,Mitt Romney,Mitt,,Romney,,Republican,160
+Sedgwick,VI,President,,WRITE-IN,,,,,,0
+Sedgwick,WA01,President,,Barack Obama,Barack,,Obama,,Democratic,15
+Sedgwick,WA01,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,WA01,President,,Gary Johnson,Gary,,Johnson,,Libertarian,1
+Sedgwick,WA01,President,,Mitt Romney,Mitt,,Romney,,Republican,57
+Sedgwick,WA01,President,,WRITE-IN,,,,,,0
+Sedgwick,WA02,President,,Barack Obama,Barack,,Obama,,Democratic,46
+Sedgwick,WA02,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,1
+Sedgwick,WA02,President,,Gary Johnson,Gary,,Johnson,,Libertarian,5
+Sedgwick,WA02,President,,Mitt Romney,Mitt,,Romney,,Republican,150
+Sedgwick,WA02,President,,WRITE-IN,,,,,,0
+Sedgwick,WA03,President,,Barack Obama,Barack,,Obama,,Democratic,10
+Sedgwick,WA03,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,WA03,President,,Gary Johnson,Gary,,Johnson,,Libertarian,0
+Sedgwick,WA03,President,,Mitt Romney,Mitt,,Romney,,Republican,43
+Sedgwick,WA03,President,,WRITE-IN,,,,,,1
+Sedgwick,WA04,President,,Barack Obama,Barack,,Obama,,Democratic,4
+Sedgwick,WA04,President,,Chuck Baldwin,Chuck,,Baldwin,,Reform,0
+Sedgwick,WA04,President,,Gary Johnson,Gary,,Johnson,,Libertarian,1
+Sedgwick,WA04,President,,Mitt Romney,Mitt,,Romney,,Republican,10
+Sedgwick,WA04,President,,WRITE-IN,,,,,,0
+Sedgwick,101,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,459
+Sedgwick,102,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,152
+Sedgwick,103,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,35
+Sedgwick,104,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,18
+Sedgwick,105,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,191
+Sedgwick,106,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,98
+Sedgwick,107,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,105
+Sedgwick,108,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,289
+Sedgwick,109,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,311
+Sedgwick,110 & 111,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,185
+Sedgwick,112,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,360
+Sedgwick,113,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,81
+Sedgwick,114,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,51
+Sedgwick,116,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,80
+Sedgwick,117,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,76
+Sedgwick,118,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,167
+Sedgwick,119,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,262
+Sedgwick,120,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,292
+Sedgwick,121,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,442
+Sedgwick,122,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,668
+Sedgwick,123,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,61
+Sedgwick,126,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,130
+Sedgwick,127,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,156
+Sedgwick,128,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,48
+Sedgwick,129,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,90
+Sedgwick,130,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,235
+Sedgwick,131,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,10
+Sedgwick,132 & 124,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,6
+Sedgwick,201,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,636
+Sedgwick,202,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,670
+Sedgwick,203,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,533
+Sedgwick,204,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,502
+Sedgwick,205,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,101
+Sedgwick,206,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,147
+Sedgwick,207,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,626
+Sedgwick,208,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,180
+Sedgwick,209,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,408
+Sedgwick,210,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,525
+Sedgwick,211,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,382
+Sedgwick,212,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,714
+Sedgwick,213,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,908
+Sedgwick,214,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,872
+Sedgwick,215,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,1037
+Sedgwick,216,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,636
+Sedgwick,217,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,912
+Sedgwick,218 & 220,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,1227
+Sedgwick,221,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,538
+Sedgwick,222,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,663
+Sedgwick,223,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,894
+Sedgwick,224,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,704
+Sedgwick,225,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,780
+Sedgwick,226,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,1154
+Sedgwick,227,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,898
+Sedgwick,228,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,907
+Sedgwick,231,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,202
+Sedgwick,233,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,274
+Sedgwick,234,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,90
+Sedgwick,235,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,128
+Sedgwick,236,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,600
+Sedgwick,301,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,192
+Sedgwick,302,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,360
+Sedgwick,303,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,219
+Sedgwick,304,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,198
+Sedgwick,305,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,611
+Sedgwick,306,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,541
+Sedgwick,307,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,202
+Sedgwick,308,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,401
+Sedgwick,309,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,398
+Sedgwick,310,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,120
+Sedgwick,311,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,216
+Sedgwick,312,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,192
+Sedgwick,313,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,424
+Sedgwick,314,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,491
+Sedgwick,315,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,396
+Sedgwick,316,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,573
+Sedgwick,317,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,7
+Sedgwick,318,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,21
+Sedgwick,319,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,103
+Sedgwick,320,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,89
+Sedgwick,321,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,4
+Sedgwick,323,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,77
+Sedgwick,324,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,118
+Sedgwick,325,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,13
+Sedgwick,326,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,44
+Sedgwick,401,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,228
+Sedgwick,402,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,127
+Sedgwick,403,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,229
+Sedgwick,404,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,467
+Sedgwick,405,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,477
+Sedgwick,406,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,355
+Sedgwick,407,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,46
+Sedgwick,408,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,368
+Sedgwick,409,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,222
+Sedgwick,410,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,243
+Sedgwick,411 & 505,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,341
+Sedgwick,412,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,1185
+Sedgwick,413,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,902
+Sedgwick,414 & 415 & 537,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,146
+Sedgwick,416 & 428,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,584
+Sedgwick,417,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,352
+Sedgwick,418,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,526
+Sedgwick,419,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,434
+Sedgwick,420,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,452
+Sedgwick,421,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,407
+Sedgwick,422,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,300
+Sedgwick,423,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,392
+Sedgwick,424,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,480
+Sedgwick,425,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,608
+Sedgwick,426,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,142
+Sedgwick,429,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,248
+Sedgwick,501,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,70
+Sedgwick,502,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,316
+Sedgwick,503,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,617
+Sedgwick,504,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,468
+Sedgwick,506,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,786
+Sedgwick,507,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,800
+Sedgwick,508,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,637
+Sedgwick,509,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,689
+Sedgwick,510,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,981
+Sedgwick,511,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,87
+Sedgwick,512,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,1574
+Sedgwick,513,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,448
+Sedgwick,514,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,1004
+Sedgwick,515,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,831
+Sedgwick,516,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,565
+Sedgwick,517,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,505
+Sedgwick,518,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,737
+Sedgwick,519,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,725
+Sedgwick,520,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,303
+Sedgwick,521,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,550
+Sedgwick,522,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,753
+Sedgwick,523,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,732
+Sedgwick,524,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,1163
+Sedgwick,525,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,772
+Sedgwick,526,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,781
+Sedgwick,527,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,899
+Sedgwick,529,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,510
+Sedgwick,530,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,893
+Sedgwick,531,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,1314
+Sedgwick,532,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,1074
+Sedgwick,533,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,192
+Sedgwick,534,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,84
+Sedgwick,535,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,13
+Sedgwick,538,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,154
+Sedgwick,601,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,243
+Sedgwick,602,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,233
+Sedgwick,603,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,354
+Sedgwick,604,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,661
+Sedgwick,605,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,243
+Sedgwick,606,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,173
+Sedgwick,607,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,517
+Sedgwick,608,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,267
+Sedgwick,609,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,656
+Sedgwick,610,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,663
+Sedgwick,611,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,304
+Sedgwick,612,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,705
+Sedgwick,613,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,628
+Sedgwick,614,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,258
+Sedgwick,615,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,96
+Sedgwick,616 & 617,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,164
+Sedgwick,618,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,239
+Sedgwick,619,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,581
+Sedgwick,620,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,331
+Sedgwick,621,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,17
+Sedgwick,622,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,412
+Sedgwick,623,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,652
+Sedgwick,624,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,44
+Sedgwick,625,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,149
+Sedgwick,626,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,4
+Sedgwick,627,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,58
+Sedgwick,628,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,454
+Sedgwick,AF,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,576
+Sedgwick,AT01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,53
+Sedgwick,AT02,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,87
+Sedgwick,AT03,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,267
+Sedgwick,AT05,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,196
+Sedgwick,AT06,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,37
+Sedgwick,AT07,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,93
+Sedgwick,AT08,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,35
+Sedgwick,BA01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,856
+Sedgwick,BA02,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,730
+Sedgwick,BA03,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,521
+Sedgwick,DB11,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,855
+Sedgwick,DB12,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,481
+Sedgwick,DB13 & 24 & 27,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,114
+Sedgwick,DB14,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,283
+Sedgwick,DB15,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,32
+Sedgwick,DB21,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,447
+Sedgwick,DB22,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,466
+Sedgwick,DB23,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,265
+Sedgwick,DB25,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,42
+Sedgwick,DB26,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,310
+Sedgwick,DB31,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,208
+Sedgwick,DB32,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,153
+Sedgwick,DB34,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,131
+Sedgwick,DB35,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,235
+Sedgwick,DB36,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,761
+Sedgwick,DB37,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,106
+Sedgwick,DB41,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,308
+Sedgwick,DB42,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,837
+Sedgwick,DB43,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,15
+Sedgwick,DB44,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,420
+Sedgwick,DL02,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,2
+Sedgwick,DL03,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,1
+Sedgwick,DL04,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,1
+Sedgwick,EA,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,287
+Sedgwick,ER,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,35
+Sedgwick,GA,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,713
+Sedgwick,GD,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,223
+Sedgwick,GN01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,377
+Sedgwick,GN02,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,159
+Sedgwick,GO,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,1201
+Sedgwick,GO01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,28
+Sedgwick,GR,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,335
+Sedgwick,GY01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,1103
+Sedgwick,GY02,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,34
+Sedgwick,GY03,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,26
+Sedgwick,GY04,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,6
+Sedgwick,HA11,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,508
+Sedgwick,HA21 & HA23,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,482
+Sedgwick,HA22,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,68
+Sedgwick,HA31,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,632
+Sedgwick,HA32,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,20
+Sedgwick,HA41,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,513
+Sedgwick,HA42,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,136
+Sedgwick,IL01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,364
+Sedgwick,IL02,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,268
+Sedgwick,KE01 & 02 & 06,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,7
+Sedgwick,KE03,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,556
+Sedgwick,KE04,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,23
+Sedgwick,KE07,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,13
+Sedgwick,KE08,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,14
+Sedgwick,LI,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,200
+Sedgwick,MI01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,915
+Sedgwick,MI02,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,343
+Sedgwick,MI03,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,87
+Sedgwick,MI04 & MI05,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,2
+Sedgwick,MI07,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,12
+Sedgwick,MI08,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,16
+Sedgwick,MI09,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,131
+Sedgwick,MI11,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,0
+Sedgwick,MI12,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,50
+Sedgwick,MO,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,703
+Sedgwick,MV01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,409
+Sedgwick,MV02,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,1086
+Sedgwick,NI,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,790
+Sedgwick,NI01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,171
+Sedgwick,OH01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,435
+Sedgwick,PA01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,189
+Sedgwick,PA02 & PA03,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,92
+Sedgwick,PA04,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,2
+Sedgwick,PA05,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,926
+Sedgwick,PA06,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,37
+Sedgwick,PC11,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,359
+Sedgwick,PC12 & 14 & 15,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,59
+Sedgwick,PC13,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,120
+Sedgwick,PC21,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,493
+Sedgwick,PC22 & PC23,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,5
+Sedgwick,PC31,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,261
+Sedgwick,PC41,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,215
+Sedgwick,PC43,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,135
+Sedgwick,PY01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,354
+Sedgwick,PY02,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,53
+Sedgwick,RI01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,6
+Sedgwick,RI02,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,19
+Sedgwick,RI03,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,98
+Sedgwick,RI04,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,69
+Sedgwick,RI06,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,85
+Sedgwick,RI07,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,146
+Sedgwick,RO01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,267
+Sedgwick,RO02,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,46
+Sedgwick,RO03,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,216
+Sedgwick,RO04,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,14
+Sedgwick,SA01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,624
+Sedgwick,SA02,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,465
+Sedgwick,SH,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,603
+Sedgwick,UN01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,839
+Sedgwick,UN02,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,72
+Sedgwick,VA,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,307
+Sedgwick,VC11,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,544
+Sedgwick,VC21,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,528
+Sedgwick,VC31,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,475
+Sedgwick,VC32 & 42 & 43,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,165
+Sedgwick,VC41,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,384
+Sedgwick,VI,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,161
+Sedgwick,WA01,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,58
+Sedgwick,WA02,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,134
+Sedgwick,WA03,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,42
+Sedgwick,WA04,U.S. House,4,Mike Pompeo,Mike,,Pompeo,,Republican,10
+Sedgwick,101,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,421
+Sedgwick,102,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,175
+Sedgwick,103,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,53
+Sedgwick,104,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,12
+Sedgwick,105,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,326
+Sedgwick,106,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,151
+Sedgwick,107,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,505
+Sedgwick,108,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,400
+Sedgwick,109,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,648
+Sedgwick,110 & 111,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,117
+Sedgwick,112,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,668
+Sedgwick,113,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,616
+Sedgwick,114,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,662
+Sedgwick,116,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,952
+Sedgwick,117,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,902
+Sedgwick,118,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,854
+Sedgwick,119,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,570
+Sedgwick,120,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,518
+Sedgwick,121,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,323
+Sedgwick,122,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,643
+Sedgwick,123,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,42
+Sedgwick,126,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,73
+Sedgwick,127,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,71
+Sedgwick,128,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,110
+Sedgwick,129,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,118
+Sedgwick,130,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,297
+Sedgwick,131,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,4
+Sedgwick,132 & 124,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,9
+Sedgwick,201,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,528
+Sedgwick,202,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,483
+Sedgwick,203,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,393
+Sedgwick,204,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,320
+Sedgwick,205,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,224
+Sedgwick,206,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,141
+Sedgwick,207,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,520
+Sedgwick,208,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,166
+Sedgwick,209,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,408
+Sedgwick,210,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,455
+Sedgwick,211,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,216
+Sedgwick,212,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,423
+Sedgwick,213,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,379
+Sedgwick,214,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,302
+Sedgwick,215,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,549
+Sedgwick,216,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,335
+Sedgwick,217,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,328
+Sedgwick,218 & 220,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,579
+Sedgwick,221,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,215
+Sedgwick,222,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,278
+Sedgwick,223,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,320
+Sedgwick,224,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,507
+Sedgwick,225,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,502
+Sedgwick,226,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,445
+Sedgwick,227,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,288
+Sedgwick,228,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,196
+Sedgwick,231,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,257
+Sedgwick,233,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,166
+Sedgwick,234,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,85
+Sedgwick,235,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,158
+Sedgwick,236,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,154
+Sedgwick,301,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,210
+Sedgwick,302,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,399
+Sedgwick,303,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,146
+Sedgwick,304,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,188
+Sedgwick,305,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,578
+Sedgwick,306,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,658
+Sedgwick,307,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,314
+Sedgwick,308,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,519
+Sedgwick,309,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,453
+Sedgwick,310,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,200
+Sedgwick,311,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,210
+Sedgwick,312,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,177
+Sedgwick,313,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,418
+Sedgwick,314,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,413
+Sedgwick,315,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,369
+Sedgwick,316,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,360
+Sedgwick,317,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,5
+Sedgwick,318,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,5
+Sedgwick,319,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,118
+Sedgwick,320,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,57
+Sedgwick,321,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,18
+Sedgwick,323,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,146
+Sedgwick,324,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,140
+Sedgwick,325,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,36
+Sedgwick,326,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,20
+Sedgwick,401,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,203
+Sedgwick,402,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,98
+Sedgwick,403,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,147
+Sedgwick,404,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,405
+Sedgwick,405,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,333
+Sedgwick,406,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,322
+Sedgwick,407,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,40
+Sedgwick,408,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,327
+Sedgwick,409,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,183
+Sedgwick,410,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,205
+Sedgwick,411 & 505,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,186
+Sedgwick,412,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,406
+Sedgwick,413,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,300
+Sedgwick,414 & 415 & 537,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,64
+Sedgwick,416 & 428,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,237
+Sedgwick,417,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,256
+Sedgwick,418,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,338
+Sedgwick,419,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,340
+Sedgwick,420,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,347
+Sedgwick,421,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,383
+Sedgwick,422,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,222
+Sedgwick,423,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,299
+Sedgwick,424,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,263
+Sedgwick,425,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,323
+Sedgwick,426,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,111
+Sedgwick,429,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,215
+Sedgwick,501,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,20
+Sedgwick,502,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,101
+Sedgwick,503,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,382
+Sedgwick,504,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,340
+Sedgwick,506,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,362
+Sedgwick,507,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,374
+Sedgwick,508,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,355
+Sedgwick,509,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,270
+Sedgwick,510,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,250
+Sedgwick,511,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,14
+Sedgwick,512,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,489
+Sedgwick,513,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,72
+Sedgwick,514,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,401
+Sedgwick,515,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,336
+Sedgwick,516,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,240
+Sedgwick,517,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,301
+Sedgwick,518,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,326
+Sedgwick,519,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,362
+Sedgwick,520,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,160
+Sedgwick,521,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,154
+Sedgwick,522,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,273
+Sedgwick,523,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,297
+Sedgwick,524,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,467
+Sedgwick,525,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,379
+Sedgwick,526,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,322
+Sedgwick,527,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,302
+Sedgwick,529,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,155
+Sedgwick,530,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,210
+Sedgwick,531,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,421
+Sedgwick,532,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,231
+Sedgwick,533,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,53
+Sedgwick,534,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,27
+Sedgwick,535,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,6
+Sedgwick,538,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,48
+Sedgwick,601,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,372
+Sedgwick,602,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,187
+Sedgwick,603,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,250
+Sedgwick,604,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,438
+Sedgwick,605,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,165
+Sedgwick,606,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,142
+Sedgwick,607,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,699
+Sedgwick,608,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,495
+Sedgwick,609,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,786
+Sedgwick,610,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,425
+Sedgwick,611,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,280
+Sedgwick,612,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,406
+Sedgwick,613,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,433
+Sedgwick,614,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,424
+Sedgwick,615,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,278
+Sedgwick,616 & 617,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,196
+Sedgwick,618,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,158
+Sedgwick,619,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,452
+Sedgwick,620,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,223
+Sedgwick,621,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,2
+Sedgwick,622,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,133
+Sedgwick,623,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,284
+Sedgwick,624,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,42
+Sedgwick,625,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,74
+Sedgwick,626,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,2
+Sedgwick,627,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,41
+Sedgwick,628,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,169
+Sedgwick,AF,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,120
+Sedgwick,AT01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,6
+Sedgwick,AT02,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,42
+Sedgwick,AT03,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,52
+Sedgwick,AT05,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,45
+Sedgwick,AT06,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,2
+Sedgwick,AT07,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,34
+Sedgwick,AT08,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,17
+Sedgwick,BA01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,418
+Sedgwick,BA02,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,384
+Sedgwick,BA03,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,249
+Sedgwick,DB11,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,282
+Sedgwick,DB12,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,182
+Sedgwick,DB13 & 24 & 27,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,45
+Sedgwick,DB14,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,99
+Sedgwick,DB15,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,6
+Sedgwick,DB21,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,204
+Sedgwick,DB22,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,156
+Sedgwick,DB23,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,72
+Sedgwick,DB25,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,22
+Sedgwick,DB26,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,123
+Sedgwick,DB31,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,104
+Sedgwick,DB32,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,68
+Sedgwick,DB34,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,54
+Sedgwick,DB35,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,90
+Sedgwick,DB36,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,289
+Sedgwick,DB37,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,54
+Sedgwick,DB41,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,146
+Sedgwick,DB42,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,227
+Sedgwick,DB43,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,14
+Sedgwick,DB44,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,175
+Sedgwick,DL02,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,1
+Sedgwick,DL03,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,1
+Sedgwick,DL04,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,0
+Sedgwick,EA,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,130
+Sedgwick,ER,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,11
+Sedgwick,GA,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,114
+Sedgwick,GD,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,34
+Sedgwick,GN01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,82
+Sedgwick,GN02,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,40
+Sedgwick,GO,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,302
+Sedgwick,GO01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,5
+Sedgwick,GR,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,85
+Sedgwick,GY01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,369
+Sedgwick,GY02,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,17
+Sedgwick,GY03,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,14
+Sedgwick,GY04,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,2
+Sedgwick,HA11,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,228
+Sedgwick,HA21 & HA23,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,254
+Sedgwick,HA22,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,19
+Sedgwick,HA31,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,272
+Sedgwick,HA32,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,4
+Sedgwick,HA41,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,225
+Sedgwick,HA42,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,38
+Sedgwick,IL01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,70
+Sedgwick,IL02,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,79
+Sedgwick,KE01 & 02 & 06,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,2
+Sedgwick,KE03,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,237
+Sedgwick,KE04,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,9
+Sedgwick,KE07,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,7
+Sedgwick,KE08,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,1
+Sedgwick,LI,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,52
+Sedgwick,MI01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,197
+Sedgwick,MI02,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,111
+Sedgwick,MI03,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,36
+Sedgwick,MI04 & MI05,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,1
+Sedgwick,MI07,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,3
+Sedgwick,MI08,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,8
+Sedgwick,MI09,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,70
+Sedgwick,MI11,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,1
+Sedgwick,MI12,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,5
+Sedgwick,MO,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,195
+Sedgwick,MV01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,165
+Sedgwick,MV02,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,411
+Sedgwick,NI,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,239
+Sedgwick,NI01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,40
+Sedgwick,OH01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,139
+Sedgwick,PA01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,43
+Sedgwick,PA02 & PA03,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,48
+Sedgwick,PA04,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,0
+Sedgwick,PA05,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,310
+Sedgwick,PA06,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,21
+Sedgwick,PC11,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,130
+Sedgwick,PC12 & 14 & 15,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,34
+Sedgwick,PC13,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,49
+Sedgwick,PC21,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,199
+Sedgwick,PC22 & PC23,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,1
+Sedgwick,PC31,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,155
+Sedgwick,PC41,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,116
+Sedgwick,PC43,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,94
+Sedgwick,PY01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,79
+Sedgwick,PY02,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,16
+Sedgwick,RI01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,6
+Sedgwick,RI02,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,13
+Sedgwick,RI03,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,54
+Sedgwick,RI04,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,102
+Sedgwick,RI06,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,37
+Sedgwick,RI07,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,127
+Sedgwick,RO01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,73
+Sedgwick,RO02,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,10
+Sedgwick,RO03,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,66
+Sedgwick,RO04,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,12
+Sedgwick,SA01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,258
+Sedgwick,SA02,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,207
+Sedgwick,SH,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,121
+Sedgwick,UN01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,105
+Sedgwick,UN02,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,6
+Sedgwick,VA,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,112
+Sedgwick,VC11,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,155
+Sedgwick,VC21,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,161
+Sedgwick,VC31,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,129
+Sedgwick,VC32 & 42 & 43,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,51
+Sedgwick,VC41,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,122
+Sedgwick,VI,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,50
+Sedgwick,WA01,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,10
+Sedgwick,WA02,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,47
+Sedgwick,WA03,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,11
+Sedgwick,WA04,U.S. House,4,Robert Leon Tillman,Robert,Leon,Tillman,,Democratic,4
+Sedgwick,101,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,86
+Sedgwick,102,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,31
+Sedgwick,103,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,9
+Sedgwick,104,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,4
+Sedgwick,105,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,45
+Sedgwick,106,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,34
+Sedgwick,107,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,52
+Sedgwick,108,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,53
+Sedgwick,109,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,62
+Sedgwick,110 & 111,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,20
+Sedgwick,112,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,41
+Sedgwick,113,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,33
+Sedgwick,114,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,20
+Sedgwick,116,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,42
+Sedgwick,117,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,13
+Sedgwick,118,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,38
+Sedgwick,119,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,31
+Sedgwick,120,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,33
+Sedgwick,121,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,40
+Sedgwick,122,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,73
+Sedgwick,123,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,4
+Sedgwick,126,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,7
+Sedgwick,127,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,7
+Sedgwick,128,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,16
+Sedgwick,129,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,29
+Sedgwick,130,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,62
+Sedgwick,131,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,0
+Sedgwick,132 & 124,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,1
+Sedgwick,201,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,112
+Sedgwick,202,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,88
+Sedgwick,203,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,56
+Sedgwick,204,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,45
+Sedgwick,205,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,37
+Sedgwick,206,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,23
+Sedgwick,207,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,66
+Sedgwick,208,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,23
+Sedgwick,209,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,59
+Sedgwick,210,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,69
+Sedgwick,211,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,35
+Sedgwick,212,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,61
+Sedgwick,213,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,59
+Sedgwick,214,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,50
+Sedgwick,215,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,65
+Sedgwick,216,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,44
+Sedgwick,217,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,67
+Sedgwick,218 & 220,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,89
+Sedgwick,221,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,29
+Sedgwick,222,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,45
+Sedgwick,223,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,48
+Sedgwick,224,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,85
+Sedgwick,225,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,94
+Sedgwick,226,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,91
+Sedgwick,227,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,44
+Sedgwick,228,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,44
+Sedgwick,231,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,34
+Sedgwick,233,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,21
+Sedgwick,234,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,15
+Sedgwick,235,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,26
+Sedgwick,236,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,29
+Sedgwick,301,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,39
+Sedgwick,302,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,75
+Sedgwick,303,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,31
+Sedgwick,304,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,28
+Sedgwick,305,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,105
+Sedgwick,306,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,87
+Sedgwick,307,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,40
+Sedgwick,308,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,54
+Sedgwick,309,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,71
+Sedgwick,310,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,28
+Sedgwick,311,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,30
+Sedgwick,312,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,30
+Sedgwick,313,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,72
+Sedgwick,314,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,96
+Sedgwick,315,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,70
+Sedgwick,316,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,87
+Sedgwick,317,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,1
+Sedgwick,318,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,1
+Sedgwick,319,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,26
+Sedgwick,320,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,13
+Sedgwick,321,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,3
+Sedgwick,323,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,17
+Sedgwick,324,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,19
+Sedgwick,325,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,0
+Sedgwick,326,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,4
+Sedgwick,401,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,48
+Sedgwick,402,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,15
+Sedgwick,403,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,43
+Sedgwick,404,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,69
+Sedgwick,405,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,74
+Sedgwick,406,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,75
+Sedgwick,407,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,9
+Sedgwick,408,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,54
+Sedgwick,409,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,35
+Sedgwick,410,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,47
+Sedgwick,411 & 505,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,45
+Sedgwick,412,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,118
+Sedgwick,413,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,97
+Sedgwick,414 & 415 & 537,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,20
+Sedgwick,416 & 428,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,57
+Sedgwick,417,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,57
+Sedgwick,418,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,86
+Sedgwick,419,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,84
+Sedgwick,420,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,73
+Sedgwick,421,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,52
+Sedgwick,422,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,46
+Sedgwick,423,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,74
+Sedgwick,424,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,56
+Sedgwick,425,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,68
+Sedgwick,426,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,27
+Sedgwick,429,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,39
+Sedgwick,501,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,8
+Sedgwick,502,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,24
+Sedgwick,503,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,76
+Sedgwick,504,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,62
+Sedgwick,506,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,84
+Sedgwick,507,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,61
+Sedgwick,508,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,66
+Sedgwick,509,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,63
+Sedgwick,510,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,44
+Sedgwick,511,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,5
+Sedgwick,512,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,97
+Sedgwick,513,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,21
+Sedgwick,514,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,76
+Sedgwick,515,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,68
+Sedgwick,516,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,49
+Sedgwick,517,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,71
+Sedgwick,518,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,65
+Sedgwick,519,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,73
+Sedgwick,520,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,42
+Sedgwick,521,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,46
+Sedgwick,522,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,55
+Sedgwick,523,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,52
+Sedgwick,524,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,104
+Sedgwick,525,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,70
+Sedgwick,526,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,68
+Sedgwick,527,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,79
+Sedgwick,529,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,47
+Sedgwick,530,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,47
+Sedgwick,531,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,97
+Sedgwick,532,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,52
+Sedgwick,533,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,16
+Sedgwick,534,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,4
+Sedgwick,535,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,1
+Sedgwick,538,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,10
+Sedgwick,601,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,64
+Sedgwick,602,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,60
+Sedgwick,603,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,55
+Sedgwick,604,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,110
+Sedgwick,605,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,43
+Sedgwick,606,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,25
+Sedgwick,607,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,111
+Sedgwick,608,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,65
+Sedgwick,609,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,109
+Sedgwick,610,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,79
+Sedgwick,611,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,46
+Sedgwick,612,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,89
+Sedgwick,613,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,76
+Sedgwick,614,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,37
+Sedgwick,615,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,27
+Sedgwick,616 & 617,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,22
+Sedgwick,618,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,33
+Sedgwick,619,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,90
+Sedgwick,620,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,41
+Sedgwick,621,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,2
+Sedgwick,622,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,34
+Sedgwick,623,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,65
+Sedgwick,624,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,11
+Sedgwick,625,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,17
+Sedgwick,626,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,0
+Sedgwick,627,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,6
+Sedgwick,628,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,40
+Sedgwick,AF,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,42
+Sedgwick,AT01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,3
+Sedgwick,AT02,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,5
+Sedgwick,AT03,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,8
+Sedgwick,AT05,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,4
+Sedgwick,AT06,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,0
+Sedgwick,AT07,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,8
+Sedgwick,AT08,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,1
+Sedgwick,BA01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,67
+Sedgwick,BA02,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,67
+Sedgwick,BA03,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,31
+Sedgwick,DB11,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,77
+Sedgwick,DB12,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,39
+Sedgwick,DB13 & 24 & 27,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,9
+Sedgwick,DB14,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,26
+Sedgwick,DB15,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,2
+Sedgwick,DB21,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,53
+Sedgwick,DB22,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,35
+Sedgwick,DB23,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,16
+Sedgwick,DB25,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,5
+Sedgwick,DB26,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,30
+Sedgwick,DB31,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,31
+Sedgwick,DB32,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,9
+Sedgwick,DB34,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,12
+Sedgwick,DB35,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,21
+Sedgwick,DB36,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,48
+Sedgwick,DB37,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,15
+Sedgwick,DB41,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,39
+Sedgwick,DB42,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,57
+Sedgwick,DB43,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,4
+Sedgwick,DB44,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,55
+Sedgwick,DL02,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,0
+Sedgwick,DL03,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,0
+Sedgwick,DL04,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,0
+Sedgwick,EA,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,35
+Sedgwick,ER,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,4
+Sedgwick,GA,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,55
+Sedgwick,GD,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,17
+Sedgwick,GN01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,32
+Sedgwick,GN02,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,11
+Sedgwick,GO,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,89
+Sedgwick,GO01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,1
+Sedgwick,GR,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,31
+Sedgwick,GY01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,95
+Sedgwick,GY02,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,5
+Sedgwick,GY03,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,4
+Sedgwick,GY04,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,0
+Sedgwick,HA11,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,48
+Sedgwick,HA21 & HA23,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,89
+Sedgwick,HA22,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,9
+Sedgwick,HA31,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,66
+Sedgwick,HA32,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,0
+Sedgwick,HA41,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,62
+Sedgwick,HA42,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,22
+Sedgwick,IL01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,31
+Sedgwick,IL02,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,29
+Sedgwick,KE01 & 02 & 06,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,0
+Sedgwick,KE03,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,50
+Sedgwick,KE04,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,4
+Sedgwick,KE07,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,1
+Sedgwick,KE08,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,0
+Sedgwick,LI,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,14
+Sedgwick,MI01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,51
+Sedgwick,MI02,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,17
+Sedgwick,MI03,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,4
+Sedgwick,MI04 & MI05,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,1
+Sedgwick,MI07,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,0
+Sedgwick,MI08,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,8
+Sedgwick,MI09,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,24
+Sedgwick,MI11,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,0
+Sedgwick,MI12,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,47
+Sedgwick,MO,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,39
+Sedgwick,MV01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,49
+Sedgwick,MV02,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,74
+Sedgwick,NI,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,76
+Sedgwick,NI01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,15
+Sedgwick,OH01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,50
+Sedgwick,PA01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,23
+Sedgwick,PA02 & PA03,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,10
+Sedgwick,PA04,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,0
+Sedgwick,PA05,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,87
+Sedgwick,PA06,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,2
+Sedgwick,PC11,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,29
+Sedgwick,PC12 & 14 & 15,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,10
+Sedgwick,PC13,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,8
+Sedgwick,PC21,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,64
+Sedgwick,PC22 & PC23,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,1
+Sedgwick,PC31,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,40
+Sedgwick,PC41,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,19
+Sedgwick,PC43,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,13
+Sedgwick,PY01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,26
+Sedgwick,PY02,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,4
+Sedgwick,RI01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,1
+Sedgwick,RI02,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,3
+Sedgwick,RI03,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,10
+Sedgwick,RI04,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,32
+Sedgwick,RI06,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,14
+Sedgwick,RI07,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,39
+Sedgwick,RO01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,17
+Sedgwick,RO02,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,6
+Sedgwick,RO03,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,13
+Sedgwick,RO04,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,5
+Sedgwick,SA01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,91
+Sedgwick,SA02,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,43
+Sedgwick,SH,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,24
+Sedgwick,UN01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,43
+Sedgwick,UN02,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,4
+Sedgwick,VA,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,37
+Sedgwick,VC11,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,44
+Sedgwick,VC21,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,29
+Sedgwick,VC31,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,38
+Sedgwick,VC32 & 42 & 43,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,17
+Sedgwick,VC41,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,29
+Sedgwick,VI,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,8
+Sedgwick,WA01,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,2
+Sedgwick,WA02,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,9
+Sedgwick,WA03,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,1
+Sedgwick,WA04,U.S. House,4,Thomas Jefferson,Thomas,,Jefferson,,Libertarian,1
+Sedgwick,WICHITA PRECINCT 122,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,836
+Sedgwick,WICHITA PRECINCT 208,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,232
+Sedgwick,WICHITA PRECINCT 218,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,1282
+Sedgwick,WICHITA PRECINCT 226,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,1213
+Sedgwick,WICHITA PRECINCT 228,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,885
+Sedgwick,WICHITA PRECINCT 233,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,321
+Sedgwick,WICHITA PRECINCT 236,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,625
+Sedgwick,BEL AIRE PRECINCT 03,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,545
+Sedgwick,DERBY WARD 01 PRECINCT 03,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,132
+Sedgwick,DERBY WARD 02 PRECINCT 02,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,490
+Sedgwick,DERBY WARD 03 PRECINCT 06,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,793
+Sedgwick,DERBY WARD 04 PRECINCT 02,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,863
+Sedgwick,DERBY WARD 04 PRECINCT 04,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,460
+Sedgwick,GREELEY PRECINCT 01,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,1146
+Sedgwick,GREELEY PRECINCT 02,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,47
+Sedgwick,LINCOLN,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,206
+Sedgwick,MINNEHA PRECINCT 03,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,89
+Sedgwick,MINNEHA PRECINCT 07,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,9
+Sedgwick,MINNEHA PRECINCT 08,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,22
+Sedgwick,PAYNE PRECINCT 01,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,359
+Sedgwick,PAYNE PRECINCT 02,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,51
+Sedgwick,ROCKFORD PRECINCT 01,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,272
+Sedgwick,ROCKFORD PRECINCT 02,State Senate,16,"Masterson, Ty",Ty,,Masterson,,Republican,41
+Sedgwick,WICHITA PRECINCT 101,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,433
+Sedgwick,WICHITA PRECINCT 102,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,149
+Sedgwick,WICHITA PRECINCT 128,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,53
+Sedgwick,WICHITA PRECINCT 129,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,81
+Sedgwick,WICHITA PRECINCT 130,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,223
+Sedgwick,WICHITA PRECINCT 301,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,188
+Sedgwick,WICHITA PRECINCT 302,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,352
+Sedgwick,WICHITA PRECINCT 303,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,192
+Sedgwick,WICHITA PRECINCT 304,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,177
+Sedgwick,WICHITA PRECINCT 401,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,226
+Sedgwick,WICHITA PRECINCT 402,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,114
+Sedgwick,WICHITA PRECINCT 403,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,220
+Sedgwick,WICHITA PRECINCT 404,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,414
+Sedgwick,WICHITA PRECINCT 405,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,435
+Sedgwick,WICHITA PRECINCT 406,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,355
+Sedgwick,WICHITA PRECINCT 407,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,40
+Sedgwick,WICHITA PRECINCT 408,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,337
+Sedgwick,WICHITA PRECINCT 409,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,213
+Sedgwick,WICHITA PRECINCT 410,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,220
+Sedgwick,WICHITA PRECINCT 602,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,215
+Sedgwick,WICHITA PRECINCT 603,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,332
+Sedgwick,WICHITA PRECINCT 604,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,641
+Sedgwick,WICHITA PRECINCT 605,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,232
+Sedgwick,WICHITA PRECINCT 606,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,168
+Sedgwick,WICHITA PRECINCT 607,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,463
+Sedgwick,WICHITA PRECINCT 609,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,586
+Sedgwick,WICHITA PRECINCT 610,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,596
+Sedgwick,WICHITA PRECINCT 611,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,287
+Sedgwick,WICHITA PRECINCT 612,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,655
+Sedgwick,WICHITA PRECINCT 613,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,550
+Sedgwick,WICHITA PRECINCT 624,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,38
+Sedgwick,WICHITA PRECINCT 625,State Senate,25,"O'Donnell, Michael",Michael,,O'Donnell,,Republican,141
+Sedgwick,WICHITA PRECINCT 101,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,440
+Sedgwick,WICHITA PRECINCT 102,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,175
+Sedgwick,WICHITA PRECINCT 128,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,99
+Sedgwick,WICHITA PRECINCT 129,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,118
+Sedgwick,WICHITA PRECINCT 130,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,289
+Sedgwick,WICHITA PRECINCT 301,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,216
+Sedgwick,WICHITA PRECINCT 302,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,399
+Sedgwick,WICHITA PRECINCT 303,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,167
+Sedgwick,WICHITA PRECINCT 304,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,192
+Sedgwick,WICHITA PRECINCT 401,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,205
+Sedgwick,WICHITA PRECINCT 402,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,102
+Sedgwick,WICHITA PRECINCT 403,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,162
+Sedgwick,WICHITA PRECINCT 404,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,437
+Sedgwick,WICHITA PRECINCT 405,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,360
+Sedgwick,WICHITA PRECINCT 406,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,337
+Sedgwick,WICHITA PRECINCT 407,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,40
+Sedgwick,WICHITA PRECINCT 408,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,343
+Sedgwick,WICHITA PRECINCT 409,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,189
+Sedgwick,WICHITA PRECINCT 410,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,223
+Sedgwick,WICHITA PRECINCT 602,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,201
+Sedgwick,WICHITA PRECINCT 603,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,274
+Sedgwick,WICHITA PRECINCT 604,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,464
+Sedgwick,WICHITA PRECINCT 605,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,173
+Sedgwick,WICHITA PRECINCT 606,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,156
+Sedgwick,WICHITA PRECINCT 607,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,744
+Sedgwick,WICHITA PRECINCT 609,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,823
+Sedgwick,WICHITA PRECINCT 610,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,426
+Sedgwick,WICHITA PRECINCT 611,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,275
+Sedgwick,WICHITA PRECINCT 612,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,438
+Sedgwick,WICHITA PRECINCT 613,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,475
+Sedgwick,WICHITA PRECINCT 624,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,47
+Sedgwick,WICHITA PRECINCT 625,State Senate,25,"Snow, Tim",Tim,,Snow,,Democratic,74
+Sedgwick,WICHITA PRECINCT 101,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,84
+Sedgwick,WICHITA PRECINCT 102,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,25
+Sedgwick,WICHITA PRECINCT 128,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,17
+Sedgwick,WICHITA PRECINCT 129,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,31
+Sedgwick,WICHITA PRECINCT 130,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,67
+Sedgwick,WICHITA PRECINCT 301,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,32
+Sedgwick,WICHITA PRECINCT 302,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,71
+Sedgwick,WICHITA PRECINCT 303,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,28
+Sedgwick,WICHITA PRECINCT 304,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,33
+Sedgwick,WICHITA PRECINCT 401,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,46
+Sedgwick,WICHITA PRECINCT 402,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,20
+Sedgwick,WICHITA PRECINCT 403,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,35
+Sedgwick,WICHITA PRECINCT 404,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,72
+Sedgwick,WICHITA PRECINCT 405,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,72
+Sedgwick,WICHITA PRECINCT 406,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,50
+Sedgwick,WICHITA PRECINCT 407,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,12
+Sedgwick,WICHITA PRECINCT 408,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,54
+Sedgwick,WICHITA PRECINCT 409,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,35
+Sedgwick,WICHITA PRECINCT 410,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,47
+Sedgwick,WICHITA PRECINCT 602,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,53
+Sedgwick,WICHITA PRECINCT 603,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,47
+Sedgwick,WICHITA PRECINCT 604,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,91
+Sedgwick,WICHITA PRECINCT 605,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,39
+Sedgwick,WICHITA PRECINCT 606,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,24
+Sedgwick,WICHITA PRECINCT 607,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,96
+Sedgwick,WICHITA PRECINCT 609,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,112
+Sedgwick,WICHITA PRECINCT 610,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,93
+Sedgwick,WICHITA PRECINCT 611,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,54
+Sedgwick,WICHITA PRECINCT 612,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,73
+Sedgwick,WICHITA PRECINCT 613,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,66
+Sedgwick,WICHITA PRECINCT 624,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,8
+Sedgwick,WICHITA PRECINCT 625,State Senate,25,"Thomas, Dave",Dave,,Thomas,,Libertarian,20
+Sedgwick,WICHITA PRECINCT 316,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,685
+Sedgwick,WICHITA PRECINCT 317,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,8
+Sedgwick,WICHITA PRECINCT 318,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,21
+Sedgwick,WICHITA PRECINCT 411,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,392
+Sedgwick,WICHITA PRECINCT 412,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,1297
+Sedgwick,WICHITA PRECINCT 413,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,991
+Sedgwick,WICHITA PRECINCT 414,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,174
+Sedgwick,WICHITA PRECINCT 416,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,655
+Sedgwick,WICHITA PRECINCT 424,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,564
+Sedgwick,WICHITA PRECINCT 425,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,679
+Sedgwick,WICHITA PRECINCT 426,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,179
+Sedgwick,WICHITA PRECINCT 520,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,335
+Sedgwick,WICHITA PRECINCT 521,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,566
+Sedgwick,WICHITA PRECINCT 532,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,1058
+Sedgwick,WICHITA PRECINCT 533,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,203
+Sedgwick,WICHITA PRECINCT 535,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,13
+Sedgwick,AFTON,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,612
+Sedgwick,ATTICA PRECINCT 01,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,52
+Sedgwick,ATTICA PRECINCT 02,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,101
+Sedgwick,ATTICA PRECINCT 08,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,39
+Sedgwick,DERBY WARD 01 PRECINCT 05,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,30
+Sedgwick,DERBY WARD 02 PRECINCT 05,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,45
+Sedgwick,DERBY WARD 03 PRECINCT 07,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,125
+Sedgwick,DERBY WARD 04 PRECINCT 01,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,346
+Sedgwick,DERBY WARD 04 PRECINCT 03,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,23
+Sedgwick,DELANO PRECINCT 03,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,2
+Sedgwick,DELANO PRECINCT 04,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,1
+Sedgwick,GRANT,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,801
+Sedgwick,GRAND,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,243
+Sedgwick,GODDARD,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,1307
+Sedgwick,HAYSVILLE WARD 01 PRECINCT 01,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,570
+Sedgwick,HAYSVILLE WARD 02 PRECINCT 01,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,608
+Sedgwick,HAYSVILLE WARD 02 PRECINCT 02,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,78
+Sedgwick,HAYSVILLE WARD 03 PRECINCT 01,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,717
+Sedgwick,HAYSVILLE WARD 03 PRECINCT 02,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,22
+Sedgwick,HAYSVILLE WARD 04 PRECINCT 01,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,596
+Sedgwick,HAYSVILLE WARD 04 PRECINCT 02,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,153
+Sedgwick,ILLINOIS PRECINCT 01,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,375
+Sedgwick,ILLINOIS PRECINCT 02,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,298
+Sedgwick,MORTON,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,859
+Sedgwick,MULVANE PRECINCT 01,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,437
+Sedgwick,MULVANE PRECINCT 02,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,1127
+Sedgwick,NINNESCAH PRECINCT 01,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,860
+Sedgwick,OHIO PRECINCT 01,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,478
+Sedgwick,RIVERSIDE PRECINCT 01,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,10
+Sedgwick,RIVERSIDE PRECINCT 02,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,20
+Sedgwick,RIVERSIDE PRECINCT 06,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,98
+Sedgwick,ROCKFORD PRECINCT 03,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,218
+Sedgwick,ROCKFORD PRECINCT 04,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,23
+Sedgwick,SALEM PRECINCT 01,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,723
+Sedgwick,SALEM PRECINCT 02,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,518
+Sedgwick,WACO PRECINCT 01,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,59
+Sedgwick,WACO PRECINCT 02,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,141
+Sedgwick,WACO PRECINCT 03,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,47
+Sedgwick,WACO PRECINCT 04,State Senate,26,"Kerschen, Dan",Dan,,Kerschen,,Republican,11
+Sedgwick,WICHITA PRECINCT 501,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,27
+Sedgwick,WICHITA PRECINCT 502,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,130
+Sedgwick,WICHITA PRECINCT 503,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,452
+Sedgwick,WICHITA PRECINCT 504,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,401
+Sedgwick,WICHITA PRECINCT 506,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,484
+Sedgwick,WICHITA PRECINCT 507,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,487
+Sedgwick,WICHITA PRECINCT 508,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,446
+Sedgwick,WICHITA PRECINCT 509,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,340
+Sedgwick,WICHITA PRECINCT 510,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,336
+Sedgwick,WICHITA PRECINCT 511,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,21
+Sedgwick,WICHITE PRECINCT 512,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,655
+Sedgwick,WICHITA PRECINCT 513,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,106
+Sedgwick,WICHITA PRECINCT 514,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,510
+Sedgwick,WICHITA PRECINCT 515,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,456
+Sedgwick,WICHITA PRECINCT 516,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,347
+Sedgwick,WICHITA PRECINCT 517,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,371
+Sedgwick,WICHITA PRECINCT 518,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,448
+Sedgwick,WICHITA PRECINCT 519,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,473
+Sedgwick,WICHITA PRECINCT 522,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,365
+Sedgwick,WICHITA PRECINCT 523,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,356
+Sedgwick,WICHITA PRECINCT 524,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,633
+Sedgwick,WICHITA PRECINCT 525,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,546
+Sedgwick,WICHITA PRECINCT 526,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,406
+Sedgwick,WICHITA PRECINCT 527,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,416
+Sedgwick,WICHITA PRECINCT 529,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,211
+Sedgwick,WICHITA PRECINCT 530,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,279
+Sedgwick,WICHITA PRECINCT 531,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,528
+Sedgwick,WICHITA PRECINCT 538,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,55
+Sedgwick,WICHITA PRECINCT 621,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,4
+Sedgwick,ATTICA PRECINCT 03,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,67
+Sedgwick,ATTICA PRECINCT 05,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,65
+Sedgwick,ATTICA PRECINCT 06,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,3
+Sedgwick,ATTICA PRECINCT 07,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,41
+Sedgwick,DELANO PRECINCT 02,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,1
+Sedgwick,GODDARD PRECINCT 01,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,6
+Sedgwick,PAYNE PRECINCT 02,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,52
+Sedgwick,PAYNE PRECINCT 04,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,0
+Sedgwick,SHERMAN,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,211
+Sedgwick,IJNION PRECINCT 01,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,172
+Sedgwick,UNION PRECINCT 02,State Senate,27,"Cubbage, Diana",Diana,,Cubbage,,Democratic,15
+Sedgwick,WICHITA PRECINCT 501,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,66
+Sedgwick,WICHITA PRECINCT 502,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,310
+Sedgwick,WICHITA PRECINCT 503,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,594
+Sedgwick,WICHITA PRECINCT 504,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,445
+Sedgwick,WICHITA PRECINCT 506,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,740
+Sedgwick,WICHITA PRECINCT 507,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,725
+Sedgwick,WICHITA PRECINCT 508,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,613
+Sedgwick,WICHITA PRECINCT 509,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,654
+Sedgwick,WICHITA PRECINCT 510,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,938
+Sedgwick,WICHITA PRECINCT 511,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,79
+Sedgwick,WICHITE PRECINCT 512,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,1458
+Sedgwick,WICHITA PRECINCT 513,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,418
+Sedgwick,WICHITA PRECINCT 514,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,951
+Sedgwick,WICHITA PRECINCT 515,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,761
+Sedgwick,WICHITA PRECINCT 516,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,498
+Sedgwick,WICHITA PRECINCT 517,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,499
+Sedgwick,WICHITA PRECINCT 518,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,671
+Sedgwick,WICHITA PRECINCT 519,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,678
+Sedgwick,WICHITA PRECINCT 522,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,711
+Sedgwick,WICHITA PRECINCT 523,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,728
+Sedgwick,WICHITA PRECINCT 524,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,1094
+Sedgwick,WICHITA PRECINCT 525,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,671
+Sedgwick,WICHITA PRECINCT 526,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,760
+Sedgwick,WICHITA PRECINCT 527,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,843
+Sedgwick,WICHITA PRECINCT 529,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,483
+Sedgwick,WICHITA PRECINCT 530,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,858
+Sedgwick,WICHITA PRECINCT 531,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,1290
+Sedgwick,WICHITA PRECINCT 538,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,151
+Sedgwick,WICHITA PRECINCT 621,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,16
+Sedgwick,ATTICA PRECINCT 03,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,256
+Sedgwick,ATTICA PRECINCT 05,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,176
+Sedgwick,ATTICA PRECINCT 06,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,39
+Sedgwick,ATTICA PRECINCT 07,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,89
+Sedgwick,DELANO PRECINCT 02,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,2
+Sedgwick,GODDARD PRECINCT 01,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,26
+Sedgwick,PAYNE PRECINCT 02,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,96
+Sedgwick,PAYNE PRECINCT 04,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,2
+Sedgwick,SHERMAN,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,529
+Sedgwick,IJNION PRECINCT 01,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,792
+Sedgwick,UNION PRECINCT 02,State Senate,27,"Donovan, Leslie",Leslie,,Donovan,,Republican,63
+Sedgwick,WICHITA PRECINCT 305,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,674
+Sedgwick,WICHITA PRECINCT 309,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,518
+Sedgwick,WICHITA PRECINCT 310,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,210
+Sedgwick,WICHITA PRECINCT 311,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,216
+Sedgwick,WICHITA PRECINCT 312,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,194
+Sedgwick,WICHITA PRECINCT 313,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,481
+Sedgwick,WICHITA PRECINCT 314,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,478
+Sedgwick,WICHITA PRECINCT 315,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,418
+Sedgwick,WICHITA PRECINCT 319,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,129
+Sedgwick,WICHITA PRECINCT 320,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,66
+Sedgwick,WICHITA PRECINCT 321,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,24
+Sedgwick,WICHITA PRECINCT 323,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,155
+Sedgwick,WICHITA PRECINCT 324,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,150
+Sedgwick,WICHITA PRECINCT 325,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,37
+Sedgwick,WICHITA PRECINCT 326,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,32
+Sedgwick,WICHITA PRECINCT 417,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,307
+Sedgwick,WICHITA PRECINCT 418,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,436
+Sedgwick,WICHITA PRECINCT 419,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,398
+Sedgwick,WICHITA PRECINCT 420,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,396
+Sedgwick,WICHITA PRECINCT 421,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,441
+Sedgwick,WICHITA PRECINCT 422,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,247
+Sedgwick,WICHITA PRECINCT 423,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,345
+Sedgwick,WICHITA PRECINCT 429,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,268
+Sedgwick,DERBY WARD 01 PRECINCT 01,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,436
+Sedgwick,DERBY WARD 01 PRECINCT 02,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,253
+Sedgwick,DERBY WARD 01 PRECINCT 04,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,150
+Sedgwick,DERBY WARD 02 PRECINCT 01,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,276
+Sedgwick,DERBY WARD 02 PRECINCT 03,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,110
+Sedgwick,DERBY WARD 02 PRECINCT 06,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,174
+Sedgwick,DERBY WARD 03 PRECINCT 01,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,142
+Sedgwick,DERBY WARD 03 PRECINCT 02,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,95
+Sedgwick,DERBY WARD 03 PRECINCT 04,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,80
+Sedgwick,RIVERSIDE PRECINCT 03,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,135
+Sedgwick,RIVERSIDE PRECINCT 04,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,20
+Sedgwick,RIVERSIDE PRECINCT 07,State Senate,28,"Humphrey, Keith",Keith,,Humphrey,,Democratic,2
+Sedgwick,WICHITA PRECINCT 305,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,601
+Sedgwick,WICHITA PRECINCT 309,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,387
+Sedgwick,WICHITA PRECINCT 310,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,136
+Sedgwick,WICHITA PRECINCT 311,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,234
+Sedgwick,WICHITA PRECINCT 312,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,198
+Sedgwick,WICHITA PRECINCT 313,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,428
+Sedgwick,WICHITA PRECINCT 314,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,516
+Sedgwick,WICHITA PRECINCT 315,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,407
+Sedgwick,WICHITA PRECINCT 319,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,109
+Sedgwick,WICHITA PRECINCT 320,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,92
+Sedgwick,WICHITA PRECINCT 321,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,0
+Sedgwick,WICHITA PRECINCT 323,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,79
+Sedgwick,WICHITA PRECINCT 324,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,119
+Sedgwick,WICHITA PRECINCT 325,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,12
+Sedgwick,WICHITA PRECINCT 326,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,53
+Sedgwick,WICHITA PRECINCT 417,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,340
+Sedgwick,WICHITA PRECINCT 418,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,503
+Sedgwick,WICHITA PRECINCT 419,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,443
+Sedgwick,WICHITA PRECINCT 420,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,458
+Sedgwick,WICHITA PRECINCT 421,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,391
+Sedgwick,WICHITA PRECINCT 422,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,309
+Sedgwick,WICHITA PRECINCT 423,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,401
+Sedgwick,WICHITA PRECINCT 429,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,233
+Sedgwick,DERBY WARD 01 PRECINCT 01,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,769
+Sedgwick,DERBY WARD 01 PRECINCT 02,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,434
+Sedgwick,DERBY WARD 01 PRECINCT 04,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,253
+Sedgwick,DERBY WARD 02 PRECINCT 01,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,422
+Sedgwick,DERBY WARD 02 PRECINCT 03,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,241
+Sedgwick,DERBY WARD 02 PRECINCT 06,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,277
+Sedgwick,DERBY WARD 03 PRECINCT 01,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,201
+Sedgwick,DERBY WARD 03 PRECINCT 02,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,133
+Sedgwick,DERBY WARD 03 PRECINCT 04,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,118
+Sedgwick,RIVERSIDE PRECINCT 03,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,212
+Sedgwick,RIVERSIDE PRECINCT 04,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,25
+Sedgwick,RIVERSIDE PRECINCT 07,State Senate,28,"Petersen, Mike",Mike,,Petersen,,Republican,5
+Sedgwick,WICHITA PRECINCT 103,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,39
+Sedgwick,WICHITA PRECINCT 104,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,18
+Sedgwick,WICHITA PRECINCT 105,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,176
+Sedgwick,WICHITA PRECINCT 106,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,95
+Sedgwick,WICHITA PRECINCT 107,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,125
+Sedgwick,WICHITA PRECINCT 108,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,254
+Sedgwick,WICHITA PRECINCT 109,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,276
+Sedgwick,WICHITA PRECINCT 112,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,309
+Sedgwick,WICHITA PRECINCT 113,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,88
+Sedgwick,WICHITA PRECINCT 114,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,65
+Sedgwick,WICHITA PRECINCT 116,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,113
+Sedgwick,WICHITA PRECINCT 117,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,96
+Sedgwick,WICHITA PRECINCT 118,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,201
+Sedgwick,WICHITA PRECINCT 119,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,240
+Sedgwick,WICHITA PRECINCT 120,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,288
+Sedgwick,WICHITA PRECINCT 132,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,9
+Sedgwick,WICHITA PRECINCT 201,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,562
+Sedgwick,WICHITA PRECINCT 202,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,622
+Sedgwick,WICHITA PRECINCT 601,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,226
+Sedgwick,WICHITA PRECINCT 608,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,237
+Sedgwick,WICHITA PRECINCT 614,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,218
+Sedgwick,WICHITA PRECINCT 615,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,106
+Sedgwick,WICHITA PRECINCT 616,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,128
+Sedgwick,WICHITA PRECINCT 618,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,215
+Sedgwick,WICHITA PRECINCT 619,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,556
+Sedgwick,WICHITA PRECINCT 620,State Senate,29,"Cox, Kenya",Kenya,,Cox,,Republican,308
+Sedgwick,WICHITA PRECINCT 103,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,49
+Sedgwick,WICHITA PRECINCT 104,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,13
+Sedgwick,WICHITA PRECINCT 105,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,321
+Sedgwick,WICHITA PRECINCT 106,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,157
+Sedgwick,WICHITA PRECINCT 107,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,519
+Sedgwick,WICHITA PRECINCT 108,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,408
+Sedgwick,WICHITA PRECINCT 109,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,693
+Sedgwick,WICHITA PRECINCT 112,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,702
+Sedgwick,WICHITA PRECINCT 113,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,646
+Sedgwick,WICHITA PRECINCT 114,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,675
+Sedgwick,WICHITA PRECINCT 116,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,993
+Sedgwick,WICHITA PRECINCT 117,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,902
+Sedgwick,WICHITA PRECINCT 118,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,844
+Sedgwick,WICHITA PRECINCT 119,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,587
+Sedgwick,WICHITA PRECINCT 120,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,505
+Sedgwick,WICHITA PRECINCT 132,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,8
+Sedgwick,WICHITA PRECINCT 201,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,555
+Sedgwick,WICHITA PRECINCT 202,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,515
+Sedgwick,WICHITA PRECINCT 601,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,385
+Sedgwick,WICHITA PRECINCT 608,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,495
+Sedgwick,WICHITA PRECINCT 614,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,442
+Sedgwick,WICHITA PRECINCT 615,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,271
+Sedgwick,WICHITA PRECINCT 616,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,214
+Sedgwick,WICHITA PRECINCT 618,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,159
+Sedgwick,WICHITA PRECINCT 619,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,445
+Sedgwick,WICHITA PRECINCT 620,State Senate,29,"Faust-Goudeau, Oletha",Oletha,,Faust-Goudeau,,Democratic,217
+Sedgwick,WICHITA PRECINCT 103,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,8
+Sedgwick,WICHITA PRECINCT 104,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,5
+Sedgwick,WICHITA PRECINCT 105,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,52
+Sedgwick,WICHITA PRECINCT 106,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,33
+Sedgwick,WICHITA PRECINCT 107,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,37
+Sedgwick,WICHITA PRECINCT 108,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,62
+Sedgwick,WICHITA PRECINCT 109,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,52
+Sedgwick,WICHITA PRECINCT 112,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,55
+Sedgwick,WICHITA PRECINCT 113,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,24
+Sedgwick,WICHITA PRECINCT 114,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,9
+Sedgwick,WICHITA PRECINCT 116,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,33
+Sedgwick,WICHITA PRECINCT 117,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,16
+Sedgwick,WICHITA PRECINCT 118,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,30
+Sedgwick,WICHITA PRECINCT 119,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,38
+Sedgwick,WICHITA PRECINCT 120,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,43
+Sedgwick,WICHITA PRECINCT 132,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,1
+Sedgwick,WICHITA PRECINCT 201,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,120
+Sedgwick,WICHITA PRECINCT 202,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,83
+Sedgwick,WICHITA PRECINCT 601,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,49
+Sedgwick,WICHITA PRECINCT 608,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,76
+Sedgwick,WICHITA PRECINCT 614,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,54
+Sedgwick,WICHITA PRECINCT 615,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,19
+Sedgwick,WICHITA PRECINCT 616,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,31
+Sedgwick,WICHITA PRECINCT 618,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,40
+Sedgwick,WICHITA PRECINCT 619,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,96
+Sedgwick,WICHITA PRECINCT 620,State Senate,29,"Kramer, Carl",Carl,,Kramer,,Libertarian,54
+Sedgwick,WICHITA PRECINCT 110,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,129
+Sedgwick,WICHITA PRECINCT 121,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,331
+Sedgwick,WICHITA PRECINCT 203,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,425
+Sedgwick,WICHITA PRECINCT 204,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,358
+Sedgwick,WICHITA PRECINCT 205,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,231
+Sedgwick,WICHITA PRECINCT 206,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,147
+Sedgwick,WICHITA PRECINCT 207,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,537
+Sedgwick,WICHITA PRECINCT 209,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,431
+Sedgwick,WICHITA PRECINCT 210,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,488
+Sedgwick,WICHITA PRECINCT 211,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,241
+Sedgwick,WICHITA PRECINCT 212,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,443
+Sedgwick,WICHITA PRECINCT 213,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,402
+Sedgwick,WICHITA PRECINCT 214,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,357
+Sedgwick,WICHITA PRECINCT 215,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,597
+Sedgwick,WICHITA PRECINCT 216,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,343
+Sedgwick,WICHITA PRECINCT 217,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,348
+Sedgwick,WICHITA PRECINCT 221,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,223
+Sedgwick,WICHITA PRECINCT 222,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,274
+Sedgwick,WICHITA PRECINCT 223,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,339
+Sedgwick,WICHITA PRECINCT 224,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,540
+Sedgwick,WICHITA PRECINCT 225,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,550
+Sedgwick,WICHITA PRECINCT 227,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,301
+Sedgwick,WICHITA PRECINCT 231,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,276
+Sedgwick,WICHITA PRECINCT 234,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,99
+Sedgwick,WICHITA PRECINCT 235,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,156
+Sedgwick,WICHITA PRECINCT 306,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,675
+Sedgwick,WICHITA PRECINCT 307,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,322
+Sedgwick,WICHITA PRECINCT 308,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,537
+Sedgwick,MINNEHA PRECINCT 01,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,224
+Sedgwick,MINNEHA PRECINCT 02,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,129
+Sedgwick,MINNEHA PRECINCT 04,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,1
+Sedgwick,MINNEHA PRECINCT 09,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,72
+Sedgwick,MINNEHA PRECINCT 11,State Senate,30,"Cantwell, Patrick K.",Patrick,K.,Cantwell,,Democratic,1
+Sedgwick,WICHITA PRECINCT 110,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,190
+Sedgwick,WICHITA PRECINCT 121,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,462
+Sedgwick,WICHITA PRECINCT 203,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,525
+Sedgwick,WICHITA PRECINCT 204,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,498
+Sedgwick,WICHITA PRECINCT 205,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,119
+Sedgwick,WICHITA PRECINCT 206,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,158
+Sedgwick,WICHITA PRECINCT 207,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,649
+Sedgwick,WICHITA PRECINCT 209,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,434
+Sedgwick,WICHITA PRECINCT 210,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,529
+Sedgwick,WICHITA PRECINCT 211,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,382
+Sedgwick,WICHITA PRECINCT 212,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,739
+Sedgwick,WICHITA PRECINCT 213,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,919
+Sedgwick,WICHITA PRECINCT 214,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,836
+Sedgwick,WICHITA PRECINCT 215,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,1035
+Sedgwick,WICHITA PRECINCT 216,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,647
+Sedgwick,WICHITA PRECINCT 217,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,926
+Sedgwick,WICHITA PRECINCT 221,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,540
+Sedgwick,WICHITA PRECINCT 222,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,680
+Sedgwick,WICHITA PRECINCT 223,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,907
+Sedgwick,WICHITA PRECINCT 224,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,716
+Sedgwick,WICHITA PRECINCT 225,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,807
+Sedgwick,WICHITA PRECINCT 227,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,911
+Sedgwick,WICHITA PRECINCT 231,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,207
+Sedgwick,WICHITA PRECINCT 234,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,86
+Sedgwick,WICHITA PRECINCT 235,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,146
+Sedgwick,WICHITA PRECINCT 306,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,588
+Sedgwick,WICHITA PRECINCT 307,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,234
+Sedgwick,WICHITA PRECINCT 308,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,425
+Sedgwick,MINNEHA PRECINCT 01,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,922
+Sedgwick,MINNEHA PRECINCT 02,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,331
+Sedgwick,MINNEHA PRECINCT 04,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,3
+Sedgwick,MINNEHA PRECINCT 09,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,149
+Sedgwick,MINNEHA PRECINCT 11,State Senate,30,"Wagle, Susan",Susan,,Wagle,,Republican,0
+Sedgwick,WICHITA PRECINCT 123,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,71
+Sedgwick,WICHITA PRECINCT 126,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,142
+Sedgwick,WICHITA PRECINCT 127,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,170
+Sedgwick,WICHITA PRECINCT 131,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,7
+Sedgwick,WICHITA PRECINCT 534,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,82
+Sedgwick,WICHITA PRECINCT 622,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,451
+Sedgwick,WICHITA PRECINCT 623,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,772
+Sedgwick,WICHITA PRECINCT 626,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,3
+Sedgwick,WICHITA PRECINCT 627,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,68
+Sedgwick,WICHITA PRECINCT 628,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,493
+Sedgwick,BEL AIRE PRECINCT 01,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,1018
+Sedgwick,BEL AIRE PRECINCT 02,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,849
+Sedgwick,EAGLE,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,364
+Sedgwick,GRANT PRECINCT 01,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,395
+Sedgwick,GRANT PRECINCT 02,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,170
+Sedgwick,GREELEY,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,379
+Sedgwick,KECHI PRECINCT 01,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,5
+Sedgwick,KECHI PRECINCT 03,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,620
+Sedgwick,KECHI PRECINCT 04,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,27
+Sedgwick,KECHI PRECINCT 07,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,15
+Sedgwick,KECHI PRECINCT 08,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,11
+Sedgwick,PARK PRECINCT 01,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,215
+Sedgwick,PARK PRECINCT 05,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,1030
+Sedgwick,PARK PRECINCT 06,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,48
+Sedgwick,PARK CITY WARD 01 PRECINCT 01,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,395
+Sedgwick,PARK CITY WARD 01 PRECINCT 02,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,67
+Sedgwick,PARK CITY WARD 01 PRECINCT 03,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,147
+Sedgwick,PARK CITY WARD 02 PRECINCT 01,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,573
+Sedgwick,PARK CITY WARD 02 PRECINCT 02,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,5
+Sedgwick,PARK CITY WARD 03 PRECINCT 01,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,327
+Sedgwick,PARK CITY WARD 04 PRECINCT 01,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,252
+Sedgwick,PARK CITY WARD 04 PRECINCT 03,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,179
+Sedgwick,VALLEY CENTER TOWNSHIP,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,378
+Sedgwick,VALLEY CENTER WARD 01 PRECINCT 01,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,642
+Sedgwick,VALLEY CENTER WARD 02 PRECINCT 01,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,600
+Sedgwick,VALLEY CENTER WARD 03 PRECINCT 01,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,544
+Sedgwick,VALLEY CENTER WARD 03 PRECINCT 02,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,175
+Sedgwick,VALLEY CENTER WARD 04 PRECINCT 01,State Senate,31,"McGinn, Carolyn  ",Carolyn,,McGinn,,Republican,442
+Sedgwick,ERIE,State Senate,32,"Abrams, Steve",Steve,,Abrams,,Republican,28
+Sedgwick,NINNESCAH PRECINCT 01,State Senate,32,"Abrams, Steve",Steve,,Abrams,,Republican,159
+Sedgwick,VIOLA,State Senate,32,"Abrams, Steve",Steve,,Abrams,,Republican,169
+Sedgwick,WICHITA PRECINCT 233,State House,81,"Howell, Jim",Jim,,Howell,,Republican,259
+Sedgwick,WICHITA PRECINCT 310,State House,81,"Howell, Jim",Jim,,Howell,,Republican,105
+Sedgwick,WICHITA PRECINCT 323,State House,81,"Howell, Jim",Jim,,Howell,,Republican,78
+Sedgwick,DERBY WARD 01 PRECINCT 01,State House,81,"Howell, Jim",Jim,,Howell,,Republican,856
+Sedgwick,DERBY WARD 01 PRECINCT 02,State House,81,"Howell, Jim",Jim,,Howell,,Republican,464
+Sedgwick,DERBY WARD 01 PRECINCT 03,State House,81,"Howell, Jim",Jim,,Howell,,Republican,111
+Sedgwick,DERBY WARD 01 PRECINCT 04,State House,81,"Howell, Jim",Jim,,Howell,,Republican,289
+Sedgwick,DERBY WARD 01 PRECINCT 05,State House,81,"Howell, Jim",Jim,,Howell,,Republican,27
+Sedgwick,DERBY WARD 02 PRECINCT 03,State House,81,"Howell, Jim",Jim,,Howell,,Republican,268
+Sedgwick,DERBY WARD 02 PRECINCT 06,State House,81,"Howell, Jim",Jim,,Howell,,Republican,310
+Sedgwick,GYPSUM PRECINCT 01,State House,81,"Howell, Jim",Jim,,Howell,,Republican,1054
+Sedgwick,GYPSUM PRECINCT 02,State House,81,"Howell, Jim",Jim,,Howell,,Republican,33
+Sedgwick,GYPSUM PRECINCT 03,State House,81,"Howell, Jim",Jim,,Howell,,Republican,24
+Sedgwick,GYPSUM PRECINCT 04,State House,81,"Howell, Jim",Jim,,Howell,,Republican,5
+Sedgwick,RIVERSIDE PRECINCT 03,State House,81,"Howell, Jim",Jim,,Howell,,Republican,85
+Sedgwick,RIVERSIDE PRECINCT 04,State House,81,"Howell, Jim",Jim,,Howell,,Republican,55
+Sedgwick,RIVERSIDE PRECINCT 06,State House,81,"Howell, Jim",Jim,,Howell,,Republican,83
+Sedgwick,WICHITA PRECINCT 233,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,172
+Sedgwick,WICHITA PRECINCT 310,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,228
+Sedgwick,WICHITA PRECINCT 323,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,148
+Sedgwick,DERBY WARD 01 PRECINCT 01,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,347
+Sedgwick,DERBY WARD 01 PRECINCT 02,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,220
+Sedgwick,DERBY WARD 01 PRECINCT 03,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,52
+Sedgwick,DERBY WARD 01 PRECINCT 04,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,115
+Sedgwick,DERBY WARD 01 PRECINCT 05,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,11
+Sedgwick,DERBY WARD 02 PRECINCT 03,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,78
+Sedgwick,DERBY WARD 02 PRECINCT 06,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,143
+Sedgwick,GYPSUM PRECINCT 01,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,423
+Sedgwick,GYPSUM PRECINCT 02,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,15
+Sedgwick,GYPSUM PRECINCT 03,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,20
+Sedgwick,GYPSUM PRECINCT 04,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,2
+Sedgwick,RIVERSIDE PRECINCT 03,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,74
+Sedgwick,RIVERSIDE PRECINCT 04,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,141
+Sedgwick,RIVERSIDE PRECINCT 06,State House,81,"Wells, Barbara",Barbara,,Wells,,Democratic,53
+Sedgwick,DERBY WARD 02 PRECINCT 01,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,508
+Sedgwick,DERBY WARD 02 PRECINCT 02,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,476
+Sedgwick,DERBY WARD 02 PRECINCT 05,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,48
+Sedgwick,DERBY WARD 03 PRECINCT 01,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,234
+Sedgwick,DERBY WARD 03 PRECINCT 02,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,165
+Sedgwick,DERBY WARD 03 PRECINCT 04,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,144
+Sedgwick,DERBY WARD 03 PRECINCT 05,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,255
+Sedgwick,DERBY WARD 03 PRECINCT 06,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,772
+Sedgwick,DERBY WARD 03 PRECINCT 07,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,130
+Sedgwick,DERBY WARD 04 PRECINCT 01,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,352
+Sedgwick,DERBY WARD 04 PRECINCT 02,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,831
+Sedgwick,DERBY WARD 04 PRECINCT 03,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,22
+Sedgwick,DERBY WARD 04 PRECINCT 04,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,454
+Sedgwick,MULVANE PRECINCT 01,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,419
+Sedgwick,MULVANE PRECINCT 02,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,1044
+Sedgwick,ROCKFORD PRECINCT 01,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,272
+Sedgwick,ROCKFORD PRECINCT 02,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,40
+Sedgwick,ROCKFORD PRECINCT 03,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,207
+Sedgwick,ROCKFORD PRECINCT 04,State House,82,"DeGraaf, Peter",Peter,,DeGraaf,,Republican,23
+Sedgwick,WICHITA PRECINCT 109,State House,83,"Bridges, Carolyn",Carolyn,,Bridges,,Democratic,698
+Sedgwick,WICHITA PRECINCT 110,State House,83,"Bridges, Carolyn",Carolyn,,Bridges,,Democratic,162
+Sedgwick,WICHITA PRECINCT 203,State House,83,"Bridges, Carolyn",Carolyn,,Bridges,,Democratic,524
+Sedgwick,WICHITA PRECINCT 204,State House,83,"Bridges, Carolyn",Carolyn,,Bridges,,Democratic,441
+Sedgwick,WICHITA PRECINCT 205,State House,83,"Bridges, Carolyn",Carolyn,,Bridges,,Democratic,232
+Sedgwick,WICHITA PRECINCT 306,State House,83,"Bridges, Carolyn",Carolyn,,Bridges,,Democratic,726
+Sedgwick,WICHITA PRECINCT 307,State House,83,"Bridges, Carolyn",Carolyn,,Bridges,,Democratic,329
+Sedgwick,WICHITA PRECINCT 308,State House,83,"Bridges, Carolyn",Carolyn,,Bridges,,Democratic,591
+Sedgwick,WICHITA PRECINCT 321,State House,83,"Bridges, Carolyn",Carolyn,,Bridges,,Democratic,19
+Sedgwick,MINNEHA PRECINCT 02,State House,83,"Bridges, Carolyn",Carolyn,,Bridges,,Democratic,181
+Sedgwick,WICHITA PRECINCT 109,State House,83,"Garvey, Tim",Tim,,Garvey,,Republican,291
+Sedgwick,WICHITA PRECINCT 110,State House,83,"Garvey, Tim",Tim,,Garvey,,Republican,152
+Sedgwick,WICHITA PRECINCT 203,State House,83,"Garvey, Tim",Tim,,Garvey,,Republican,427
+Sedgwick,WICHITA PRECINCT 204,State House,83,"Garvey, Tim",Tim,,Garvey,,Republican,412
+Sedgwick,WICHITA PRECINCT 205,State House,83,"Garvey, Tim",Tim,,Garvey,,Republican,115
+Sedgwick,WICHITA PRECINCT 306,State House,83,"Garvey, Tim",Tim,,Garvey,,Republican,520
+Sedgwick,WICHITA PRECINCT 307,State House,83,"Garvey, Tim",Tim,,Garvey,,Republican,216
+Sedgwick,WICHITA PRECINCT 308,State House,83,"Garvey, Tim",Tim,,Garvey,,Republican,366
+Sedgwick,WICHITA PRECINCT 321,State House,83,"Garvey, Tim",Tim,,Garvey,,Republican,3
+Sedgwick,MINNEHA PRECINCT 02,State House,83,"Garvey, Tim",Tim,,Garvey,,Republican,274
+Sedgwick,WICHITA PRECINCT 106,State House,84,"Bakken, Gordon",Gordon,,Bakken,,Libertarian,22
+Sedgwick,WICHITA PRECINCT 107,State House,84,"Bakken, Gordon",Gordon,,Bakken,,Libertarian,35
+Sedgwick,WICHITA PRECINCT 108,State House,84,"Bakken, Gordon",Gordon,,Bakken,,Libertarian,44
+Sedgwick,WICHITA PRECINCT 113,State House,84,"Bakken, Gordon",Gordon,,Bakken,,Libertarian,22
+Sedgwick,WICHITA PRECINCT 114,State House,84,"Bakken, Gordon",Gordon,,Bakken,,Libertarian,15
+Sedgwick,WICHITA PRECINCT 116,State House,84,"Bakken, Gordon",Gordon,,Bakken,,Libertarian,27
+Sedgwick,WICHITA PRECINCT 201,State House,84,"Bakken, Gordon",Gordon,,Bakken,,Libertarian,86
+Sedgwick,WICHITA PRECINCT 202,State House,84,"Bakken, Gordon",Gordon,,Bakken,,Libertarian,78
+Sedgwick,WICHITA PRECINCT 106,State House,84,"Finney, Gail",Gail,,Finney,,Democratic,166
+Sedgwick,WICHITA PRECINCT 107,State House,84,"Finney, Gail",Gail,,Finney,,Democratic,557
+Sedgwick,WICHITA PRECINCT 108,State House,84,"Finney, Gail",Gail,,Finney,,Democratic,436
+Sedgwick,WICHITA PRECINCT 113,State House,84,"Finney, Gail",Gail,,Finney,,Democratic,664
+Sedgwick,WICHITA PRECINCT 114,State House,84,"Finney, Gail",Gail,,Finney,,Democratic,705
+Sedgwick,WICHITA PRECINCT 116,State House,84,"Finney, Gail",Gail,,Finney,,Democratic,1018
+Sedgwick,WICHITA PRECINCT 201,State House,84,"Finney, Gail",Gail,,Finney,,Democratic,629
+Sedgwick,WICHITA PRECINCT 202,State House,84,"Finney, Gail",Gail,,Finney,,Democratic,574
+Sedgwick,WICHITA PRECINCT 106,State House,84,"Heflin, Dan",Dan,,Heflin,,Republican,85
+Sedgwick,WICHITA PRECINCT 107,State House,84,"Heflin, Dan",Dan,,Heflin,,Republican,76
+Sedgwick,WICHITA PRECINCT 108,State House,84,"Heflin, Dan",Dan,,Heflin,,Republican,226
+Sedgwick,WICHITA PRECINCT 113,State House,84,"Heflin, Dan",Dan,,Heflin,,Republican,52
+Sedgwick,WICHITA PRECINCT 114,State House,84,"Heflin, Dan",Dan,,Heflin,,Republican,23
+Sedgwick,WICHITA PRECINCT 116,State House,84,"Heflin, Dan",Dan,,Heflin,,Republican,41
+Sedgwick,WICHITA PRECINCT 201,State House,84,"Heflin, Dan",Dan,,Heflin,,Republican,486
+Sedgwick,WICHITA PRECINCT 202,State House,84,"Heflin, Dan",Dan,,Heflin,,Republican,533
+Sedgwick,WICHITA PRECINCT 122,State House,85,"Brunk, Steven",Steven,,Brunk,,Republican,629
+Sedgwick,WICHITA PRECINCT 216,State House,85,"Brunk, Steven",Steven,,Brunk,,Republican,629
+Sedgwick,WICHITA PRECINCT 217,State House,85,"Brunk, Steven",Steven,,Brunk,,Republican,893
+Sedgwick,WICHITA PRECINCT 218,State House,85,"Brunk, Steven",Steven,,Brunk,,Republican,1185
+Sedgwick,WICHITA PRECINCT 221,State House,85,"Brunk, Steven",Steven,,Brunk,,Republican,518
+Sedgwick,WICHITA PRECINCT 222,State House,85,"Brunk, Steven",Steven,,Brunk,,Republican,651
+Sedgwick,WICHITA PRECINCT 236,State House,85,"Brunk, Steven",Steven,,Brunk,,Republican,565
+Sedgwick,BEL AIRE PRECINCT 03,State House,85,"Brunk, Steven",Steven,,Brunk,,Republican,499
+Sedgwick,MINNEHA PRECINCT 07,State House,85,"Brunk, Steven",Steven,,Brunk,,Republican,7
+Sedgwick,MINNEHA PRECINCT 11,State House,85,"Brunk, Steven",Steven,,Brunk,,Republican,0
+Sedgwick,PAYNE PRECINCT 01,State House,85,"Brunk, Steven",Steven,,Brunk,,Republican,332
+Sedgwick,PAYNE PRECINCT 02,State House,85,"Brunk, Steven",Steven,,Brunk,,Republican,52
+Sedgwick,WICHITA PRECINCT 122,State House,85,"Stanley, Barry",Barry,,Stanley,,Democratic,689
+Sedgwick,WICHITA PRECINCT 216,State House,85,"Stanley, Barry",Barry,,Stanley,,Democratic,332
+Sedgwick,WICHITA PRECINCT 217,State House,85,"Stanley, Barry",Barry,,Stanley,,Democratic,351
+Sedgwick,WICHITA PRECINCT 218,State House,85,"Stanley, Barry",Barry,,Stanley,,Democratic,627
+Sedgwick,WICHITA PRECINCT 221,State House,85,"Stanley, Barry",Barry,,Stanley,,Democratic,228
+Sedgwick,WICHITA PRECINCT 222,State House,85,"Stanley, Barry",Barry,,Stanley,,Democratic,275
+Sedgwick,WICHITA PRECINCT 236,State House,85,"Stanley, Barry",Barry,,Stanley,,Democratic,189
+Sedgwick,BEL AIRE PRECINCT 03,State House,85,"Stanley, Barry",Barry,,Stanley,,Democratic,258
+Sedgwick,MINNEHA PRECINCT 07,State House,85,"Stanley, Barry",Barry,,Stanley,,Democratic,5
+Sedgwick,MINNEHA PRECINCT 11,State House,85,"Stanley, Barry",Barry,,Stanley,,Democratic,1
+Sedgwick,PAYNE PRECINCT 01,State House,85,"Stanley, Barry",Barry,,Stanley,,Democratic,96
+Sedgwick,PAYNE PRECINCT 02,State House,85,"Stanley, Barry",Barry,,Stanley,,Democratic,16
+Sedgwick,WICHITA PRECINCT 101,State House,86,"Pruden, James",James,,Pruden,,Libertarian,47
+Sedgwick,WICHITA PRECINCT 105,State House,86,"Pruden, James",James,,Pruden,,Libertarian,39
+Sedgwick,WICHITA PRECINCT 130,State House,86,"Pruden, James",James,,Pruden,,Libertarian,44
+Sedgwick,WICHITA PRECINCT 301,State House,86,"Pruden, James",James,,Pruden,,Libertarian,18
+Sedgwick,WICHITA PRECINCT 302,State House,86,"Pruden, James",James,,Pruden,,Libertarian,42
+Sedgwick,WICHITA PRECINCT 303,State House,86,"Pruden, James",James,,Pruden,,Libertarian,24
+Sedgwick,WICHITA PRECINCT 304,State House,86,"Pruden, James",James,,Pruden,,Libertarian,18
+Sedgwick,WICHITA PRECINCT 305,State House,86,"Pruden, James",James,,Pruden,,Libertarian,59
+Sedgwick,WICHITA PRECINCT 319,State House,86,"Pruden, James",James,,Pruden,,Libertarian,12
+Sedgwick,WICHITA PRECINCT 407,State House,86,"Pruden, James",James,,Pruden,,Libertarian,9
+Sedgwick,WICHITA PRECINCT 101,State House,86,"Stevens, John",John,,Stevens,,Republican,379
+Sedgwick,WICHITA PRECINCT 105,State House,86,"Stevens, John",John,,Stevens,,Republican,157
+Sedgwick,WICHITA PRECINCT 130,State House,86,"Stevens, John",John,,Stevens,,Republican,176
+Sedgwick,WICHITA PRECINCT 301,State House,86,"Stevens, John",John,,Stevens,,Republican,162
+Sedgwick,WICHITA PRECINCT 302,State House,86,"Stevens, John",John,,Stevens,,Republican,300
+Sedgwick,WICHITA PRECINCT 303,State House,86,"Stevens, John",John,,Stevens,,Republican,161
+Sedgwick,WICHITA PRECINCT 304,State House,86,"Stevens, John",John,,Stevens,,Republican,157
+Sedgwick,WICHITA PRECINCT 305,State House,86,"Stevens, John",John,,Stevens,,Republican,445
+Sedgwick,WICHITA PRECINCT 319,State House,86,"Stevens, John",John,,Stevens,,Republican,81
+Sedgwick,WICHITA PRECINCT 407,State House,86,"Stevens, John",John,,Stevens,,Republican,38
+Sedgwick,WICHITA PRECINCT 101,State House,86,"Ward, Jim",Jim,,Ward,,Democratic,536
+Sedgwick,WICHITA PRECINCT 105,State House,86,"Ward, Jim",Jim,,Ward,,Democratic,356
+Sedgwick,WICHITA PRECINCT 130,State House,86,"Ward, Jim",Jim,,Ward,,Democratic,364
+Sedgwick,WICHITA PRECINCT 301,State House,86,"Ward, Jim",Jim,,Ward,,Democratic,254
+Sedgwick,WICHITA PRECINCT 302,State House,86,"Ward, Jim",Jim,,Ward,,Democratic,481
+Sedgwick,WICHITA PRECINCT 303,State House,86,"Ward, Jim",Jim,,Ward,,Democratic,198
+Sedgwick,WICHITA PRECINCT 304,State House,86,"Ward, Jim",Jim,,Ward,,Democratic,228
+Sedgwick,WICHITA PRECINCT 305,State House,86,"Ward, Jim",Jim,,Ward,,Democratic,779
+Sedgwick,WICHITA PRECINCT 319,State House,86,"Ward, Jim",Jim,,Ward,,Democratic,150
+Sedgwick,WICHITA PRECINCT 407,State House,86,"Ward, Jim",Jim,,Ward,,Democratic,43
+Sedgwick,WICHITA PRECINCT 121,State House,87,"Florquist, Chris",Chris,,Florquist,,Democratic,307
+Sedgwick,WICHITA PRECINCT 206,State House,87,"Florquist, Chris",Chris,,Florquist,,Democratic,129
+Sedgwick,WICHITA PRECINCT 211,State House,87,"Florquist, Chris",Chris,,Florquist,,Democratic,214
+Sedgwick,WICHITA PRECINCT 212,State House,87,"Florquist, Chris",Chris,,Florquist,,Democratic,416
+Sedgwick,WICHITA PRECINCT 213,State House,87,"Florquist, Chris",Chris,,Florquist,,Democratic,363
+Sedgwick,WICHITA PRECINCT 214,State House,87,"Florquist, Chris",Chris,,Florquist,,Democratic,300
+Sedgwick,WICHITA PRECINCT 215,State House,87,"Florquist, Chris",Chris,,Florquist,,Democratic,536
+Sedgwick,WICHITA PRECINCT 223,State House,87,"Florquist, Chris",Chris,,Florquist,,Democratic,302
+Sedgwick,WICHITA PRECINCT 224,State House,87,"Florquist, Chris",Chris,,Florquist,,Democratic,490
+Sedgwick,WICHITA PRECINCT 234,State House,87,"Florquist, Chris",Chris,,Florquist,,Democratic,88
+Sedgwick,MINNEHA PRECINCT 04,State House,87,"Florquist, Chris",Chris,,Florquist,,Democratic,1
+Sedgwick,WICHITA PRECINCT 121,State House,87,"Kahrs, Mark",Mark,,Kahrs,,Republican,423
+Sedgwick,WICHITA PRECINCT 206,State House,87,"Kahrs, Mark",Mark,,Kahrs,,Republican,141
+Sedgwick,WICHITA PRECINCT 211,State House,87,"Kahrs, Mark",Mark,,Kahrs,,Republican,365
+Sedgwick,WICHITA PRECINCT 212,State House,87,"Kahrs, Mark",Mark,,Kahrs,,Republican,701
+Sedgwick,WICHITA PRECINCT 213,State House,87,"Kahrs, Mark",Mark,,Kahrs,,Republican,863
+Sedgwick,WICHITA PRECINCT 214,State House,87,"Kahrs, Mark",Mark,,Kahrs,,Republican,825
+Sedgwick,WICHITA PRECINCT 215,State House,87,"Kahrs, Mark",Mark,,Kahrs,,Republican,993
+Sedgwick,WICHITA PRECINCT 223,State House,87,"Kahrs, Mark",Mark,,Kahrs,,Republican,879
+Sedgwick,WICHITA PRECINCT 224,State House,87,"Kahrs, Mark",Mark,,Kahrs,,Republican,668
+Sedgwick,WICHITA PRECINCT 234,State House,87,"Kahrs, Mark",Mark,,Kahrs,,Republican,79
+Sedgwick,MINNEHA PRECINCT 04,State House,87,"Kahrs, Mark",Mark,,Kahrs,,Republican,2
+Sedgwick,WICHITA PRECINCT 121,State House,87,"Talbert, Santana Marie",Santana,Marie,Talbert,,Libertarian,43
+Sedgwick,WICHITA PRECINCT 206,State House,87,"Talbert, Santana Marie",Santana,Marie,Talbert,,Libertarian,19
+Sedgwick,WICHITA PRECINCT 211,State House,87,"Talbert, Santana Marie",Santana,Marie,Talbert,,Libertarian,29
+Sedgwick,WICHITA PRECINCT 212,State House,87,"Talbert, Santana Marie",Santana,Marie,Talbert,,Libertarian,45
+Sedgwick,WICHITA PRECINCT 213,State House,87,"Talbert, Santana Marie",Santana,Marie,Talbert,,Libertarian,73
+Sedgwick,WICHITA PRECINCT 214,State House,87,"Talbert, Santana Marie",Santana,Marie,Talbert,,Libertarian,48
+Sedgwick,WICHITA PRECINCT 215,State House,87,"Talbert, Santana Marie",Santana,Marie,Talbert,,Libertarian,58
+Sedgwick,WICHITA PRECINCT 223,State House,87,"Talbert, Santana Marie",Santana,Marie,Talbert,,Libertarian,40
+Sedgwick,WICHITA PRECINCT 224,State House,87,"Talbert, Santana Marie",Santana,Marie,Talbert,,Libertarian,73
+Sedgwick,WICHITA PRECINCT 234,State House,87,"Talbert, Santana Marie",Santana,Marie,Talbert,,Libertarian,11
+Sedgwick,MINNEHA PRECINCT 04,State House,87,"Talbert, Santana Marie",Santana,Marie,Talbert,,Libertarian,1
+Sedgwick,WICHITA PRECINCT 207,State House,88,"Scapa, Joseph",Joseph,,Scapa,,Republican,568
+Sedgwick,WICHITA PRECINCT 208,State House,88,"Scapa, Joseph",Joseph,,Scapa,,Republican,172
+Sedgwick,WICHITA PRECINCT 209,State House,88,"Scapa, Joseph",Joseph,,Scapa,,Republican,367
+Sedgwick,WICHITA PRECINCT 210,State House,88,"Scapa, Joseph",Joseph,,Scapa,,Republican,467
+Sedgwick,WICHITA PRECINCT 225,State House,88,"Scapa, Joseph",Joseph,,Scapa,,Republican,751
+Sedgwick,WICHITA PRECINCT 231,State House,88,"Scapa, Joseph",Joseph,,Scapa,,Republican,192
+Sedgwick,WICHITA PRECINCT 235,State House,88,"Scapa, Joseph",Joseph,,Scapa,,Republican,130
+Sedgwick,WICHITA PRECINCT 309,State House,88,"Scapa, Joseph",Joseph,,Scapa,,Republican,349
+Sedgwick,WICHITA PRECINCT 320,State House,88,"Scapa, Joseph",Joseph,,Scapa,,Republican,80
+Sedgwick,MINNEHA PRECINCT 09,State House,88,"Scapa, Joseph",Joseph,,Scapa,,Republican,133
+Sedgwick,MINNEHA PRECINCT 12,State House,88,"Scapa, Joseph",Joseph,,Scapa,,Republican,17
+Sedgwick,WICHITA PRECINCT 207,State House,88,"Sloop, Patricia",Patricia,,Sloop,,Democratic,615
+Sedgwick,WICHITA PRECINCT 208,State House,88,"Sloop, Patricia",Patricia,,Sloop,,Democratic,185
+Sedgwick,WICHITA PRECINCT 209,State House,88,"Sloop, Patricia",Patricia,,Sloop,,Democratic,494
+Sedgwick,WICHITA PRECINCT 210,State House,88,"Sloop, Patricia",Patricia,,Sloop,,Democratic,553
+Sedgwick,WICHITA PRECINCT 225,State House,88,"Sloop, Patricia",Patricia,,Sloop,,Democratic,603
+Sedgwick,WICHITA PRECINCT 231,State House,88,"Sloop, Patricia",Patricia,,Sloop,,Democratic,289
+Sedgwick,WICHITA PRECINCT 235,State House,88,"Sloop, Patricia",Patricia,,Sloop,,Democratic,179
+Sedgwick,WICHITA PRECINCT 309,State House,88,"Sloop, Patricia",Patricia,,Sloop,,Democratic,558
+Sedgwick,WICHITA PRECINCT 320,State House,88,"Sloop, Patricia",Patricia,,Sloop,,Democratic,76
+Sedgwick,MINNEHA PRECINCT 09,State House,88,"Sloop, Patricia",Patricia,,Sloop,,Democratic,85
+Sedgwick,MINNEHA PRECINCT 12,State House,88,"Sloop, Patricia",Patricia,,Sloop,,Democratic,30
+Sedgwick,WICHITA PRECINCT 112,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,279
+Sedgwick,WICHITA PRECINCT 117,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,57
+Sedgwick,WICHITA PRECINCT 118,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,125
+Sedgwick,WICHITA PRECINCT 119,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,211
+Sedgwick,WICHITA PRECINCT 120,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,256
+Sedgwick,WICHITA PRECINCT 123,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,52
+Sedgwick,WICHITA PRECINCT 126,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,107
+Sedgwick,WICHITA PRECINCT 127,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,123
+Sedgwick,WICHITA PRECINCT 131,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,6
+Sedgwick,WICHITA PRECINCT 132,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,6
+Sedgwick,BEL AIRE PRECINCT 01,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,754
+Sedgwick,BEL AIRE PRECINCT 02,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,592
+Sedgwick,KECHI PRECINCT 01,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,4
+Sedgwick,KECHI PRECINCT 08,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,10
+Sedgwick,PARK CITY WARD 02 PRECINCT 02,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,4
+Sedgwick,PARK CITY WARD 04 PRECINCT 03,State House,89,"Banks, Emmanuel",Emmanuel,,Banks,,Republican,119
+Sedgwick,WICHITA PRECINCT 112,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,723
+Sedgwick,WICHITA PRECINCT 117,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,892
+Sedgwick,WICHITA PRECINCT 118,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,892
+Sedgwick,WICHITA PRECINCT 119,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,616
+Sedgwick,WICHITA PRECINCT 120,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,529
+Sedgwick,WICHITA PRECINCT 123,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,46
+Sedgwick,WICHITA PRECINCT 126,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,82
+Sedgwick,WICHITA PRECINCT 127,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,85
+Sedgwick,WICHITA PRECINCT 131,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,4
+Sedgwick,WICHITA PRECINCT 132,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,12
+Sedgwick,BEL AIRE PRECINCT 01,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,463
+Sedgwick,BEL AIRE PRECINCT 02,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,465
+Sedgwick,KECHI PRECINCT 01,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,3
+Sedgwick,KECHI PRECINCT 08,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,2
+Sedgwick,PARK CITY WARD 02 PRECINCT 02,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,2
+Sedgwick,PARK CITY WARD 04 PRECINCT 03,State House,89,"Houston, Roderick",Roderick,,Houston,,Democratic,102
+Sedgwick,WICHITA PRECINCT 527,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,845
+Sedgwick,EAGLE,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,303
+Sedgwick,GRANT PRECINCT 01,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,399
+Sedgwick,GRANT PRECINCT 02,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,160
+Sedgwick,GREELEY,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,324
+Sedgwick,LINCOLN,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,193
+Sedgwick,PARK PRECINCT 05,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,882
+Sedgwick,PARK CITY WARD 01 PRECINCT 03,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,124
+Sedgwick,SHERMAN,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,563
+Sedgwick,UNION PRECINCT 01,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,821
+Sedgwick,UNION PRECINCT 02,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,64
+Sedgwick,VALLEY CENTER TOWNSHIP,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,335
+Sedgwick,VALLEY CENTER WARD 01 PRECINCT 01,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,583
+Sedgwick,VALLEY CENTER WARD 02 PRECINCT 01,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,529
+Sedgwick,VALLEY CENTER WARD 03 PRECINCT 01,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,515
+Sedgwick,VALLEY CENTER WARD 04 PRECINCT 01,State House,90,"Huebert, Steve",Steve,,Huebert,,Republican,410
+Sedgwick,WICHITA PRECINCT 527,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,360
+Sedgwick,EAGLE,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,123
+Sedgwick,GRANT PRECINCT 01,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,76
+Sedgwick,GRANT PRECINCT 02,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,40
+Sedgwick,GREELEY,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,98
+Sedgwick,LINCOLN,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,57
+Sedgwick,PARK PRECINCT 05,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,356
+Sedgwick,PARK CITY WARD 01 PRECINCT 03,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,44
+Sedgwick,SHERMAN,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,129
+Sedgwick,UNION PRECINCT 01,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,118
+Sedgwick,UNION PRECINCT 02,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,11
+Sedgwick,VALLEY CENTER TOWNSHIP,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,106
+Sedgwick,VALLEY CENTER WARD 01 PRECINCT 01,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,141
+Sedgwick,VALLEY CENTER WARD 02 PRECINCT 01,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,170
+Sedgwick,VALLEY CENTER WARD 03 PRECINCT 01,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,116
+Sedgwick,VALLEY CENTER WARD 04 PRECINCT 01,State House,90,"Matthews, Merry",Merry,,Matthews,,Democratic,110
+Sedgwick,WICHITA PRECINCT 512,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,517
+Sedgwick,WICHITA PRECINCT 618,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,171
+Sedgwick,WICHITA PRECINCT 620,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,224
+Sedgwick,WICHITA PRECINCT 621,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,6
+Sedgwick,WICHITA PRECINCT 622,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,134
+Sedgwick,WICHITA PRECINCT 623,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,292
+Sedgwick,WICHITA PRECINCT 628,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,179
+Sedgwick,KECHI PRECINCT 03,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,260
+Sedgwick,KECHI PRECINCT 04,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,11
+Sedgwick,KECHI PRECINCT 07,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,7
+Sedgwick,PAYNE PRECINCT 01,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,57
+Sedgwick,PAYNE PRECINCT 02,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,49
+Sedgwick,PARK CITY WARD 01 PRECINCT 01,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,156
+Sedgwick,PARK CITY WARD 01 PRECINCT 02,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,33
+Sedgwick,PARK CITY WARD 02 PRECINCT 01,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,238
+Sedgwick,PARK CITY WARD 03 PRECINCT 01,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,175
+Sedgwick,PARK CITY WARD 04 PRECINCT 01,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,125
+Sedgwick,VALLEY CENTER WARD 03 PRECINCT 02,State House,91,"Delvaux, Katelyn",Katelyn,,Delvaux,,Democratic,58
+Sedgwick,WICHITA PRECINCT 512,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,1552
+Sedgwick,WICHITA PRECINCT 618,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,238
+Sedgwick,WICHITA PRECINCT 620,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,335
+Sedgwick,WICHITA PRECINCT 621,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,14
+Sedgwick,WICHITA PRECINCT 622,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,415
+Sedgwick,WICHITA PRECINCT 623,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,649
+Sedgwick,WICHITA PRECINCT 628,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,439
+Sedgwick,KECHI PRECINCT 03,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,529
+Sedgwick,KECHI PRECINCT 04,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,24
+Sedgwick,KECHI PRECINCT 07,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,14
+Sedgwick,PAYNE PRECINCT 01,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,185
+Sedgwick,PAYNE PRECINCT 02,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,98
+Sedgwick,PARK CITY WARD 01 PRECINCT 01,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,324
+Sedgwick,PARK CITY WARD 01 PRECINCT 02,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,64
+Sedgwick,PARK CITY WARD 02 PRECINCT 01,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,463
+Sedgwick,PARK CITY WARD 03 PRECINCT 01,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,244
+Sedgwick,PARK CITY WARD 04 PRECINCT 01,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,202
+Sedgwick,VALLEY CENTER WARD 03 PRECINCT 02,State House,91,"Suellentrop, Gene",Gene,,Suellentrop,,Republican,160
+Sedgwick,WICHITA PRECINCT 606,State House,92,"Dillmore, Nile",Nile,,Dillmore,,Democratic,163
+Sedgwick,WICHITA PRECINCT 607,State House,92,"Dillmore, Nile",Nile,,Dillmore,,Democratic,871
+Sedgwick,WICHITA PRECINCT 608,State House,92,"Dillmore, Nile",Nile,,Dillmore,,Democratic,589
+Sedgwick,WICHITA PRECINCT 609,State House,92,"Dillmore, Nile",Nile,,Dillmore,,Democratic,952
+Sedgwick,WICHITA PRECINCT 610,State House,92,"Dillmore, Nile",Nile,,Dillmore,,Democratic,523
+Sedgwick,WICHITA PRECINCT 611,State House,92,"Dillmore, Nile",Nile,,Dillmore,,Democratic,295
+Sedgwick,WICHITA PRECINCT 613,State House,92,"Dillmore, Nile",Nile,,Dillmore,,Democratic,533
+Sedgwick,WICHITA PRECINCT 619,State House,92,"Dillmore, Nile",Nile,,Dillmore,,Democratic,550
+Sedgwick,WICHITA PRECINCT 606,State House,92,"Landwehr, Brenda",Brenda,,Landwehr,,Republican,173
+Sedgwick,WICHITA PRECINCT 607,State House,92,"Landwehr, Brenda",Brenda,,Landwehr,,Republican,445
+Sedgwick,WICHITA PRECINCT 608,State House,92,"Landwehr, Brenda",Brenda,,Landwehr,,Republican,220
+Sedgwick,WICHITA PRECINCT 609,State House,92,"Landwehr, Brenda",Brenda,,Landwehr,,Republican,590
+Sedgwick,WICHITA PRECINCT 610,State House,92,"Landwehr, Brenda",Brenda,,Landwehr,,Republican,636
+Sedgwick,WICHITA PRECINCT 611,State House,92,"Landwehr, Brenda",Brenda,,Landwehr,,Republican,317
+Sedgwick,WICHITA PRECINCT 613,State House,92,"Landwehr, Brenda",Brenda,,Landwehr,,Republican,591
+Sedgwick,WICHITA PRECINCT 619,State House,92,"Landwehr, Brenda",Brenda,,Landwehr,,Republican,581

--- a/2012/20121106__ks__general__seward__precinct.csv
+++ b/2012/20121106__ks__general__seward__precinct.csv
@@ -1,0 +1,627 @@
+county,precinct,office,district,party,candidate,votes,vtd
+SEWARD,Fargo Township 1,Kansas House of Representatives,125,Republican,"Petty, Reid",104,000010
+SEWARD,Fargo Township 2,Kansas House of Representatives,125,Republican,"Petty, Reid",28,000020
+SEWARD,Fargo Township 3,Kansas House of Representatives,125,Republican,"Petty, Reid",22,000030
+SEWARD,Fargo Township 4,Kansas House of Representatives,125,Republican,"Petty, Reid",17,000040
+SEWARD,Liberal Township 1,Kansas House of Representatives,125,Republican,"Petty, Reid",48,00005A
+SEWARD,Liberal Township 1 Exclave,Kansas House of Representatives,125,Republican,"Petty, Reid",0,00005B
+SEWARD,Liberal Township 2,Kansas House of Representatives,125,Republican,"Petty, Reid",36,000060
+SEWARD,Liberal Township 3,Kansas House of Representatives,125,Republican,"Petty, Reid",21,000070
+SEWARD,Liberal Township 4,Kansas House of Representatives,125,Republican,"Petty, Reid",27,00008A
+SEWARD,Liberal Township 4 Exclave,Kansas House of Representatives,125,Republican,"Petty, Reid",0,00008B
+SEWARD,Liberal Township 5,Kansas House of Representatives,125,Republican,"Petty, Reid",20,000090
+SEWARD,Liberal Ward 1 Precinct 1,Kansas House of Representatives,125,Republican,"Petty, Reid",195,000100
+SEWARD,Liberal Ward 1 Precinct 2,Kansas House of Representatives,125,Republican,"Petty, Reid",223,000110
+SEWARD,Liberal Ward 1 Precinct 3,Kansas House of Representatives,125,Republican,"Petty, Reid",178,000120
+SEWARD,Liberal Ward 2,Kansas House of Representatives,125,Republican,"Petty, Reid",209,000130
+SEWARD,Liberal Ward 3,Kansas House of Representatives,125,Republican,"Petty, Reid",153,000140
+SEWARD,Liberal Ward 4,Kansas House of Representatives,125,Republican,"Petty, Reid",211,000150
+SEWARD,Liberal Ward 5,Kansas House of Representatives,125,Republican,"Petty, Reid",128,000160
+SEWARD,Liberal Ward 6 Precinct 1,Kansas House of Representatives,125,Republican,"Petty, Reid",354,000170
+SEWARD,Liberal Ward 6 Precinct 2,Kansas House of Representatives,125,Republican,"Petty, Reid",261,000180
+SEWARD,Seward Township 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",24,000190
+SEWARD,Seward Township 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",16,000200
+SEWARD,Seward Township 3,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",18,000210
+SEWARD,Kismet City,Kansas House of Representatives,125,Republican,"Petty, Reid",18,300010
+SEWARD,ADVANCE VOTES,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",26,900010
+SEWARD,PROVISIONAL VOTES,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",0,900020
+SEWARD,ADVANCE VOTES HOUSE125,Kansas House of Representatives,125,Republican,"Petty, Reid",1329,900030
+SEWARD,PROVISIONAL VOTES HOUSE125,Kansas House of Representatives,125,Republican,"Petty, Reid",153,900040
+SEWARD,Fargo Township 1,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",1,000010
+SEWARD,Fargo Township 1,Kansas Senate,38,Republican,"Love, Garrett",29,000010
+SEWARD,Fargo Township 2,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",0,000020
+SEWARD,Fargo Township 2,Kansas Senate,38,Republican,"Love, Garrett",24,000020
+SEWARD,Fargo Township 3,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",0,000030
+SEWARD,Fargo Township 3,Kansas Senate,38,Republican,"Love, Garrett",20,000030
+SEWARD,Fargo Township 4,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",22,000040
+SEWARD,Fargo Township 4,Kansas Senate,38,Republican,"Love, Garrett",42,000040
+SEWARD,Liberal Township 1,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",5,00005A
+SEWARD,Liberal Township 1,Kansas Senate,38,Republican,"Love, Garrett",36,00005A
+SEWARD,Liberal Township 1 Exclave,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",0,00005B
+SEWARD,Liberal Township 1 Exclave,Kansas Senate,38,Republican,"Love, Garrett",0,00005B
+SEWARD,Liberal Township 2,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",3,000060
+SEWARD,Liberal Township 2,Kansas Senate,38,Republican,"Love, Garrett",23,000060
+SEWARD,Liberal Township 3,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",3,000070
+SEWARD,Liberal Township 3,Kansas Senate,38,Republican,"Love, Garrett",29,000070
+SEWARD,Liberal Township 4,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",4,00008A
+SEWARD,Liberal Township 4,Kansas Senate,38,Republican,"Love, Garrett",19,00008A
+SEWARD,Liberal Township 4 Exclave,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",0,00008B
+SEWARD,Liberal Township 4 Exclave,Kansas Senate,38,Republican,"Love, Garrett",0,00008B
+SEWARD,Liberal Township 5,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",7,000090
+SEWARD,Liberal Township 5,Kansas Senate,38,Republican,"Love, Garrett",19,000090
+SEWARD,Liberal Ward 1 Precinct 1,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",91,000100
+SEWARD,Liberal Ward 1 Precinct 1,Kansas Senate,38,Republican,"Love, Garrett",154,000100
+SEWARD,Liberal Ward 1 Precinct 2,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",123,000110
+SEWARD,Liberal Ward 1 Precinct 2,Kansas Senate,38,Republican,"Love, Garrett",171,000110
+SEWARD,Liberal Ward 1 Precinct 3,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",77,000120
+SEWARD,Liberal Ward 1 Precinct 3,Kansas Senate,38,Republican,"Love, Garrett",142,000120
+SEWARD,Liberal Ward 2,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",73,000130
+SEWARD,Liberal Ward 2,Kansas Senate,38,Republican,"Love, Garrett",190,000130
+SEWARD,Liberal Ward 3,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",85,000140
+SEWARD,Liberal Ward 3,Kansas Senate,38,Republican,"Love, Garrett",125,000140
+SEWARD,Liberal Ward 4,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",57,000150
+SEWARD,Liberal Ward 4,Kansas Senate,38,Republican,"Love, Garrett",191,000150
+SEWARD,Liberal Ward 5,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",41,000160
+SEWARD,Liberal Ward 5,Kansas Senate,38,Republican,"Love, Garrett",114,000160
+SEWARD,Liberal Ward 6 Precinct 1,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",92,000170
+SEWARD,Liberal Ward 6 Precinct 1,Kansas Senate,38,Republican,"Love, Garrett",354,000170
+SEWARD,Liberal Ward 6 Precinct 2,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",66,000180
+SEWARD,Liberal Ward 6 Precinct 2,Kansas Senate,38,Republican,"Love, Garrett",266,000180
+SEWARD,Seward Township 1,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",4,000190
+SEWARD,Seward Township 1,Kansas Senate,38,Republican,"Love, Garrett",22,000190
+SEWARD,Seward Township 2,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",1,000200
+SEWARD,Seward Township 2,Kansas Senate,38,Republican,"Love, Garrett",17,000200
+SEWARD,Seward Township 3,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",1,000210
+SEWARD,Seward Township 3,Kansas Senate,38,Republican,"Love, Garrett",17,000210
+SEWARD,Kismet City,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",11,300010
+SEWARD,Kismet City,Kansas Senate,38,Republican,"Love, Garrett",103,300010
+SEWARD,ADVANCE VOTES,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",357,900010
+SEWARD,ADVANCE VOTES,Kansas Senate,38,Republican,"Love, Garrett",1302,900010
+SEWARD,PROVISIONAL VOTES,Kansas Senate,38,Democratic,"Dunlap, Johnny  II",72,900020
+SEWARD,PROVISIONAL VOTES,Kansas Senate,38,Republican,"Love, Garrett",124,900020
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Barnett, Andre",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Bush, Kent W",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Christensen, Will",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Goode, Virgil",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Stein, Jill E",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,Democratic,"Obama, Barack",2,000010
+SEWARD,Fargo Township 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,Republican,"Romney, Mitt",28,000010
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Barnett, Andre",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Bush, Kent W",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Christensen, Will",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Goode, Virgil",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Stein, Jill E",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,Democratic,"Obama, Barack",3,000020
+SEWARD,Fargo Township 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,Republican,"Romney, Mitt",22,000020
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Barnett, Andre",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Bush, Kent W",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Christensen, Will",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Goode, Virgil",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Stein, Jill E",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,Democratic,"Obama, Barack",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,Republican,"Romney, Mitt",20,000030
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Barnett, Andre",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Bush, Kent W",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Christensen, Will",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Goode, Virgil",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Stein, Jill E",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,Democratic,"Obama, Barack",33,000040
+SEWARD,Fargo Township 4,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+SEWARD,Fargo Township 4,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,Republican,"Romney, Mitt",38,000040
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Ayers, Avery L",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Barnett, Andre",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Bush, Kent W",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Christensen, Will",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Duncan, Richard A",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Goode, Virgil",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Knill, Dennis J",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Reed, Jill A.",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Rogers, Rick L",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Stein, Jill E",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,Democratic,"Obama, Barack",7,00005A
+SEWARD,Liberal Township 1,President / Vice President,,Libertarian,"Johnson, Gary",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,Reform,"Baldwin, Chuck",1,00005A
+SEWARD,Liberal Township 1,President / Vice President,,Republican,"Romney, Mitt",34,00005A
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00005B
+SEWARD,Liberal Township 1 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00005B
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Barnett, Andre",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Bush, Kent W",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Christensen, Will",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Goode, Virgil",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Stein, Jill E",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,Democratic,"Obama, Barack",3,000060
+SEWARD,Liberal Township 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+SEWARD,Liberal Township 2,President / Vice President,,Republican,"Romney, Mitt",23,000060
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Barnett, Andre",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Bush, Kent W",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Christensen, Will",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Goode, Virgil",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Stein, Jill E",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,Democratic,"Obama, Barack",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,Republican,"Romney, Mitt",34,000070
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Ayers, Avery L",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Barnett, Andre",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Barr, Roseanne C",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Bush, Kent W",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Christensen, Will",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Duncan, Richard A",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Goode, Virgil",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Hoefling, Tom",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Knill, Dennis J",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Reed, Jill A.",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Rogers, Rick L",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Stein, Jill E",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Thorne, Kevin M",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Warner, Gerald L.",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,Democratic,"Obama, Barack",1,00008A
+SEWARD,Liberal Township 4,President / Vice President,,Libertarian,"Johnson, Gary",1,00008A
+SEWARD,Liberal Township 4,President / Vice President,,Reform,"Baldwin, Chuck",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,Republican,"Romney, Mitt",22,00008A
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00008B
+SEWARD,Liberal Township 4 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00008B
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Barnett, Andre",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Bush, Kent W",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Christensen, Will",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Goode, Virgil",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Stein, Jill E",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,Democratic,"Obama, Barack",5,000090
+SEWARD,Liberal Township 5,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,Republican,"Romney, Mitt",21,000090
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",105,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",162,000100
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",147,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",5,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",168,000110
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,Democratic,"Obama, Barack",88,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",1,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,Republican,"Romney, Mitt",151,000120
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,Democratic,"Obama, Barack",87,000130
+SEWARD,Liberal Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000130
+SEWARD,Liberal Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000130
+SEWARD,Liberal Ward 2,President / Vice President,,Republican,"Romney, Mitt",198,000130
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,Democratic,"Obama, Barack",88,000140
+SEWARD,Liberal Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",9,000140
+SEWARD,Liberal Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,Republican,"Romney, Mitt",133,000140
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,Democratic,"Obama, Barack",67,000150
+SEWARD,Liberal Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",4,000150
+SEWARD,Liberal Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+SEWARD,Liberal Ward 4,President / Vice President,,Republican,"Romney, Mitt",190,000150
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Barnett, Andre",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Bush, Kent W",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Christensen, Will",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Goode, Virgil",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Stein, Jill E",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,Democratic,"Obama, Barack",44,000160
+SEWARD,Liberal Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",4,000160
+SEWARD,Liberal Ward 5,President / Vice President,,Reform,"Baldwin, Chuck",2,000160
+SEWARD,Liberal Ward 5,President / Vice President,,Republican,"Romney, Mitt",120,000160
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",95,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",371,000170
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",75,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",2,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",275,000180
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Barnett, Andre",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Bush, Kent W",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Christensen, Will",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Goode, Virgil",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Stein, Jill E",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+SEWARD,Seward Township 1,President / Vice President,,Democratic,"Obama, Barack",4,000190
+SEWARD,Seward Township 1,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+SEWARD,Seward Township 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+SEWARD,Seward Township 1,President / Vice President,,Republican,"Romney, Mitt",21,000190
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Barnett, Andre",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Bush, Kent W",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Christensen, Will",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Goode, Virgil",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Stein, Jill E",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+SEWARD,Seward Township 2,President / Vice President,,Democratic,"Obama, Barack",3,000200
+SEWARD,Seward Township 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+SEWARD,Seward Township 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+SEWARD,Seward Township 2,President / Vice President,,Republican,"Romney, Mitt",16,000200
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Barnett, Andre",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Bush, Kent W",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Christensen, Will",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Goode, Virgil",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Stein, Jill E",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+SEWARD,Seward Township 3,President / Vice President,,Democratic,"Obama, Barack",0,000210
+SEWARD,Seward Township 3,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+SEWARD,Seward Township 3,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+SEWARD,Seward Township 3,President / Vice President,,Republican,"Romney, Mitt",17,000210
+SEWARD,Kismet City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Ayers, Avery L",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Barnett, Andre",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Barr, Roseanne C",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Bush, Kent W",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Christensen, Will",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Duncan, Richard A",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Goode, Virgil",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Hoefling, Tom",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Knill, Dennis J",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Reed, Jill A.",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Rogers, Rick L",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Stein, Jill E",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Thorne, Kevin M",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,300010
+SEWARD,Kismet City,President / Vice President,,write - in,"Warner, Gerald L.",0,300010
+SEWARD,Kismet City,President / Vice President,,Democratic,"Obama, Barack",19,300010
+SEWARD,Kismet City,President / Vice President,,Libertarian,"Johnson, Gary",1,300010
+SEWARD,Kismet City,President / Vice President,,Reform,"Baldwin, Chuck",1,300010
+SEWARD,Kismet City,President / Vice President,,Republican,"Romney, Mitt",98,300010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Barnett, Andre",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Bush, Kent W",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Christensen, Will",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Goode, Virgil",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Stein, Jill E",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,Democratic,"Obama, Barack",517,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,Libertarian,"Johnson, Gary",13,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,Reform,"Baldwin, Chuck",3,900010
+SEWARD,ADVANCE VOTES,President / Vice President,,Republican,"Romney, Mitt",1333,900010
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Barnett, Andre",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Bush, Kent W",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Christensen, Will",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Goode, Virgil",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Stein, Jill E",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,Democratic,"Obama, Barack",97,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,Libertarian,"Johnson, Gary",2,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+SEWARD,PROVISIONAL VOTES,President / Vice President,,Republican,"Romney, Mitt",122,900020
+SEWARD,Fargo Township 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000010
+SEWARD,Fargo Township 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000020
+SEWARD,Fargo Township 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000030
+SEWARD,Fargo Township 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",48,000040
+SEWARD,Liberal Township 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,00005A
+SEWARD,Liberal Township 1 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00005B
+SEWARD,Liberal Township 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000060
+SEWARD,Liberal Township 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000070
+SEWARD,Liberal Township 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,00008A
+SEWARD,Liberal Township 4 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00008B
+SEWARD,Liberal Township 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000090
+SEWARD,Liberal Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",200,000100
+SEWARD,Liberal Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",228,000110
+SEWARD,Liberal Ward 1 Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",181,000120
+SEWARD,Liberal Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",228,000130
+SEWARD,Liberal Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",156,000140
+SEWARD,Liberal Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",216,000150
+SEWARD,Liberal Ward 5,United States House of Representatives,1,Republican,"Huelskamp, Tim",142,000160
+SEWARD,Liberal Ward 6 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",390,000170
+SEWARD,Liberal Ward 6 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",298,000180
+SEWARD,Seward Township 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",23,000190
+SEWARD,Seward Township 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",18,000200
+SEWARD,Seward Township 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000210
+SEWARD,Kismet City,United States House of Representatives,1,Republican,"Huelskamp, Tim",102,300010
+SEWARD,ADVANCE VOTES,United States House of Representatives,1,Republican,"Huelskamp, Tim",1411,900010
+SEWARD,PROVISIONAL VOTES,United States House of Representatives,1,Republican,"Huelskamp, Tim",165,900020

--- a/2012/20121106__ks__general__shawnee__precinct.csv
+++ b/2012/20121106__ks__general__shawnee__precinct.csv
@@ -1,0 +1,2443 @@
+county,precinct,office,district,candidate,candidate_first,candidate_middle,candidate_last,candidate_suffix,party,votes
+Shawnee,ALDERSGATE,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,119
+Shawnee,APACE,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,161
+Shawnee,BUFFALO,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,135
+Shawnee,CENTRAL MISSION,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,215
+Shawnee,CENTRAL PAULINE,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,39
+Shawnee,CHEYENNE,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,201
+Shawnee,CITY OF AUBURN,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,182
+Shawnee,CULLEN,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,207
+Shawnee,DEER CREEK,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,5
+Shawnee,DOVER,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,136
+Shawnee,EAST PECK,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,125
+Shawnee,EAST ROSSVILLE,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,141
+Shawnee,EAST SILVER LAKE,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,243
+Shawnee,EAST SOLDIER,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,220
+Shawnee,EAST WICHITA,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,362
+Shawnee,ELMONT,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,253
+Shawnee,FORBES,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,20
+Shawnee,FOX,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,202
+Shawnee,GAILLARDIA,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,158
+Shawnee,GROVE,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,102
+Shawnee,INDIAN HILLS,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,181
+Shawnee,INDIANOLA,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,177
+Shawnee,IROQUIS,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,201
+Shawnee,KAW,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,231
+Shawnee,KILMER,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,51
+Shawnee,KINGSTON,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,42
+Shawnee,KIOWA,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,293
+Shawnee,KIRO,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,182
+Shawnee,LITTLE MUDDY CREEK,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,110
+Shawnee,MEADOWLARK,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,195
+Shawnee,MESSHOSS CREEK,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,94
+Shawnee,MONTARA,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,189
+Shawnee,NE MONMOUTH,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,209
+Shawnee,NW MONMOUTH,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,225
+Shawnee,NORTH MISSION,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,37
+Shawnee,NORTH TECUMSEH,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,210
+Shawnee,PAULINE,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,99
+Shawnee,PAWNEE,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,198
+Shawnee,PECK,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,152
+Shawnee,PONCA,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,151
+Shawnee,POTTAWATOMIE,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,222
+Shawnee,ROCHESTER,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,177
+Shawnee,S MONMOUTH,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,243
+Shawnee,SAC,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,217
+Shawnee,SHERMAN,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,168
+Shawnee,SHERWOOD,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,161
+Shawnee,SIOUX,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,180
+Shawnee,SOUTH MISSION,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,112
+Shawnee,SOUTH SHERWOOD,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,119
+Shawnee,SOUTH TECUMSEH,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,196
+Shawnee,STINSON CREEK,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,77
+Shawnee,SUNFLOWER,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,216
+Shawnee,TOPEKA WARD 01 PRECINCT 01,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,156
+Shawnee,TOPEKA WARD 01 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,187
+Shawnee,TOPEKA WARD 01 PRECINCT 03,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,125
+Shawnee,TOPEKA WARD 01 PRECINCT 04,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,181
+Shawnee,TOPEKA WARD 01 PRECINCT 05,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,229
+Shawnee,TOPEKA WARD 01 PRECINCT 06,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,231
+Shawnee,TOPEKA WARD 02 PRECINCT 01,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,175
+Shawnee,TOPEKA WARD 02 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,155
+Shawnee,TOPEKA WARD 02 PRECINCT 03,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,176
+Shawnee,TOPEKA WARD 02 PRECINCT 04,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,178
+Shawnee,TOPEKA WARD 02 PRECINCT 05,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,157
+Shawnee,TOPEKA WARD 02 PRECINCT 06,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,180
+Shawnee,TOPEKA WARD 02 PRECINCT 07,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,123
+Shawnee,TOPEKA WARD 02 PRECINCT 08,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,164
+Shawnee,TOPEKA WARD 02 PRECINCT 09,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,202
+Shawnee,TOPEKA WARD 02 PRECINCT 10,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,266
+Shawnee,TOPEKA WARD 02 PRECINCT 11,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,129
+Shawnee,TOPEKA WARD 03 PRECINCT 01,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,187
+Shawnee,TOPEKA WARD 03 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,177
+Shawnee,TOPEKA WARD 03 PRECINCT 03,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,147
+Shawnee,TOPEKA WARD 03 PRECINCT 04,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,170
+Shawnee,TOPEKA WARD 03 PRECINCT 05,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,152
+Shawnee,TOPEKA WARD 03 PRECINCT 06,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,137
+Shawnee,TOPEKA WARD 03 PRECINCT 07,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,192
+Shawnee,TOPEKA WARD 03 PRECINCT 08,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,184
+Shawnee,TOPEKA WARD 03 PRECINCT 09,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,205
+Shawnee,TOPEKA WARD 03 PRECINCT 10,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,21
+Shawnee,TOPEKA WARD 04 PRECINCT 01,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,198
+Shawnee,TOPEKA WARD 04 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,271
+Shawnee,TOPEKA WARD 04 PRECINCT 03,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,180
+Shawnee,TOPEKA WARD 04 PRECINCT 04,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,334
+Shawnee,TOPEKA WARD 04 PRECINCT 06,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,227
+Shawnee,TOPEKA WARD 04 PRECINCT 07,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,172
+Shawnee,TOPEKA WARD 04 PRECINCT 08,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,192
+Shawnee,TOPEKA WARD 04 PRECINCT 09,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,227
+Shawnee,TOPEKA WARD 04 PRECINCT 10,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,280
+Shawnee,TOPEKA WARD 04 PRECINCT 11,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,67
+Shawnee,TOPEKA WARD 04 PRECINCT 14,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,23
+Shawnee,TOPEKA WARD 04 PRECINCT 15,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,123
+Shawnee,TOPEKA WARD 05 PRECINCT 01,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,184
+Shawnee,TOPEKA WARD 05 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,197
+Shawnee,TOPEKA WARD 05 PRECINCT 03,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,183
+Shawnee,TOPEKA WARD 05 PRECINCT 04,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,191
+Shawnee,TOPEKA WARD 05 PRECINCT 05,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,223
+Shawnee,TOPEKA WARD 05 PRECINCT 06,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,180
+Shawnee,TOPEKA WARD 05 PRECINCT 07,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,204
+Shawnee,TOPEKA WARD 05 PRECINCT 08,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,157
+Shawnee,TOPEKA WARD 05 PRECINCT 09,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,241
+Shawnee,TOPEKA WARD 05 PRECINCT 10,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,249
+Shawnee,TOPEKA WARD 05 PRECINCT 11,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,203
+Shawnee,TOPEKA WARD 05 PRECINCT 14,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,104
+Shawnee,TOPEKA WARD 05 PRECINCT 15,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,21
+Shawnee,TOPEKA WARD 05 PRECINCT 91,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,60
+Shawnee,TOPEKA WARD 06 PRECINCT 01,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,219
+Shawnee,TOPEKA WARD 06 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,201
+Shawnee,TOPEKA WARD 06 PRECINCT 03,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,152
+Shawnee,TOPEKA WARD 06 PRECINCT 04,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,191
+Shawnee,TOPEKA WARD 06 PRECINCT 05,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,210
+Shawnee,TOPEKA WARD 06 PRECINCT 06,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,154
+Shawnee,TOPEKA WARD 06 PRECINCT 07,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,119
+Shawnee,TOPEKA WARD 06 PRECINCT 08,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,274
+Shawnee,TOPEKA WARD 06 PRECINCT 09,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,350
+Shawnee,TOPEKA WARD 07 PRECINCT 01,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,229
+Shawnee,TOPEKA WARD 07 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,196
+Shawnee,TOPEKA WARD 07 PRECINCT 03,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,199
+Shawnee,TOPEKA WARD 07 PRECINCT 04,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,200
+Shawnee,TOPEKA WARD 07 PRECINCT 05,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,146
+Shawnee,TOPEKA WARD 07 PRECINCT 06,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,131
+Shawnee,TOPEKA WARD 07 PRECINCT 07,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,164
+Shawnee,TOPEKA WARD 07 PRECINCT 09,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,137
+Shawnee,TOPEKA WARD 07 PRECINCT 10,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,157
+Shawnee,TOPEKA WARD 07 PRECINCT 11,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,248
+Shawnee,TOPEKA WARD 08 PRECINCT 01,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,204
+Shawnee,TOPEKA WARD 08 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,229
+Shawnee,TOPEKA WARD 08 PRECINCT 03,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,268
+Shawnee,TOPEKA WARD 08 PRECINCT 04,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,231
+Shawnee,TOPEKA WARD 08 PRECINCT 05,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,289
+Shawnee,TOPEKA WARD 08 PRECINCT 06,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,134
+Shawnee,TOPEKA WARD 08 PRECINCT 07,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,213
+Shawnee,TOPEKA WARD 08 PRECINCT 08,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,184
+Shawnee,TOPEKA WARD 08 PRECINCT 09,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,203
+Shawnee,TOPEKA WARD 08 PRECINCT 10,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,145
+Shawnee,TOPEKA WARD 08 PRECINCT 11,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,203
+Shawnee,TOPEKA WARD 09 PRECINCT 01,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,52
+Shawnee,TOPEKA WARD 09 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,148
+Shawnee,TOPEKA WARD 09 PRECINCT 03,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,258
+Shawnee,TOPEKA WARD 09 PRECINCT 04,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,216
+Shawnee,TOPEKA WARD 09 PRECINCT 05,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,218
+Shawnee,TOPEKA WARD 09 PRECINCT 06,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,210
+Shawnee,TOPEKA WARD 09 PRECINCT 08,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,305
+Shawnee,TOPEKA WARD 09 PRECINCT 09,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,138
+Shawnee,TOPEKA WARD 09 PRECINCT 10,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,314
+Shawnee,TOPEKA WARD 09 PRECINCT 11,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,162
+Shawnee,TOPEKA WARD 09 PRECINCT 12,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,119
+Shawnee,TOPEKA WARD 10 PRECINCT 01,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,225
+Shawnee,TOPEKA WARD 10 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,156
+Shawnee,TOPEKA WARD 10 PRECINCT 03,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,255
+Shawnee,TOPEKA WARD 10 PRECINCT 04,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,191
+Shawnee,TOPEKA WARD 10 PRECINCT 05,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,167
+Shawnee,TOPEKA WARD 10 PRECINCT 06,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,139
+Shawnee,TOPEKA WARD 10 PRECINCT 07,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,169
+Shawnee,TOPEKA WARD 10 PRECINCT 08,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,174
+Shawnee,TOPEKA WARD 10 PRECINCT 09,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,138
+Shawnee,TOPEKA WARD 10 PRECINCT 10,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,209
+Shawnee,TOPEKA WARD 10 PRECINCT 11,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,267
+Shawnee,TOPEKA WARD 10 PRECINCT 14,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,192
+Shawnee,TOPEKA WARD 11 PRECINCT 01,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,140
+Shawnee,TOPEKA WARD 11 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,182
+Shawnee,TOPEKA WARD 11 PRECINCT 03,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,150
+Shawnee,TOPEKA WARD 11 PRECINCT 04,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,254
+Shawnee,TOPEKA WARD 11 PRECINCT 05,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,203
+Shawnee,TOPEKA WARD 11 PRECINCT 06,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,197
+Shawnee,TOPEKA WARD 11 PRECINCT 07,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,184
+Shawnee,TOPEKA WARD 11 PRECINCT 08,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,164
+Shawnee,TOPEKA WARD 11 PRECINCT 09,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,188
+Shawnee,TOPEKA WARD 11 PRECINCT 10,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,157
+Shawnee,TOPEKA WARD 12 PRECINCT 01,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,219
+Shawnee,TOPEKA WARD 12 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,162
+Shawnee,TOPEKA WARD 12 PRECINCT 03,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,179
+Shawnee,TOPEKA WARD 12 PRECINCT 04,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,217
+Shawnee,TOPEKA WARD 12 PRECINCT 05,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,166
+Shawnee,TOPEKA WARD 12 PRECINCT 06,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,248
+Shawnee,TOPEKA WARD 12 PRECINCT 07,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,242
+Shawnee,TOPEKA WARD 12 PRECINCT 08,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,265
+Shawnee,TOPEKA WARD 12 PRECINCT 09,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,347
+Shawnee,TOPEKA WARD 12 PRECINCT 11,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,271
+Shawnee,TOPEKA WARD 12 PRECINCT 13,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,163
+Shawnee,TOPEKA WARD 12 PRECINCT 14,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,161
+Shawnee,TOPEKA WARD 12 PRECINCT 15,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,272
+Shawnee,TOPEKA WARD 12 PRECINCT 16,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,328
+Shawnee,TOPEKA WARD 12 PRECINCT 19,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,33
+Shawnee,TOPEKA WARD 12 PRECINCT 20,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,232
+Shawnee,TOPEKA WARD 12 PRECINCT 31,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,125
+Shawnee,TOPEKA WARD 13 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,77
+Shawnee,TOPEKA WARD 13 PRECINCT 05,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,11
+Shawnee,TOPEKA WARD 13 PRECINCT 06,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,18
+Shawnee,TOPEKA WARD 13 PRECINCT 09,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,22
+Shawnee,TOPEKA WARD 13 PRECINCT 12,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,217
+Shawnee,TOPEKA WARD 13 PRECINCT 21,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,52
+Shawnee,TOPEKA WARD 13 PRECINCT 22,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,28
+Shawnee,TOPEKA WARD 13 PRECINCT 30,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,64
+Shawnee,TOPEKA WARD 14 PRECINCT 01,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,301
+Shawnee,TOPEKA WARD 14 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,231
+Shawnee,TOPEKA WARD 14 PRECINCT 03,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,115
+Shawnee,TOPEKA WARD 14 PRECINCT 04,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,204
+Shawnee,TOPEKA WARD 14 PRECINCT 05,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,94
+Shawnee,TOPEKA WARD 15 PRECINCT 01,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,276
+Shawnee,TOPEKA WARD 15 PRECINCT 02,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,185
+Shawnee,TOPEKA WARD 15 PRECINCT 03,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,13
+Shawnee,VACQUERO,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,154
+Shawnee,VERBENA,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,24
+Shawnee,WAKARUSA,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,155
+Shawnee,WASHBURN,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,147
+Shawnee,WEST POTTER,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,21
+Shawnee,WEST ROSSVILLE,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,96
+Shawnee,WEST SILVER LAKE,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,161
+Shawnee,WEST WICHITA,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,94
+Shawnee,WHITFIELD,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,171
+Shawnee,WILLARD,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,127
+Shawnee,YORK,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,195
+Shawnee,YORK OUTER,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,15
+Shawnee,YUCCA,President,,"Obama, Barack  ",Barack,,Obama,,Democratic,38
+Shawnee,ALDERSGATE,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,0
+Shawnee,APACE,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,BUFFALO,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,CENTRAL MISSION,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,12
+Shawnee,CENTRAL PAULINE,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,CHEYENNE,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,10
+Shawnee,CITY OF AUBURN,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,CULLEN,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,20
+Shawnee,DEER CREEK,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,DOVER,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,EAST PECK,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,EAST ROSSVILLE,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,13
+Shawnee,EAST SILVER LAKE,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,EAST SOLDIER,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,14
+Shawnee,EAST WICHITA,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,12
+Shawnee,ELMONT,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,12
+Shawnee,FORBES,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,0
+Shawnee,FOX,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,GAILLARDIA,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,8
+Shawnee,GROVE,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,INDIAN HILLS,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,10
+Shawnee,INDIANOLA,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,IROQUIS,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,KAW,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,KILMER,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,KINGSTON,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,1
+Shawnee,KIOWA,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,10
+Shawnee,KIRO,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,LITTLE MUDDY CREEK,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,MEADOWLARK,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,12
+Shawnee,MESSHOSS CREEK,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,MONTARA,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,NE MONMOUTH,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,NW MONMOUTH,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,11
+Shawnee,NORTH MISSION,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,NORTH TECUMSEH,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,11
+Shawnee,PAULINE,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,PAWNEE,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,12
+Shawnee,PECK,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,14
+Shawnee,PONCA,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,POTTAWATOMIE,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,ROCHESTER,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,S MONMOUTH,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,10
+Shawnee,SAC,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,SHERMAN,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,11
+Shawnee,SHERWOOD,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,SIOUX,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,SOUTH MISSION,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,SOUTH SHERWOOD,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,SOUTH TECUMSEH,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,10
+Shawnee,STINSON CREEK,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,0
+Shawnee,SUNFLOWER,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 01 PRECINCT 01,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 01 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 01 PRECINCT 03,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 01 PRECINCT 04,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,8
+Shawnee,TOPEKA WARD 01 PRECINCT 05,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,13
+Shawnee,TOPEKA WARD 01 PRECINCT 06,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,TOPEKA WARD 02 PRECINCT 01,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,TOPEKA WARD 02 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 02 PRECINCT 03,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,TOPEKA WARD 02 PRECINCT 04,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,TOPEKA WARD 02 PRECINCT 05,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 02 PRECINCT 06,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 02 PRECINCT 07,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,TOPEKA WARD 02 PRECINCT 08,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,TOPEKA WARD 02 PRECINCT 09,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,TOPEKA WARD 02 PRECINCT 10,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,TOPEKA WARD 02 PRECINCT 11,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,TOPEKA WARD 03 PRECINCT 01,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,12
+Shawnee,TOPEKA WARD 03 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,8
+Shawnee,TOPEKA WARD 03 PRECINCT 03,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,8
+Shawnee,TOPEKA WARD 03 PRECINCT 04,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,11
+Shawnee,TOPEKA WARD 03 PRECINCT 05,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 03 PRECINCT 06,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,1
+Shawnee,TOPEKA WARD 03 PRECINCT 07,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,11
+Shawnee,TOPEKA WARD 03 PRECINCT 08,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 03 PRECINCT 09,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,8
+Shawnee,TOPEKA WARD 03 PRECINCT 10,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,1
+Shawnee,TOPEKA WARD 04 PRECINCT 01,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 04 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 04 PRECINCT 03,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 04 PRECINCT 04,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,TOPEKA WARD 04 PRECINCT 06,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,10
+Shawnee,TOPEKA WARD 04 PRECINCT 07,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,TOPEKA WARD 04 PRECINCT 08,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 04 PRECINCT 09,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 04 PRECINCT 10,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,12
+Shawnee,TOPEKA WARD 04 PRECINCT 11,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,TOPEKA WARD 04 PRECINCT 14,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,0
+Shawnee,TOPEKA WARD 04 PRECINCT 15,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,1
+Shawnee,TOPEKA WARD 05 PRECINCT 01,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,TOPEKA WARD 05 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,TOPEKA WARD 05 PRECINCT 03,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 05 PRECINCT 04,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 05 PRECINCT 05,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 05 PRECINCT 06,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 05 PRECINCT 07,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,TOPEKA WARD 05 PRECINCT 08,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 05 PRECINCT 09,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 05 PRECINCT 10,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 05 PRECINCT 11,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,10
+Shawnee,TOPEKA WARD 05 PRECINCT 14,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 05 PRECINCT 15,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,0
+Shawnee,TOPEKA WARD 05 PRECINCT 91,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,1
+Shawnee,TOPEKA WARD 06 PRECINCT 01,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 06 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 06 PRECINCT 03,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,TOPEKA WARD 06 PRECINCT 04,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,TOPEKA WARD 06 PRECINCT 05,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,TOPEKA WARD 06 PRECINCT 06,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 06 PRECINCT 07,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,1
+Shawnee,TOPEKA WARD 06 PRECINCT 08,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 06 PRECINCT 09,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,12
+Shawnee,TOPEKA WARD 07 PRECINCT 01,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 07 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,10
+Shawnee,TOPEKA WARD 07 PRECINCT 03,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,13
+Shawnee,TOPEKA WARD 07 PRECINCT 04,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,TOPEKA WARD 07 PRECINCT 05,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,14
+Shawnee,TOPEKA WARD 07 PRECINCT 06,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,14
+Shawnee,TOPEKA WARD 07 PRECINCT 07,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 07 PRECINCT 09,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,TOPEKA WARD 07 PRECINCT 10,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,10
+Shawnee,TOPEKA WARD 07 PRECINCT 11,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,12
+Shawnee,TOPEKA WARD 08 PRECINCT 01,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 08 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,TOPEKA WARD 08 PRECINCT 03,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,10
+Shawnee,TOPEKA WARD 08 PRECINCT 04,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,8
+Shawnee,TOPEKA WARD 08 PRECINCT 05,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,19
+Shawnee,TOPEKA WARD 08 PRECINCT 06,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 08 PRECINCT 07,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,TOPEKA WARD 08 PRECINCT 08,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,8
+Shawnee,TOPEKA WARD 08 PRECINCT 09,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,8
+Shawnee,TOPEKA WARD 08 PRECINCT 10,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 08 PRECINCT 11,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,TOPEKA WARD 09 PRECINCT 01,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,0
+Shawnee,TOPEKA WARD 09 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,8
+Shawnee,TOPEKA WARD 09 PRECINCT 03,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,TOPEKA WARD 09 PRECINCT 04,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 09 PRECINCT 05,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,12
+Shawnee,TOPEKA WARD 09 PRECINCT 06,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,11
+Shawnee,TOPEKA WARD 09 PRECINCT 08,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 09 PRECINCT 09,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,TOPEKA WARD 09 PRECINCT 10,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 09 PRECINCT 11,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 09 PRECINCT 12,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,1
+Shawnee,TOPEKA WARD 10 PRECINCT 01,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,TOPEKA WARD 10 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 10 PRECINCT 03,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,10
+Shawnee,TOPEKA WARD 10 PRECINCT 04,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,TOPEKA WARD 10 PRECINCT 05,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,TOPEKA WARD 10 PRECINCT 06,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,TOPEKA WARD 10 PRECINCT 07,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,13
+Shawnee,TOPEKA WARD 10 PRECINCT 08,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,10
+Shawnee,TOPEKA WARD 10 PRECINCT 09,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 10 PRECINCT 10,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,TOPEKA WARD 10 PRECINCT 11,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,12
+Shawnee,TOPEKA WARD 10 PRECINCT 14,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,8
+Shawnee,TOPEKA WARD 11 PRECINCT 01,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 11 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,TOPEKA WARD 11 PRECINCT 03,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 11 PRECINCT 04,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,10
+Shawnee,TOPEKA WARD 11 PRECINCT 05,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 11 PRECINCT 06,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,TOPEKA WARD 11 PRECINCT 07,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,8
+Shawnee,TOPEKA WARD 11 PRECINCT 08,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,TOPEKA WARD 11 PRECINCT 09,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 11 PRECINCT 10,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,TOPEKA WARD 12 PRECINCT 01,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 12 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,TOPEKA WARD 12 PRECINCT 03,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,TOPEKA WARD 12 PRECINCT 04,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 12 PRECINCT 05,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,TOPEKA WARD 12 PRECINCT 06,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 12 PRECINCT 07,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,11
+Shawnee,TOPEKA WARD 12 PRECINCT 08,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,TOPEKA WARD 12 PRECINCT 09,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,12
+Shawnee,TOPEKA WARD 12 PRECINCT 11,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,14
+Shawnee,TOPEKA WARD 12 PRECINCT 13,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,8
+Shawnee,TOPEKA WARD 12 PRECINCT 14,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,TOPEKA WARD 12 PRECINCT 15,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,13
+Shawnee,TOPEKA WARD 12 PRECINCT 16,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,TOPEKA WARD 12 PRECINCT 19,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,1
+Shawnee,TOPEKA WARD 12 PRECINCT 20,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,15
+Shawnee,TOPEKA WARD 12 PRECINCT 31,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,4
+Shawnee,TOPEKA WARD 13 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,TOPEKA WARD 13 PRECINCT 05,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,0
+Shawnee,TOPEKA WARD 13 PRECINCT 06,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,1
+Shawnee,TOPEKA WARD 13 PRECINCT 09,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 13 PRECINCT 12,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,TOPEKA WARD 13 PRECINCT 21,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,1
+Shawnee,TOPEKA WARD 13 PRECINCT 22,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,1
+Shawnee,TOPEKA WARD 13 PRECINCT 30,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 14 PRECINCT 01,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,15
+Shawnee,TOPEKA WARD 14 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,TOPEKA WARD 14 PRECINCT 03,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,TOPEKA WARD 14 PRECINCT 04,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,TOPEKA WARD 14 PRECINCT 05,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,TOPEKA WARD 15 PRECINCT 01,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,12
+Shawnee,TOPEKA WARD 15 PRECINCT 02,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,7
+Shawnee,TOPEKA WARD 15 PRECINCT 03,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,0
+Shawnee,VACQUERO,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,8
+Shawnee,VERBENA,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,0
+Shawnee,WAKARUSA,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,WASHBURN,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,6
+Shawnee,WEST POTTER,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,2
+Shawnee,WEST ROSSVILLE,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,WEST SILVER LAKE,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,WEST WICHITA,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,WHITFIELD,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,15
+Shawnee,WILLARD,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,9
+Shawnee,YORK,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,5
+Shawnee,YORK OUTER,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,0
+Shawnee,YUCCA,President,,"Johnson, Gary  ",Gary,,Johnson,,Libertarian,3
+Shawnee,ALDERSGATE,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,APACE,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,5
+Shawnee,BUFFALO,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,CENTRAL MISSION,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,CENTRAL PAULINE,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,CHEYENNE,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,CITY OF AUBURN,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,CULLEN,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,DEER CREEK,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,DOVER,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,EAST PECK,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,EAST ROSSVILLE,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,5
+Shawnee,EAST SILVER LAKE,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,EAST SOLDIER,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,4
+Shawnee,EAST WICHITA,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,ELMONT,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,4
+Shawnee,FORBES,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,FOX,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,GAILLARDIA,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,GROVE,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,INDIAN HILLS,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,INDIANOLA,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,IROQUIS,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,4
+Shawnee,KAW,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,KILMER,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,KINGSTON,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,KIOWA,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,5
+Shawnee,KIRO,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,LITTLE MUDDY CREEK,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,MEADOWLARK,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,MESSHOSS CREEK,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,MONTARA,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,NE MONMOUTH,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,NW MONMOUTH,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,4
+Shawnee,NORTH MISSION,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,NORTH TECUMSEH,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,PAULINE,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,PAWNEE,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,PECK,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,PONCA,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,POTTAWATOMIE,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,ROCHESTER,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,4
+Shawnee,S MONMOUTH,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,SAC,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,SHERMAN,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,4
+Shawnee,SHERWOOD,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,SIOUX,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,SOUTH MISSION,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,SOUTH SHERWOOD,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,SOUTH TECUMSEH,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,4
+Shawnee,STINSON CREEK,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,SUNFLOWER,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 01 PRECINCT 01,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 01 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,4
+Shawnee,TOPEKA WARD 01 PRECINCT 03,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 01 PRECINCT 04,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,5
+Shawnee,TOPEKA WARD 01 PRECINCT 05,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 01 PRECINCT 06,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 02 PRECINCT 01,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,6
+Shawnee,TOPEKA WARD 02 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 02 PRECINCT 03,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 02 PRECINCT 04,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,4
+Shawnee,TOPEKA WARD 02 PRECINCT 05,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 02 PRECINCT 06,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 02 PRECINCT 07,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,5
+Shawnee,TOPEKA WARD 02 PRECINCT 08,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 02 PRECINCT 09,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 02 PRECINCT 10,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 02 PRECINCT 11,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 03 PRECINCT 01,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 03 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 03 PRECINCT 03,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 03 PRECINCT 04,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 03 PRECINCT 05,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 03 PRECINCT 06,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 03 PRECINCT 07,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 03 PRECINCT 08,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 03 PRECINCT 09,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 03 PRECINCT 10,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 04 PRECINCT 01,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 04 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 04 PRECINCT 03,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 04 PRECINCT 04,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 04 PRECINCT 06,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,5
+Shawnee,TOPEKA WARD 04 PRECINCT 07,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 04 PRECINCT 08,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,5
+Shawnee,TOPEKA WARD 04 PRECINCT 09,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 04 PRECINCT 10,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 04 PRECINCT 11,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 04 PRECINCT 14,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 04 PRECINCT 15,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 05 PRECINCT 01,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,5
+Shawnee,TOPEKA WARD 05 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 05 PRECINCT 03,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 05 PRECINCT 04,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 05 PRECINCT 05,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 05 PRECINCT 06,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 05 PRECINCT 07,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,4
+Shawnee,TOPEKA WARD 05 PRECINCT 08,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 05 PRECINCT 09,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 05 PRECINCT 10,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,5
+Shawnee,TOPEKA WARD 05 PRECINCT 11,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 05 PRECINCT 14,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 05 PRECINCT 15,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 05 PRECINCT 91,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 06 PRECINCT 01,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 06 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 06 PRECINCT 03,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,4
+Shawnee,TOPEKA WARD 06 PRECINCT 04,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 06 PRECINCT 05,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 06 PRECINCT 06,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 06 PRECINCT 07,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 06 PRECINCT 08,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 06 PRECINCT 09,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 07 PRECINCT 01,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 07 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 07 PRECINCT 03,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 07 PRECINCT 04,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 07 PRECINCT 05,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 07 PRECINCT 06,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 07 PRECINCT 07,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 07 PRECINCT 09,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 07 PRECINCT 10,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,4
+Shawnee,TOPEKA WARD 07 PRECINCT 11,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 08 PRECINCT 01,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 08 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 08 PRECINCT 03,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 08 PRECINCT 04,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 08 PRECINCT 05,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 08 PRECINCT 06,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 08 PRECINCT 07,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 08 PRECINCT 08,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 08 PRECINCT 09,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 08 PRECINCT 10,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 08 PRECINCT 11,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 09 PRECINCT 01,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 09 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 09 PRECINCT 03,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 09 PRECINCT 04,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 09 PRECINCT 05,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 09 PRECINCT 06,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,4
+Shawnee,TOPEKA WARD 09 PRECINCT 08,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 09 PRECINCT 09,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 09 PRECINCT 10,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 09 PRECINCT 11,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 09 PRECINCT 12,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 10 PRECINCT 01,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 10 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 10 PRECINCT 03,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 10 PRECINCT 04,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 10 PRECINCT 05,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 10 PRECINCT 06,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 10 PRECINCT 07,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 10 PRECINCT 08,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 10 PRECINCT 09,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 10 PRECINCT 10,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 10 PRECINCT 11,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 10 PRECINCT 14,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 11 PRECINCT 01,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 11 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 11 PRECINCT 03,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 11 PRECINCT 04,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 11 PRECINCT 05,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 11 PRECINCT 06,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 11 PRECINCT 07,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 11 PRECINCT 08,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 11 PRECINCT 09,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 11 PRECINCT 10,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 12 PRECINCT 01,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 12 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 12 PRECINCT 03,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 12 PRECINCT 04,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 12 PRECINCT 05,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 12 PRECINCT 06,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 12 PRECINCT 07,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 12 PRECINCT 08,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 12 PRECINCT 09,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 12 PRECINCT 11,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 12 PRECINCT 13,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 12 PRECINCT 14,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 12 PRECINCT 15,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 12 PRECINCT 16,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 12 PRECINCT 19,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 12 PRECINCT 20,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 12 PRECINCT 31,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 13 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 13 PRECINCT 05,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 13 PRECINCT 06,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 13 PRECINCT 09,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 13 PRECINCT 12,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 13 PRECINCT 21,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 13 PRECINCT 22,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 13 PRECINCT 30,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 14 PRECINCT 01,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,TOPEKA WARD 14 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 14 PRECINCT 03,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 14 PRECINCT 04,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,2
+Shawnee,TOPEKA WARD 14 PRECINCT 05,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 15 PRECINCT 01,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,TOPEKA WARD 15 PRECINCT 02,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,TOPEKA WARD 15 PRECINCT 03,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,VACQUERO,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,VERBENA,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,WAKARUSA,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,4
+Shawnee,WASHBURN,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,WEST POTTER,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,WEST ROSSVILLE,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,6
+Shawnee,WEST SILVER LAKE,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,WEST WICHITA,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,WHITFIELD,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,WILLARD,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,3
+Shawnee,YORK,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,YORK OUTER,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,1
+Shawnee,YUCCA,President,,"Baldwin, Chuck  ",Chuck,,Baldwin,,Reform,0
+Shawnee,ALDERSGATE,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,131
+Shawnee,APACE,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,284
+Shawnee,BUFFALO,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,345
+Shawnee,CENTRAL MISSION,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,392
+Shawnee,CENTRAL PAULINE,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,34
+Shawnee,CHEYENNE,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,312
+Shawnee,CITY OF AUBURN,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,290
+Shawnee,CULLEN,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,185
+Shawnee,DEER CREEK,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,16
+Shawnee,DOVER,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,222
+Shawnee,EAST PECK,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,182
+Shawnee,EAST ROSSVILLE,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,311
+Shawnee,EAST SILVER LAKE,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,331
+Shawnee,EAST SOLDIER,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,306
+Shawnee,EAST WICHITA,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,570
+Shawnee,ELMONT,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,399
+Shawnee,FORBES,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,37
+Shawnee,FOX,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,328
+Shawnee,GAILLARDIA,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,298
+Shawnee,GROVE,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,223
+Shawnee,INDIAN HILLS,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,274
+Shawnee,INDIANOLA,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,339
+Shawnee,IROQUIS,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,317
+Shawnee,KAW,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,273
+Shawnee,KILMER,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,97
+Shawnee,KINGSTON,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,84
+Shawnee,KIOWA,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,404
+Shawnee,KIRO,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,339
+Shawnee,LITTLE MUDDY CREEK,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,198
+Shawnee,MEADOWLARK,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,450
+Shawnee,MESSHOSS CREEK,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,202
+Shawnee,MONTARA,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,150
+Shawnee,NE MONMOUTH,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,301
+Shawnee,NW MONMOUTH,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,431
+Shawnee,NORTH MISSION,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,112
+Shawnee,NORTH TECUMSEH,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,225
+Shawnee,PAULINE,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,99
+Shawnee,PAWNEE,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,386
+Shawnee,PECK,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,183
+Shawnee,PONCA,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,186
+Shawnee,POTTAWATOMIE,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,334
+Shawnee,ROCHESTER,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,251
+Shawnee,S MONMOUTH,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,419
+Shawnee,SAC,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,341
+Shawnee,SHERMAN,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,315
+Shawnee,SHERWOOD,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,274
+Shawnee,SIOUX,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,266
+Shawnee,SOUTH MISSION,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,220
+Shawnee,SOUTH SHERWOOD,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,238
+Shawnee,SOUTH TECUMSEH,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,245
+Shawnee,STINSON CREEK,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,112
+Shawnee,SUNFLOWER,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,548
+Shawnee,TOPEKA WARD 01 PRECINCT 01,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,72
+Shawnee,TOPEKA WARD 01 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,82
+Shawnee,TOPEKA WARD 01 PRECINCT 03,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,101
+Shawnee,TOPEKA WARD 01 PRECINCT 04,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,155
+Shawnee,TOPEKA WARD 01 PRECINCT 05,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,251
+Shawnee,TOPEKA WARD 01 PRECINCT 06,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,305
+Shawnee,TOPEKA WARD 02 PRECINCT 01,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,142
+Shawnee,TOPEKA WARD 02 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,107
+Shawnee,TOPEKA WARD 02 PRECINCT 03,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,113
+Shawnee,TOPEKA WARD 02 PRECINCT 04,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,91
+Shawnee,TOPEKA WARD 02 PRECINCT 05,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,81
+Shawnee,TOPEKA WARD 02 PRECINCT 06,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,64
+Shawnee,TOPEKA WARD 02 PRECINCT 07,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,27
+Shawnee,TOPEKA WARD 02 PRECINCT 08,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,12
+Shawnee,TOPEKA WARD 02 PRECINCT 09,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,116
+Shawnee,TOPEKA WARD 02 PRECINCT 10,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,68
+Shawnee,TOPEKA WARD 02 PRECINCT 11,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,81
+Shawnee,TOPEKA WARD 03 PRECINCT 01,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,127
+Shawnee,TOPEKA WARD 03 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,103
+Shawnee,TOPEKA WARD 03 PRECINCT 03,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,37
+Shawnee,TOPEKA WARD 03 PRECINCT 04,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,88
+Shawnee,TOPEKA WARD 03 PRECINCT 05,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,52
+Shawnee,TOPEKA WARD 03 PRECINCT 06,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,62
+Shawnee,TOPEKA WARD 03 PRECINCT 07,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,74
+Shawnee,TOPEKA WARD 03 PRECINCT 08,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,84
+Shawnee,TOPEKA WARD 03 PRECINCT 09,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,90
+Shawnee,TOPEKA WARD 03 PRECINCT 10,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,5
+Shawnee,TOPEKA WARD 04 PRECINCT 01,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,69
+Shawnee,TOPEKA WARD 04 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,47
+Shawnee,TOPEKA WARD 04 PRECINCT 03,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,26
+Shawnee,TOPEKA WARD 04 PRECINCT 04,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,52
+Shawnee,TOPEKA WARD 04 PRECINCT 06,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,70
+Shawnee,TOPEKA WARD 04 PRECINCT 07,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,45
+Shawnee,TOPEKA WARD 04 PRECINCT 08,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,76
+Shawnee,TOPEKA WARD 04 PRECINCT 09,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,72
+Shawnee,TOPEKA WARD 04 PRECINCT 10,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,93
+Shawnee,TOPEKA WARD 04 PRECINCT 11,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,50
+Shawnee,TOPEKA WARD 04 PRECINCT 14,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,2
+Shawnee,TOPEKA WARD 04 PRECINCT 15,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,92
+Shawnee,TOPEKA WARD 05 PRECINCT 01,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,58
+Shawnee,TOPEKA WARD 05 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,80
+Shawnee,TOPEKA WARD 05 PRECINCT 03,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,80
+Shawnee,TOPEKA WARD 05 PRECINCT 04,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,86
+Shawnee,TOPEKA WARD 05 PRECINCT 05,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,97
+Shawnee,TOPEKA WARD 05 PRECINCT 06,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,52
+Shawnee,TOPEKA WARD 05 PRECINCT 07,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,68
+Shawnee,TOPEKA WARD 05 PRECINCT 08,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,72
+Shawnee,TOPEKA WARD 05 PRECINCT 09,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,214
+Shawnee,TOPEKA WARD 05 PRECINCT 10,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,287
+Shawnee,TOPEKA WARD 05 PRECINCT 11,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,182
+Shawnee,TOPEKA WARD 05 PRECINCT 14,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,150
+Shawnee,TOPEKA WARD 05 PRECINCT 15,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,35
+Shawnee,TOPEKA WARD 05 PRECINCT 91,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,58
+Shawnee,TOPEKA WARD 06 PRECINCT 01,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,42
+Shawnee,TOPEKA WARD 06 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,61
+Shawnee,TOPEKA WARD 06 PRECINCT 03,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,219
+Shawnee,TOPEKA WARD 06 PRECINCT 04,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,114
+Shawnee,TOPEKA WARD 06 PRECINCT 05,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,172
+Shawnee,TOPEKA WARD 06 PRECINCT 06,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,98
+Shawnee,TOPEKA WARD 06 PRECINCT 07,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,72
+Shawnee,TOPEKA WARD 06 PRECINCT 08,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,90
+Shawnee,TOPEKA WARD 06 PRECINCT 09,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,353
+Shawnee,TOPEKA WARD 07 PRECINCT 01,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,129
+Shawnee,TOPEKA WARD 07 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,112
+Shawnee,TOPEKA WARD 07 PRECINCT 03,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,103
+Shawnee,TOPEKA WARD 07 PRECINCT 04,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,176
+Shawnee,TOPEKA WARD 07 PRECINCT 05,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,143
+Shawnee,TOPEKA WARD 07 PRECINCT 06,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,123
+Shawnee,TOPEKA WARD 07 PRECINCT 07,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,97
+Shawnee,TOPEKA WARD 07 PRECINCT 09,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,127
+Shawnee,TOPEKA WARD 07 PRECINCT 10,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,99
+Shawnee,TOPEKA WARD 07 PRECINCT 11,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,182
+Shawnee,TOPEKA WARD 08 PRECINCT 01,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,78
+Shawnee,TOPEKA WARD 08 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,89
+Shawnee,TOPEKA WARD 08 PRECINCT 03,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,141
+Shawnee,TOPEKA WARD 08 PRECINCT 04,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,148
+Shawnee,TOPEKA WARD 08 PRECINCT 05,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,196
+Shawnee,TOPEKA WARD 08 PRECINCT 06,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,140
+Shawnee,TOPEKA WARD 08 PRECINCT 07,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,122
+Shawnee,TOPEKA WARD 08 PRECINCT 08,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,121
+Shawnee,TOPEKA WARD 08 PRECINCT 09,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,177
+Shawnee,TOPEKA WARD 08 PRECINCT 10,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,181
+Shawnee,TOPEKA WARD 08 PRECINCT 11,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,204
+Shawnee,TOPEKA WARD 09 PRECINCT 01,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,32
+Shawnee,TOPEKA WARD 09 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,119
+Shawnee,TOPEKA WARD 09 PRECINCT 03,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,217
+Shawnee,TOPEKA WARD 09 PRECINCT 04,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,187
+Shawnee,TOPEKA WARD 09 PRECINCT 05,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,131
+Shawnee,TOPEKA WARD 09 PRECINCT 06,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,172
+Shawnee,TOPEKA WARD 09 PRECINCT 08,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,200
+Shawnee,TOPEKA WARD 09 PRECINCT 09,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,155
+Shawnee,TOPEKA WARD 09 PRECINCT 10,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,270
+Shawnee,TOPEKA WARD 09 PRECINCT 11,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,179
+Shawnee,TOPEKA WARD 09 PRECINCT 12,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,73
+Shawnee,TOPEKA WARD 10 PRECINCT 01,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,174
+Shawnee,TOPEKA WARD 10 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,235
+Shawnee,TOPEKA WARD 10 PRECINCT 03,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,294
+Shawnee,TOPEKA WARD 10 PRECINCT 04,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,153
+Shawnee,TOPEKA WARD 10 PRECINCT 05,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,139
+Shawnee,TOPEKA WARD 10 PRECINCT 06,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,164
+Shawnee,TOPEKA WARD 10 PRECINCT 07,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,199
+Shawnee,TOPEKA WARD 10 PRECINCT 08,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,137
+Shawnee,TOPEKA WARD 10 PRECINCT 09,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,108
+Shawnee,TOPEKA WARD 10 PRECINCT 10,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,190
+Shawnee,TOPEKA WARD 10 PRECINCT 11,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,238
+Shawnee,TOPEKA WARD 10 PRECINCT 14,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,182
+Shawnee,TOPEKA WARD 11 PRECINCT 01,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,126
+Shawnee,TOPEKA WARD 11 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,160
+Shawnee,TOPEKA WARD 11 PRECINCT 03,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,123
+Shawnee,TOPEKA WARD 11 PRECINCT 04,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,216
+Shawnee,TOPEKA WARD 11 PRECINCT 05,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,158
+Shawnee,TOPEKA WARD 11 PRECINCT 06,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,164
+Shawnee,TOPEKA WARD 11 PRECINCT 07,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,159
+Shawnee,TOPEKA WARD 11 PRECINCT 08,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,149
+Shawnee,TOPEKA WARD 11 PRECINCT 09,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,188
+Shawnee,TOPEKA WARD 11 PRECINCT 10,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,119
+Shawnee,TOPEKA WARD 12 PRECINCT 01,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,113
+Shawnee,TOPEKA WARD 12 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,109
+Shawnee,TOPEKA WARD 12 PRECINCT 03,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,207
+Shawnee,TOPEKA WARD 12 PRECINCT 04,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,275
+Shawnee,TOPEKA WARD 12 PRECINCT 05,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,239
+Shawnee,TOPEKA WARD 12 PRECINCT 06,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,248
+Shawnee,TOPEKA WARD 12 PRECINCT 07,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,236
+Shawnee,TOPEKA WARD 12 PRECINCT 08,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,210
+Shawnee,TOPEKA WARD 12 PRECINCT 09,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,385
+Shawnee,TOPEKA WARD 12 PRECINCT 11,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,433
+Shawnee,TOPEKA WARD 12 PRECINCT 13,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,312
+Shawnee,TOPEKA WARD 12 PRECINCT 14,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,234
+Shawnee,TOPEKA WARD 12 PRECINCT 15,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,370
+Shawnee,TOPEKA WARD 12 PRECINCT 16,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,346
+Shawnee,TOPEKA WARD 12 PRECINCT 19,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,47
+Shawnee,TOPEKA WARD 12 PRECINCT 20,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,303
+Shawnee,TOPEKA WARD 12 PRECINCT 31,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,201
+Shawnee,TOPEKA WARD 13 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,72
+Shawnee,TOPEKA WARD 13 PRECINCT 05,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,18
+Shawnee,TOPEKA WARD 13 PRECINCT 06,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,88
+Shawnee,TOPEKA WARD 13 PRECINCT 09,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,61
+Shawnee,TOPEKA WARD 13 PRECINCT 12,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,394
+Shawnee,TOPEKA WARD 13 PRECINCT 21,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,39
+Shawnee,TOPEKA WARD 13 PRECINCT 22,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,49
+Shawnee,TOPEKA WARD 13 PRECINCT 30,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,73
+Shawnee,TOPEKA WARD 14 PRECINCT 01,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,368
+Shawnee,TOPEKA WARD 14 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,295
+Shawnee,TOPEKA WARD 14 PRECINCT 03,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,233
+Shawnee,TOPEKA WARD 14 PRECINCT 04,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,445
+Shawnee,TOPEKA WARD 14 PRECINCT 05,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,294
+Shawnee,TOPEKA WARD 15 PRECINCT 01,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,282
+Shawnee,TOPEKA WARD 15 PRECINCT 02,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,171
+Shawnee,TOPEKA WARD 15 PRECINCT 03,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,20
+Shawnee,VACQUERO,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,210
+Shawnee,VERBENA,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,70
+Shawnee,WAKARUSA,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,301
+Shawnee,WASHBURN,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,228
+Shawnee,WEST POTTER,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,48
+Shawnee,WEST ROSSVILLE,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,245
+Shawnee,WEST SILVER LAKE,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,232
+Shawnee,WEST WICHITA,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,140
+Shawnee,WHITFIELD,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,224
+Shawnee,WILLARD,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,233
+Shawnee,YORK,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,319
+Shawnee,YORK OUTER,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,43
+Shawnee,YUCCA,President,,"Romney, Mitt  ",Mitt,,Romney,,Republican,88
+Shawnee,ALDERSGATE,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,4
+Shawnee,APACHE,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,20
+Shawnee,BUFFALO,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,16
+Shawnee,CENTRAL MISSION,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,26
+Shawnee,CENTRAL PAULINE,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,5
+Shawnee,CHEYENNE,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,17
+Shawnee,CITY OF AUBURN,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,16
+Shawnee,CULLEN,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,24
+Shawnee,DEER CREEK,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,1
+Shawnee,DOVER,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,EAST PECK,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,11
+Shawnee,EAST ROSSVILLE,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,28
+Shawnee,EAST SILVER LAKE,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,14
+Shawnee,EAST SOLDIER,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,15
+Shawnee,EAST WICHITA,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,25
+Shawnee,ELMONT,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,34
+Shawnee,FORBES,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,1
+Shawnee,FOX,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,21
+Shawnee,GAILLARDIA,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,17
+Shawnee,GROVE,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,15
+Shawnee,INDIAN HILLS,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,14
+Shawnee,INDIANOLA,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,10
+Shawnee,IROQUIS,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,15
+Shawnee,KAW,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,23
+Shawnee,KILMER,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,9
+Shawnee,KINGSTON,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,3
+Shawnee,KIOWA,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,18
+Shawnee,KIRO,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,20
+Shawnee,LITTLE MUDDY CREEK,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,10
+Shawnee,MEADOWLARK,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,21
+Shawnee,MESSHOSS CREEK,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,17
+Shawnee,MONTARA,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,10
+Shawnee,NE MONMOUTH,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,15
+Shawnee,NW MONMOUTH,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,24
+Shawnee,NORTH MISSION,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,1
+Shawnee,NORTH TECUMSEH,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,19
+Shawnee,PAULINE,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,8
+Shawnee,PAWNEE,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,18
+Shawnee,PECK,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,PONCA,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,9
+Shawnee,POTTAWATOMIE,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,27
+Shawnee,ROCHESTER,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,19
+Shawnee,S MONMOUTH,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,22
+Shawnee,SAC,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,25
+Shawnee,SHERMAN,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,25
+Shawnee,SHERWOOD,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,17
+Shawnee,SIOUX,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,22
+Shawnee,SOUTH MISSION,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,15
+Shawnee,SOUTH SHERWOOD,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,6
+Shawnee,SOUTH TECUMSEH,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,16
+Shawnee,STINSON CREEK,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,1
+Shawnee,SUNFLOWER,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,17
+Shawnee,TOPEKA WARD 01 PRECINCT 01,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,14
+Shawnee,TOPEKA WARD 01 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,14
+Shawnee,TOPEKA WARD 01 PRECINCT 03,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,14
+Shawnee,TOPEKA WARD 01 PRECINCT 04,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,17
+Shawnee,TOPEKA WARD 01 PRECINCT 05,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,29
+Shawnee,TOPEKA WARD 01 PRECINCT 06,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,26
+Shawnee,TOPEKA WARD 02 PRECINCT 01,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,14
+Shawnee,TOPEKA WARD 02 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,9
+Shawnee,TOPEKA WARD 02 PRECINCT 03,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,9
+Shawnee,TOPEKA WARD 02 PRECINCT 04,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,20
+Shawnee,TOPEKA WARD 02 PRECINCT 05,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,5
+Shawnee,TOPEKA WARD 02 PRECINCT 06,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,6
+Shawnee,TOPEKA WARD 02 PRECINCT 07,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,4
+Shawnee,TOPEKA WARD 02 PRECINCT 08,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,6
+Shawnee,TOPEKA WARD 02 PRECINCT 09,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,22
+Shawnee,TOPEKA WARD 02 PRECINCT 10,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,6
+Shawnee,TOPEKA WARD 02 PRECINCT 11,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,11
+Shawnee,TOPEKA WARD 03 PRECINCT 01,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,16
+Shawnee,TOPEKA WARD 03 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,TOPEKA WARD 03 PRECINCT 03,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,4
+Shawnee,TOPEKA WARD 03 PRECINCT 04,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,14
+Shawnee,TOPEKA WARD 03 PRECINCT 05,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,6
+Shawnee,TOPEKA WARD 03 PRECINCT 06,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,3
+Shawnee,TOPEKA WARD 03 PRECINCT 07,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,17
+Shawnee,TOPEKA WARD 03 PRECINCT 08,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,5
+Shawnee,TOPEKA WARD 03 PRECINCT 09,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,15
+Shawnee,TOPEKA WARD 03 PRECINCT 10,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,0
+Shawnee,TOPEKA WARD 04 PRECINCT 01,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,TOPEKA WARD 04 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,6
+Shawnee,TOPEKA WARD 04 PRECINCT 03,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,6
+Shawnee,TOPEKA WARD 04 PRECINCT 04,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,19
+Shawnee,TOPEKA WARD 04 PRECINCT 06,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,TOPEKA WARD 04 PRECINCT 07,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,5
+Shawnee,TOPEKA WARD 04 PRECINCT 08,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,13
+Shawnee,TOPEKA WARD 04 PRECINCT 09,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,9
+Shawnee,TOPEKA WARD 04 PRECINCT 10,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,16
+Shawnee,TOPEKA WARD 04 PRECINCT 11,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,5
+Shawnee,TOPEKA WARD 04 PRECINCT 14,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,0
+Shawnee,TOPEKA WARD 04 PRECINCT 15,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,13
+Shawnee,TOPEKA WARD 05 PRECINCT 01,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,TOPEKA WARD 05 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,11
+Shawnee,TOPEKA WARD 05 PRECINCT 03,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,4
+Shawnee,TOPEKA WARD 05 PRECINCT 04,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,4
+Shawnee,TOPEKA WARD 05 PRECINCT 05,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,8
+Shawnee,TOPEKA WARD 05 PRECINCT 06,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,4
+Shawnee,TOPEKA WARD 05 PRECINCT 07,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,8
+Shawnee,TOPEKA WARD 05 PRECINCT 08,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,8
+Shawnee,TOPEKA WARD 05 PRECINCT 09,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,10
+Shawnee,TOPEKA WARD 05 PRECINCT 10,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,16
+Shawnee,TOPEKA WARD 05 PRECINCT 11,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,TOPEKA WARD 05 PRECINCT 14,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,3
+Shawnee,TOPEKA WARD 05 PRECINCT 15,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,0
+Shawnee,TOPEKA WARD 05 PRECINCT 91,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,3
+Shawnee,TOPEKA WARD 06 PRECINCT 01,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,4
+Shawnee,TOPEKA WARD 06 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,10
+Shawnee,TOPEKA WARD 06 PRECINCT 03,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,13
+Shawnee,TOPEKA WARD 06 PRECINCT 04,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,8
+Shawnee,TOPEKA WARD 06 PRECINCT 05,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,10
+Shawnee,TOPEKA WARD 06 PRECINCT 06,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,13
+Shawnee,TOPEKA WARD 06 PRECINCT 07,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,9
+Shawnee,TOPEKA WARD 06 PRECINCT 08,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,13
+Shawnee,TOPEKA WARD 06 PRECINCT 09,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,25
+Shawnee,TOPEKA WARD 07 PRECINCT 01,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,5
+Shawnee,TOPEKA WARD 07 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,13
+Shawnee,TOPEKA WARD 07 PRECINCT 03,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,16
+Shawnee,TOPEKA WARD 07 PRECINCT 04,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,18
+Shawnee,TOPEKA WARD 07 PRECINCT 05,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,17
+Shawnee,TOPEKA WARD 07 PRECINCT 06,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,16
+Shawnee,TOPEKA WARD 07 PRECINCT 07,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,9
+Shawnee,TOPEKA WARD 07 PRECINCT 09,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,6
+Shawnee,TOPEKA WARD 07 PRECINCT 10,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,13
+Shawnee,TOPEKA WARD 07 PRECINCT 11,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,21
+Shawnee,TOPEKA WARD 08 PRECINCT 01,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,17
+Shawnee,TOPEKA WARD 08 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,10
+Shawnee,TOPEKA WARD 08 PRECINCT 03,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,15
+Shawnee,TOPEKA WARD 08 PRECINCT 04,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,10
+Shawnee,TOPEKA WARD 08 PRECINCT 05,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,27
+Shawnee,TOPEKA WARD 08 PRECINCT 06,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,8
+Shawnee,TOPEKA WARD 08 PRECINCT 07,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,TOPEKA WARD 08 PRECINCT 08,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,6
+Shawnee,TOPEKA WARD 08 PRECINCT 09,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,9
+Shawnee,TOPEKA WARD 08 PRECINCT 10,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,6
+Shawnee,TOPEKA WARD 08 PRECINCT 11,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,19
+Shawnee,TOPEKA WARD 09 PRECINCT 01,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,2
+Shawnee,TOPEKA WARD 09 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,7
+Shawnee,TOPEKA WARD 09 PRECINCT 03,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,10
+Shawnee,TOPEKA WARD 09 PRECINCT 04,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,TOPEKA WARD 09 PRECINCT 05,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,13
+Shawnee,TOPEKA WARD 09 PRECINCT 06,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,15
+Shawnee,TOPEKA WARD 09 PRECINCT 08,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,19
+Shawnee,TOPEKA WARD 09 PRECINCT 09,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,3
+Shawnee,TOPEKA WARD 09 PRECINCT 10,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,13
+Shawnee,TOPEKA WARD 09 PRECINCT 11,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,8
+Shawnee,TOPEKA WARD 09 PRECINCT 12,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,8
+Shawnee,TOPEKA WARD 10 PRECINCT 01,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,TOPEKA WARD 10 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,11
+Shawnee,TOPEKA WARD 10 PRECINCT 03,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,17
+Shawnee,TOPEKA WARD 10 PRECINCT 04,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,7
+Shawnee,TOPEKA WARD 10 PRECINCT 05,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,20
+Shawnee,TOPEKA WARD 10 PRECINCT 06,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,7
+Shawnee,TOPEKA WARD 10 PRECINCT 07,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,18
+Shawnee,TOPEKA WARD 10 PRECINCT 08,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,11
+Shawnee,TOPEKA WARD 10 PRECINCT 09,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,13
+Shawnee,TOPEKA WARD 10 PRECINCT 10,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,9
+Shawnee,TOPEKA WARD 10 PRECINCT 11,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,24
+Shawnee,TOPEKA WARD 10 PRECINCT 14,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,10
+Shawnee,TOPEKA WARD 11 PRECINCT 01,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,15
+Shawnee,TOPEKA WARD 11 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,5
+Shawnee,TOPEKA WARD 11 PRECINCT 03,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,13
+Shawnee,TOPEKA WARD 11 PRECINCT 04,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,14
+Shawnee,TOPEKA WARD 11 PRECINCT 05,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,9
+Shawnee,TOPEKA WARD 11 PRECINCT 06,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,17
+Shawnee,TOPEKA WARD 11 PRECINCT 07,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,14
+Shawnee,TOPEKA WARD 11 PRECINCT 08,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,15
+Shawnee,TOPEKA WARD 11 PRECINCT 09,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,9
+Shawnee,TOPEKA WARD 11 PRECINCT 10,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,13
+Shawnee,TOPEKA WARD 12 PRECINCT 01,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,TOPEKA WARD 12 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,TOPEKA WARD 12 PRECINCT 03,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,TOPEKA WARD 12 PRECINCT 04,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,10
+Shawnee,TOPEKA WARD 12 PRECINCT 05,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,15
+Shawnee,TOPEKA WARD 12 PRECINCT 06,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,16
+Shawnee,TOPEKA WARD 12 PRECINCT 07,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,22
+Shawnee,TOPEKA WARD 12 PRECINCT 08,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,22
+Shawnee,TOPEKA WARD 12 PRECINCT 09,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,25
+Shawnee,TOPEKA WARD 12 PRECINCT 11,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,17
+Shawnee,TOPEKA WARD 12 PRECINCT 13,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,TOPEKA WARD 12 PRECINCT 14,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,10
+Shawnee,TOPEKA WARD 12 PRECINCT 15,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,24
+Shawnee,TOPEKA WARD 12 PRECINCT 16,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,17
+Shawnee,TOPEKA WARD 12 PRECINCT 19,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,2
+Shawnee,TOPEKA WARD 12 PRECINCT 20,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,19
+Shawnee,TOPEKA WARD 12 PRECINCT 31,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,TOPEKA WARD 13 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,10
+Shawnee,TOPEKA WARD 13 PRECINCT 05,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,2
+Shawnee,TOPEKA WARD 13 PRECINCT 06,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,1
+Shawnee,TOPEKA WARD 13 PRECINCT 09,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,1
+Shawnee,TOPEKA WARD 13 PRECINCT 12,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,16
+Shawnee,TOPEKA WARD 13 PRECINCT 21,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,6
+Shawnee,TOPEKA WARD 13 PRECINCT 22,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,3
+Shawnee,TOPEKA WARD 13 PRECINCT 30,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,8
+Shawnee,TOPEKA WARD 14 PRECINCT 01,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,26
+Shawnee,TOPEKA WARD 14 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,17
+Shawnee,TOPEKA WARD 14 PRECINCT 03,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,14
+Shawnee,TOPEKA WARD 14 PRECINCT 04,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,16
+Shawnee,TOPEKA WARD 14 PRECINCT 05,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,7
+Shawnee,TOPEKA WARD 15 PRECINCT 01,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,26
+Shawnee,TOPEKA WARD 15 PRECINCT 02,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,11
+Shawnee,TOPEKA WARD 15 PRECINCT 03,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,0
+Shawnee,VACQUERO,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,14
+Shawnee,VERBENA,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,4
+Shawnee,WAKARUSA,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,16
+Shawnee,WASHBURN,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,10
+Shawnee,WEST POTTER,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,2
+Shawnee,WEST ROSSVILLE,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,13
+Shawnee,WEST SILVER LAKE,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,21
+Shawnee,WEST WICHITA,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,12
+Shawnee,WHITFIELD,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,19
+Shawnee,WILLARD,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,20
+Shawnee,YORK,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,18
+Shawnee,YORK OUTER,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,1
+Shawnee,YUCCA,U.S. House,2,Dennis Hawver,Dennis,,Hawver,,Libertarian,6
+Shawnee,ALDERSGATE,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,125
+Shawnee,APACHE,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,243
+Shawnee,BUFFALO,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,290
+Shawnee,CENTRAL MISSION,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,357
+Shawnee,CENTRAL PAULINE,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,35
+Shawnee,CHEYENNE,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,277
+Shawnee,CITY OF AUBURN,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,262
+Shawnee,CULLEN,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,197
+Shawnee,DEER CREEK,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,14
+Shawnee,DOVER,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,197
+Shawnee,EAST PECK,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,175
+Shawnee,EAST ROSSVILLE,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,280
+Shawnee,EAST SILVER LAKE,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,303
+Shawnee,EAST SOLDIER,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,281
+Shawnee,EAST WICHITA,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,526
+Shawnee,ELMONT,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,348
+Shawnee,FORBES,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,35
+Shawnee,FOX,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,299
+Shawnee,GAILLARDIA,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,283
+Shawnee,GROVE,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,211
+Shawnee,INDIAN HILLS,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,252
+Shawnee,INDIANOLA,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,321
+Shawnee,IROQUIS,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,304
+Shawnee,KAW,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,246
+Shawnee,KILMER,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,80
+Shawnee,KINGSTON,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,77
+Shawnee,KIOWA,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,382
+Shawnee,KIRO,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,307
+Shawnee,LITTLE MUDDY CREEK,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,180
+Shawnee,MEADOWLARK,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,408
+Shawnee,MESSHOSS CREEK,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,172
+Shawnee,MONTARA,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,165
+Shawnee,NE MONMOUTH,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,294
+Shawnee,NW MONMOUTH,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,372
+Shawnee,NORTH MISSION,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,100
+Shawnee,NORTH TECUMSEH,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,209
+Shawnee,PAULINE,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,89
+Shawnee,PAWNEE,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,341
+Shawnee,PECK,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,166
+Shawnee,PONCA,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,172
+Shawnee,POTTAWATOMIE,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,315
+Shawnee,ROCHESTER,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,201
+Shawnee,S MONMOUTH,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,375
+Shawnee,SAC,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,289
+Shawnee,SHERMAN,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,284
+Shawnee,SHERWOOD,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,241
+Shawnee,SIOUX,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,239
+Shawnee,SOUTH MISSION,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,192
+Shawnee,SOUTH SHERWOOD,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,231
+Shawnee,SOUTH TECUMSEH,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,219
+Shawnee,STINSON CREEK,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,109
+Shawnee,SUNFLOWER,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,503
+Shawnee,TOPEKA WARD 01 PRECINCT 01,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,83
+Shawnee,TOPEKA WARD 01 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,94
+Shawnee,TOPEKA WARD 01 PRECINCT 03,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,93
+Shawnee,TOPEKA WARD 01 PRECINCT 04,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,142
+Shawnee,TOPEKA WARD 01 PRECINCT 05,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,257
+Shawnee,TOPEKA WARD 01 PRECINCT 06,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,286
+Shawnee,TOPEKA WARD 02 PRECINCT 01,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,138
+Shawnee,TOPEKA WARD 02 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,98
+Shawnee,TOPEKA WARD 02 PRECINCT 03,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,121
+Shawnee,TOPEKA WARD 02 PRECINCT 04,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,97
+Shawnee,TOPEKA WARD 02 PRECINCT 05,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,82
+Shawnee,TOPEKA WARD 02 PRECINCT 06,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,73
+Shawnee,TOPEKA WARD 02 PRECINCT 07,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,47
+Shawnee,TOPEKA WARD 02 PRECINCT 08,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,33
+Shawnee,TOPEKA WARD 02 PRECINCT 09,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,128
+Shawnee,TOPEKA WARD 02 PRECINCT 10,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,88
+Shawnee,TOPEKA WARD 02 PRECINCT 11,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,85
+Shawnee,TOPEKA WARD 03 PRECINCT 01,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,121
+Shawnee,TOPEKA WARD 03 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,95
+Shawnee,TOPEKA WARD 03 PRECINCT 03,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,52
+Shawnee,TOPEKA WARD 03 PRECINCT 04,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,76
+Shawnee,TOPEKA WARD 03 PRECINCT 05,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,71
+Shawnee,TOPEKA WARD 03 PRECINCT 06,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,63
+Shawnee,TOPEKA WARD 03 PRECINCT 07,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,88
+Shawnee,TOPEKA WARD 03 PRECINCT 08,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,95
+Shawnee,TOPEKA WARD 03 PRECINCT 09,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,99
+Shawnee,TOPEKA WARD 03 PRECINCT 10,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,12
+Shawnee,TOPEKA WARD 04 PRECINCT 01,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,76
+Shawnee,TOPEKA WARD 04 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,78
+Shawnee,TOPEKA WARD 04 PRECINCT 03,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,34
+Shawnee,TOPEKA WARD 04 PRECINCT 04,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,75
+Shawnee,TOPEKA WARD 04 PRECINCT 06,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,93
+Shawnee,TOPEKA WARD 04 PRECINCT 07,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,67
+Shawnee,TOPEKA WARD 04 PRECINCT 08,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,85
+Shawnee,TOPEKA WARD 04 PRECINCT 09,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,84
+Shawnee,TOPEKA WARD 04 PRECINCT 10,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,109
+Shawnee,TOPEKA WARD 04 PRECINCT 11,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,49
+Shawnee,TOPEKA WARD 04 PRECINCT 14,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,4
+Shawnee,TOPEKA WARD 04 PRECINCT 15,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,77
+Shawnee,TOPEKA WARD 05 PRECINCT 01,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,73
+Shawnee,TOPEKA WARD 05 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,90
+Shawnee,TOPEKA WARD 05 PRECINCT 03,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,91
+Shawnee,TOPEKA WARD 05 PRECINCT 04,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,94
+Shawnee,TOPEKA WARD 05 PRECINCT 05,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,98
+Shawnee,TOPEKA WARD 05 PRECINCT 06,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,64
+Shawnee,TOPEKA WARD 05 PRECINCT 07,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,74
+Shawnee,TOPEKA WARD 05 PRECINCT 08,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,72
+Shawnee,TOPEKA WARD 05 PRECINCT 09,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,227
+Shawnee,TOPEKA WARD 05 PRECINCT 10,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,269
+Shawnee,TOPEKA WARD 05 PRECINCT 11,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,165
+Shawnee,TOPEKA WARD 05 PRECINCT 14,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,152
+Shawnee,TOPEKA WARD 05 PRECINCT 15,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,35
+Shawnee,TOPEKA WARD 05 PRECINCT 91,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,60
+Shawnee,TOPEKA WARD 06 PRECINCT 01,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,66
+Shawnee,TOPEKA WARD 06 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,79
+Shawnee,TOPEKA WARD 06 PRECINCT 03,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,148
+Shawnee,TOPEKA WARD 06 PRECINCT 04,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,122
+Shawnee,TOPEKA WARD 06 PRECINCT 05,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,161
+Shawnee,TOPEKA WARD 06 PRECINCT 06,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,104
+Shawnee,TOPEKA WARD 06 PRECINCT 07,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,65
+Shawnee,TOPEKA WARD 06 PRECINCT 08,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,109
+Shawnee,TOPEKA WARD 06 PRECINCT 09,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,344
+Shawnee,TOPEKA WARD 07 PRECINCT 01,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,117
+Shawnee,TOPEKA WARD 07 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,114
+Shawnee,TOPEKA WARD 07 PRECINCT 03,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,100
+Shawnee,TOPEKA WARD 07 PRECINCT 04,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,174
+Shawnee,TOPEKA WARD 07 PRECINCT 05,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,132
+Shawnee,TOPEKA WARD 07 PRECINCT 06,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,120
+Shawnee,TOPEKA WARD 07 PRECINCT 07,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,99
+Shawnee,TOPEKA WARD 07 PRECINCT 09,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,117
+Shawnee,TOPEKA WARD 07 PRECINCT 10,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,102
+Shawnee,TOPEKA WARD 07 PRECINCT 11,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,164
+Shawnee,TOPEKA WARD 08 PRECINCT 01,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,82
+Shawnee,TOPEKA WARD 08 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,100
+Shawnee,TOPEKA WARD 08 PRECINCT 03,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,141
+Shawnee,TOPEKA WARD 08 PRECINCT 04,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,142
+Shawnee,TOPEKA WARD 08 PRECINCT 05,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,194
+Shawnee,TOPEKA WARD 08 PRECINCT 06,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,124
+Shawnee,TOPEKA WARD 08 PRECINCT 07,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,106
+Shawnee,TOPEKA WARD 08 PRECINCT 08,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,111
+Shawnee,TOPEKA WARD 08 PRECINCT 09,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,151
+Shawnee,TOPEKA WARD 08 PRECINCT 10,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,170
+Shawnee,TOPEKA WARD 08 PRECINCT 11,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,180
+Shawnee,TOPEKA WARD 09 PRECINCT 01,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,31
+Shawnee,TOPEKA WARD 09 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,123
+Shawnee,TOPEKA WARD 09 PRECINCT 03,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,206
+Shawnee,TOPEKA WARD 09 PRECINCT 04,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,153
+Shawnee,TOPEKA WARD 09 PRECINCT 05,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,137
+Shawnee,TOPEKA WARD 09 PRECINCT 06,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,160
+Shawnee,TOPEKA WARD 09 PRECINCT 08,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,196
+Shawnee,TOPEKA WARD 09 PRECINCT 09,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,139
+Shawnee,TOPEKA WARD 09 PRECINCT 10,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,257
+Shawnee,TOPEKA WARD 09 PRECINCT 11,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,156
+Shawnee,TOPEKA WARD 09 PRECINCT 12,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,72
+Shawnee,TOPEKA WARD 10 PRECINCT 01,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,153
+Shawnee,TOPEKA WARD 10 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,222
+Shawnee,TOPEKA WARD 10 PRECINCT 03,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,259
+Shawnee,TOPEKA WARD 10 PRECINCT 04,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,149
+Shawnee,TOPEKA WARD 10 PRECINCT 05,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,119
+Shawnee,TOPEKA WARD 10 PRECINCT 06,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,142
+Shawnee,TOPEKA WARD 10 PRECINCT 07,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,170
+Shawnee,TOPEKA WARD 10 PRECINCT 08,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,132
+Shawnee,TOPEKA WARD 10 PRECINCT 09,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,105
+Shawnee,TOPEKA WARD 10 PRECINCT 10,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,190
+Shawnee,TOPEKA WARD 10 PRECINCT 11,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,228
+Shawnee,TOPEKA WARD 10 PRECINCT 14,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,176
+Shawnee,TOPEKA WARD 11 PRECINCT 01,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,115
+Shawnee,TOPEKA WARD 11 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,147
+Shawnee,TOPEKA WARD 11 PRECINCT 03,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,104
+Shawnee,TOPEKA WARD 11 PRECINCT 04,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,197
+Shawnee,TOPEKA WARD 11 PRECINCT 05,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,156
+Shawnee,TOPEKA WARD 11 PRECINCT 06,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,161
+Shawnee,TOPEKA WARD 11 PRECINCT 07,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,160
+Shawnee,TOPEKA WARD 11 PRECINCT 08,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,135
+Shawnee,TOPEKA WARD 11 PRECINCT 09,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,182
+Shawnee,TOPEKA WARD 11 PRECINCT 10,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,119
+Shawnee,TOPEKA WARD 12 PRECINCT 01,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,112
+Shawnee,TOPEKA WARD 12 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,123
+Shawnee,TOPEKA WARD 12 PRECINCT 03,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,197
+Shawnee,TOPEKA WARD 12 PRECINCT 04,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,242
+Shawnee,TOPEKA WARD 12 PRECINCT 05,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,194
+Shawnee,TOPEKA WARD 12 PRECINCT 06,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,228
+Shawnee,TOPEKA WARD 12 PRECINCT 07,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,219
+Shawnee,TOPEKA WARD 12 PRECINCT 08,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,184
+Shawnee,TOPEKA WARD 12 PRECINCT 09,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,338
+Shawnee,TOPEKA WARD 12 PRECINCT 11,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,404
+Shawnee,TOPEKA WARD 12 PRECINCT 13,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,289
+Shawnee,TOPEKA WARD 12 PRECINCT 14,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,220
+Shawnee,TOPEKA WARD 12 PRECINCT 15,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,338
+Shawnee,TOPEKA WARD 12 PRECINCT 16,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,319
+Shawnee,TOPEKA WARD 12 PRECINCT 19,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,46
+Shawnee,TOPEKA WARD 12 PRECINCT 20,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,275
+Shawnee,TOPEKA WARD 12 PRECINCT 31,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,181
+Shawnee,TOPEKA WARD 13 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,74
+Shawnee,TOPEKA WARD 13 PRECINCT 05,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,20
+Shawnee,TOPEKA WARD 13 PRECINCT 06,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,85
+Shawnee,TOPEKA WARD 13 PRECINCT 09,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,54
+Shawnee,TOPEKA WARD 13 PRECINCT 12,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,361
+Shawnee,TOPEKA WARD 13 PRECINCT 21,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,32
+Shawnee,TOPEKA WARD 13 PRECINCT 22,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,49
+Shawnee,TOPEKA WARD 13 PRECINCT 30,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,64
+Shawnee,TOPEKA WARD 14 PRECINCT 01,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,352
+Shawnee,TOPEKA WARD 14 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,276
+Shawnee,TOPEKA WARD 14 PRECINCT 03,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,205
+Shawnee,TOPEKA WARD 14 PRECINCT 04,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,382
+Shawnee,TOPEKA WARD 14 PRECINCT 05,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,292
+Shawnee,TOPEKA WARD 15 PRECINCT 01,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,274
+Shawnee,TOPEKA WARD 15 PRECINCT 02,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,149
+Shawnee,TOPEKA WARD 15 PRECINCT 03,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,18
+Shawnee,VACQUERO,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,182
+Shawnee,VERBENA,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,53
+Shawnee,WAKARUSA,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,273
+Shawnee,WASHBURN,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,213
+Shawnee,WEST POTTER,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,49
+Shawnee,WEST ROSSVILLE,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,219
+Shawnee,WEST SILVER LAKE,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,210
+Shawnee,WEST WICHITA,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,120
+Shawnee,WHITFIELD,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,202
+Shawnee,WILLARD,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,220
+Shawnee,YORK,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,288
+Shawnee,YORK OUTER,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,34
+Shawnee,YUCCA,U.S. House,2,Lynn Jenkins,Lynn,,Jenkins,,Republican,80
+Shawnee,ALDERSGATE,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,115
+Shawnee,APACHE,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,188
+Shawnee,BUFFALO,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,179
+Shawnee,CENTRAL MISSION,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,229
+Shawnee,CENTRAL PAULINE,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,34
+Shawnee,CHEYENNE,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,225
+Shawnee,CITY OF AUBURN,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,191
+Shawnee,CULLEN,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,189
+Shawnee,DEER CREEK,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,8
+Shawnee,DOVER,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,156
+Shawnee,EAST PECK,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,128
+Shawnee,EAST ROSSVILLE,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,157
+Shawnee,EAST SILVER LAKE,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,266
+Shawnee,EAST SOLDIER,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,245
+Shawnee,EAST WICHITA,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,387
+Shawnee,ELMONT,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,276
+Shawnee,FORBES,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,21
+Shawnee,FOX,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,213
+Shawnee,GAILLARDIA,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,156
+Shawnee,GROVE,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,104
+Shawnee,INDIAN HILLS,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,196
+Shawnee,INDIANOLA,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,186
+Shawnee,IROQUIS,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,206
+Shawnee,KAW,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,238
+Shawnee,KILMER,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,60
+Shawnee,KINGSTON,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,48
+Shawnee,KIOWA,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,308
+Shawnee,KIRO,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,204
+Shawnee,LITTLE MUDDY CREEK,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,124
+Shawnee,MEADOWLARK,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,231
+Shawnee,MESSHOSS CREEK,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,112
+Shawnee,MONTARA,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,164
+Shawnee,NE MONMOUTH,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,208
+Shawnee,NW MONMOUTH,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,272
+Shawnee,NORTH MISSION,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,49
+Shawnee,NORTH TECUMSEH,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,216
+Shawnee,PAULINE,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,106
+Shawnee,PAWNEE,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,237
+Shawnee,PECK,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,164
+Shawnee,PONCA,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,153
+Shawnee,POTTAWATOMIE,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,225
+Shawnee,ROCHESTER,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,216
+Shawnee,S MONMOUTH,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,272
+Shawnee,SAC,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,245
+Shawnee,SHERMAN,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,189
+Shawnee,SHERWOOD,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,180
+Shawnee,SIOUX,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,194
+Shawnee,SOUTH MISSION,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,132
+Shawnee,SOUTH SHERWOOD,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,120
+Shawnee,SOUTH TECUMSEH,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,211
+Shawnee,STINSON CREEK,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,77
+Shawnee,SUNFLOWER,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,243
+Shawnee,TOPEKA WARD 01 PRECINCT 01,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,134
+Shawnee,TOPEKA WARD 01 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,167
+Shawnee,TOPEKA WARD 01 PRECINCT 03,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,120
+Shawnee,TOPEKA WARD 01 PRECINCT 04,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,191
+Shawnee,TOPEKA WARD 01 PRECINCT 05,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,218
+Shawnee,TOPEKA WARD 01 PRECINCT 06,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,228
+Shawnee,TOPEKA WARD 02 PRECINCT 01,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,176
+Shawnee,TOPEKA WARD 02 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,161
+Shawnee,TOPEKA WARD 02 PRECINCT 03,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,166
+Shawnee,TOPEKA WARD 02 PRECINCT 04,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,164
+Shawnee,TOPEKA WARD 02 PRECINCT 05,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,156
+Shawnee,TOPEKA WARD 02 PRECINCT 06,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,158
+Shawnee,TOPEKA WARD 02 PRECINCT 07,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,102
+Shawnee,TOPEKA WARD 02 PRECINCT 08,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,132
+Shawnee,TOPEKA WARD 02 PRECINCT 09,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,170
+Shawnee,TOPEKA WARD 02 PRECINCT 10,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,243
+Shawnee,TOPEKA WARD 02 PRECINCT 11,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,117
+Shawnee,TOPEKA WARD 03 PRECINCT 01,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,188
+Shawnee,TOPEKA WARD 03 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,188
+Shawnee,TOPEKA WARD 03 PRECINCT 03,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,138
+Shawnee,TOPEKA WARD 03 PRECINCT 04,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,175
+Shawnee,TOPEKA WARD 03 PRECINCT 05,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,129
+Shawnee,TOPEKA WARD 03 PRECINCT 06,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,130
+Shawnee,TOPEKA WARD 03 PRECINCT 07,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,166
+Shawnee,TOPEKA WARD 03 PRECINCT 08,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,167
+Shawnee,TOPEKA WARD 03 PRECINCT 09,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,186
+Shawnee,TOPEKA WARD 03 PRECINCT 10,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,15
+Shawnee,TOPEKA WARD 04 PRECINCT 01,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,181
+Shawnee,TOPEKA WARD 04 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,233
+Shawnee,TOPEKA WARD 04 PRECINCT 03,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,163
+Shawnee,TOPEKA WARD 04 PRECINCT 04,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,283
+Shawnee,TOPEKA WARD 04 PRECINCT 06,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,208
+Shawnee,TOPEKA WARD 04 PRECINCT 07,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,148
+Shawnee,TOPEKA WARD 04 PRECINCT 08,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,182
+Shawnee,TOPEKA WARD 04 PRECINCT 09,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,197
+Shawnee,TOPEKA WARD 04 PRECINCT 10,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,259
+Shawnee,TOPEKA WARD 04 PRECINCT 11,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,64
+Shawnee,TOPEKA WARD 04 PRECINCT 14,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,19
+Shawnee,TOPEKA WARD 04 PRECINCT 15,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,125
+Shawnee,TOPEKA WARD 05 PRECINCT 01,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,164
+Shawnee,TOPEKA WARD 05 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,180
+Shawnee,TOPEKA WARD 05 PRECINCT 03,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,167
+Shawnee,TOPEKA WARD 05 PRECINCT 04,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,185
+Shawnee,TOPEKA WARD 05 PRECINCT 05,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,212
+Shawnee,TOPEKA WARD 05 PRECINCT 06,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,164
+Shawnee,TOPEKA WARD 05 PRECINCT 07,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,198
+Shawnee,TOPEKA WARD 05 PRECINCT 08,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,148
+Shawnee,TOPEKA WARD 05 PRECINCT 09,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,219
+Shawnee,TOPEKA WARD 05 PRECINCT 10,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,266
+Shawnee,TOPEKA WARD 05 PRECINCT 11,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,214
+Shawnee,TOPEKA WARD 05 PRECINCT 14,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,102
+Shawnee,TOPEKA WARD 05 PRECINCT 15,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,21
+Shawnee,TOPEKA WARD 05 PRECINCT 91,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,57
+Shawnee,TOPEKA WARD 06 PRECINCT 01,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,192
+Shawnee,TOPEKA WARD 06 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,174
+Shawnee,TOPEKA WARD 06 PRECINCT 03,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,212
+Shawnee,TOPEKA WARD 06 PRECINCT 04,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,178
+Shawnee,TOPEKA WARD 06 PRECINCT 05,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,208
+Shawnee,TOPEKA WARD 06 PRECINCT 06,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,132
+Shawnee,TOPEKA WARD 06 PRECINCT 07,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,117
+Shawnee,TOPEKA WARD 06 PRECINCT 08,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,243
+Shawnee,TOPEKA WARD 06 PRECINCT 09,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,326
+Shawnee,TOPEKA WARD 07 PRECINCT 01,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,240
+Shawnee,TOPEKA WARD 07 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,192
+Shawnee,TOPEKA WARD 07 PRECINCT 03,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,202
+Shawnee,TOPEKA WARD 07 PRECINCT 04,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,183
+Shawnee,TOPEKA WARD 07 PRECINCT 05,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,149
+Shawnee,TOPEKA WARD 07 PRECINCT 06,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,137
+Shawnee,TOPEKA WARD 07 PRECINCT 07,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,160
+Shawnee,TOPEKA WARD 07 PRECINCT 09,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,141
+Shawnee,TOPEKA WARD 07 PRECINCT 10,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,151
+Shawnee,TOPEKA WARD 07 PRECINCT 11,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,252
+Shawnee,TOPEKA WARD 08 PRECINCT 01,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,189
+Shawnee,TOPEKA WARD 08 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,220
+Shawnee,TOPEKA WARD 08 PRECINCT 03,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,264
+Shawnee,TOPEKA WARD 08 PRECINCT 04,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,235
+Shawnee,TOPEKA WARD 08 PRECINCT 05,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,295
+Shawnee,TOPEKA WARD 08 PRECINCT 06,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,147
+Shawnee,TOPEKA WARD 08 PRECINCT 07,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,218
+Shawnee,TOPEKA WARD 08 PRECINCT 08,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,195
+Shawnee,TOPEKA WARD 08 PRECINCT 09,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,218
+Shawnee,TOPEKA WARD 08 PRECINCT 10,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,146
+Shawnee,TOPEKA WARD 08 PRECINCT 11,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,214
+Shawnee,TOPEKA WARD 09 PRECINCT 01,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,51
+Shawnee,TOPEKA WARD 09 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,140
+Shawnee,TOPEKA WARD 09 PRECINCT 03,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,260
+Shawnee,TOPEKA WARD 09 PRECINCT 04,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,243
+Shawnee,TOPEKA WARD 09 PRECINCT 05,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,209
+Shawnee,TOPEKA WARD 09 PRECINCT 06,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,222
+Shawnee,TOPEKA WARD 09 PRECINCT 08,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,298
+Shawnee,TOPEKA WARD 09 PRECINCT 09,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,156
+Shawnee,TOPEKA WARD 09 PRECINCT 10,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,319
+Shawnee,TOPEKA WARD 09 PRECINCT 11,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,179
+Shawnee,TOPEKA WARD 09 PRECINCT 12,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,116
+Shawnee,TOPEKA WARD 10 PRECINCT 01,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,237
+Shawnee,TOPEKA WARD 10 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,160
+Shawnee,TOPEKA WARD 10 PRECINCT 03,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,270
+Shawnee,TOPEKA WARD 10 PRECINCT 04,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,197
+Shawnee,TOPEKA WARD 10 PRECINCT 05,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,169
+Shawnee,TOPEKA WARD 10 PRECINCT 06,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,157
+Shawnee,TOPEKA WARD 10 PRECINCT 07,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,192
+Shawnee,TOPEKA WARD 10 PRECINCT 08,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,181
+Shawnee,TOPEKA WARD 10 PRECINCT 09,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,128
+Shawnee,TOPEKA WARD 10 PRECINCT 10,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,200
+Shawnee,TOPEKA WARD 10 PRECINCT 11,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,257
+Shawnee,TOPEKA WARD 10 PRECINCT 14,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,192
+Shawnee,TOPEKA WARD 11 PRECINCT 01,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,142
+Shawnee,TOPEKA WARD 11 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,193
+Shawnee,TOPEKA WARD 11 PRECINCT 03,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,153
+Shawnee,TOPEKA WARD 11 PRECINCT 04,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,260
+Shawnee,TOPEKA WARD 11 PRECINCT 05,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,205
+Shawnee,TOPEKA WARD 11 PRECINCT 06,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,187
+Shawnee,TOPEKA WARD 11 PRECINCT 07,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,177
+Shawnee,TOPEKA WARD 11 PRECINCT 08,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,171
+Shawnee,TOPEKA WARD 11 PRECINCT 09,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,186
+Shawnee,TOPEKA WARD 11 PRECINCT 10,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,146
+Shawnee,TOPEKA WARD 12 PRECINCT 01,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,208
+Shawnee,TOPEKA WARD 12 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,130
+Shawnee,TOPEKA WARD 12 PRECINCT 03,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,178
+Shawnee,TOPEKA WARD 12 PRECINCT 04,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,241
+Shawnee,TOPEKA WARD 12 PRECINCT 05,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,195
+Shawnee,TOPEKA WARD 12 PRECINCT 06,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,249
+Shawnee,TOPEKA WARD 12 PRECINCT 07,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,245
+Shawnee,TOPEKA WARD 12 PRECINCT 08,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,276
+Shawnee,TOPEKA WARD 12 PRECINCT 09,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,372
+Shawnee,TOPEKA WARD 12 PRECINCT 11,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,285
+Shawnee,TOPEKA WARD 12 PRECINCT 13,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,178
+Shawnee,TOPEKA WARD 12 PRECINCT 14,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,168
+Shawnee,TOPEKA WARD 12 PRECINCT 15,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,285
+Shawnee,TOPEKA WARD 12 PRECINCT 16,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,334
+Shawnee,TOPEKA WARD 12 PRECINCT 19,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,33
+Shawnee,TOPEKA WARD 12 PRECINCT 20,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,242
+Shawnee,TOPEKA WARD 12 PRECINCT 31,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,136
+Shawnee,TOPEKA WARD 13 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,73
+Shawnee,TOPEKA WARD 13 PRECINCT 05,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,6
+Shawnee,TOPEKA WARD 13 PRECINCT 06,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,18
+Shawnee,TOPEKA WARD 13 PRECINCT 09,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,30
+Shawnee,TOPEKA WARD 13 PRECINCT 12,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,234
+Shawnee,TOPEKA WARD 13 PRECINCT 21,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,54
+Shawnee,TOPEKA WARD 13 PRECINCT 22,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,26
+Shawnee,TOPEKA WARD 13 PRECINCT 30,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,64
+Shawnee,TOPEKA WARD 14 PRECINCT 01,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,312
+Shawnee,TOPEKA WARD 14 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,240
+Shawnee,TOPEKA WARD 14 PRECINCT 03,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,132
+Shawnee,TOPEKA WARD 14 PRECINCT 04,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,250
+Shawnee,TOPEKA WARD 14 PRECINCT 05,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,91
+Shawnee,TOPEKA WARD 15 PRECINCT 01,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,272
+Shawnee,TOPEKA WARD 15 PRECINCT 02,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,198
+Shawnee,TOPEKA WARD 15 PRECINCT 03,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,14
+Shawnee,VACQUERO,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,169
+Shawnee,VERBENA,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,39
+Shawnee,WAKARUSA,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,176
+Shawnee,WASHBURN,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,159
+Shawnee,WEST POTTER,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,21
+Shawnee,WEST ROSSVILLE,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,111
+Shawnee,WEST SILVER LAKE,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,166
+Shawnee,WEST WICHITA,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,101
+Shawnee,WHITFIELD,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,189
+Shawnee,WILLARD,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,137
+Shawnee,YORK,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,205
+Shawnee,YORK OUTER,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,20
+Shawnee,YUCCA,U.S. House,2,Tobias Schlingensiepen,Tobias,,Schlingensiepen,,Democratic,44
+Shawnee,EAST ROSSVILLE,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,248
+Shawnee,WEST ROSSVILLE,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,202
+Shawnee,EAST SILVER LAKE,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,272
+Shawnee,WEST SILVER LAKE,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,189
+Shawnee,GROVE,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,195
+Shawnee,KIRO,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,297
+Shawnee,MESSHOSS CREEK,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,192
+Shawnee,LITTLE MUDDY CREEK,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,175
+Shawnee,SAC,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,336
+Shawnee,SHERMAN,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,288
+Shawnee,IROQUIS,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,297
+Shawnee,WEST WICHITA,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,127
+Shawnee,INDIANOLA,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,307
+Shawnee,APACE,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,259
+Shawnee,EAST WICHITA,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,525
+Shawnee,FOX,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,295
+Shawnee,ELMOT,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,370
+Shawnee,KILMER,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,85
+Shawnee,ROCHESTER,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,230
+Shawnee,EAST SOLDIER,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,289
+Shawnee,WHITFIELD,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,201
+Shawnee,SIOUX,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,261
+Shawnee,POTTAWATOMIE,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,327
+Shawnee,WILLARD,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,204
+Shawnee,NORTH MISSION,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,94
+Shawnee,TOPEKA WARD 01 PRECINCT 01,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,63
+Shawnee,TOPEKA WARD 01 PRECINCT 02,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,73
+Shawnee,TOPEKA WARD 01 PRECINCT 03,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,93
+Shawnee,TOPEKA WARD 01 PRECINCT 04,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,151
+Shawnee,TOPEKA WARD 01 PRECINCT 05,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,225
+Shawnee,TOPEKA WARD 01 PRECINCT 06,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,299
+Shawnee,TOPEKA WARD 02 PRECINCT 11,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,82
+Shawnee,TOPEKA WARD 03 PRECINCT 01,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,110
+Shawnee,TOPEKA WARD 03 PRECINCT 02,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,90
+Shawnee,TOPEKA WARD 03 PRECINCT 03,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,39
+Shawnee,TOPEKA WARD 03 PRECINCT 04,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,82
+Shawnee,TOPEKA WARD 03 PRECINCT 05,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,54
+Shawnee,TOPEKA WARD 03 PRECINCT 06,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,55
+Shawnee,TOPEKA WARD 03 PRECINCT 07,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,81
+Shawnee,TOPEKA WARD 03 PRECINCT 08,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,89
+Shawnee,TOPEKA WARD 03 PRECINCT 09,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,91
+Shawnee,TOPEKA WARD 03 PRECINCT 10,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,8
+Shawnee,TOPEKA WARD 04 PRECINCT 06,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,82
+Shawnee,TOPEKA WARD 04 PRECINCT 14,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,1
+Shawnee,TOPEKA WARD 07 PRECINCT 01,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,110
+Shawnee,TOPEKA WARD 07 PRECINCT 02,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,105
+Shawnee,TOPEKA WARD 07 PRECINCT 03,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,101
+Shawnee,TOPEKA WARD 07 PRECINCT 04,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,145
+Shawnee,TOPEKA WARD 07 PRECINCT 05,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,136
+Shawnee,TOPEKA WARD 07 PRECINCT 06,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,119
+Shawnee,TOPEKA WARD 07 PRECINCT 07,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,99
+Shawnee,TOPEKA WARD 07 PRECINCT 09,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,106
+Shawnee,TOPEKA WARD 07 PRECINCT 10,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,100
+Shawnee,TOPEKA WARD 07 PRECINCT 11,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,162
+Shawnee,TOPEKA WARD 08 PRECINCT 01,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,70
+Shawnee,TOPEKA WARD 08 PRECINCT 02,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,91
+Shawnee,TOPEKA WARD 08 PRECINCT 03,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,127
+Shawnee,TOPEKA WARD 08 PRECINCT 04,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,132
+Shawnee,TOPEKA WARD 08 PRECINCT 05,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,193
+Shawnee,TOPEKA WARD 08 PRECINCT 07,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,99
+Shawnee,TOPEKA WARD 08 PRECINCT 08,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,111
+Shawnee,TOPEKA WARD 08 PRECINCT 09,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,147
+Shawnee,TOPEKA WARD 10 PRECINCT 01,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,146
+Shawnee,TOPEKA WARD 10 PRECINCT 02,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,199
+Shawnee,TOPEKA WARD 10 PRECINCT 04,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,131
+Shawnee,TOPEKA WARD 10 PRECINCT 11,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,212
+Shawnee,TOPEKA WARD 10 PRECINCT 14,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,169
+Shawnee,TOPEKA WARD 13 PRECINCT 30,State Senate,18,"Barta, Dick",Dick,,Barta,,Republican,67
+Shawnee,EAST ROSSVILLE,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,222
+Shawnee,WEST ROSSVILLE,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,146
+Shawnee,EAST SILVER LAKE,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,311
+Shawnee,WEST SILVER LAKE,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,212
+Shawnee,GROVE,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,134
+Shawnee,KIRO,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,235
+Shawnee,MESSHOSS CREEK,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,111
+Shawnee,LITTLE MUDDY CREEK,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,138
+Shawnee,SAC,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,224
+Shawnee,SHERMAN,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,217
+Shawnee,IROQUIS,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,225
+Shawnee,WEST WICHITA,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,109
+Shawnee,INDIANOLA,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,217
+Shawnee,APACE,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,193
+Shawnee,EAST WICHITA,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,416
+Shawnee,FOX,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,241
+Shawnee,ELMOT,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,297
+Shawnee,KILMER,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,66
+Shawnee,ROCHESTER,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,214
+Shawnee,EAST SOLDIER,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,255
+Shawnee,WHITFIELD,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,205
+Shawnee,SIOUX,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,190
+Shawnee,POTTAWATOMIE,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,242
+Shawnee,WILLARD,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,169
+Shawnee,NORTH MISSION,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,52
+Shawnee,TOPEKA WARD 01 PRECINCT 01,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,168
+Shawnee,TOPEKA WARD 01 PRECINCT 02,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,196
+Shawnee,TOPEKA WARD 01 PRECINCT 03,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,135
+Shawnee,TOPEKA WARD 01 PRECINCT 04,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,200
+Shawnee,TOPEKA WARD 01 PRECINCT 05,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,275
+Shawnee,TOPEKA WARD 01 PRECINCT 06,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,241
+Shawnee,TOPEKA WARD 02 PRECINCT 11,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,131
+Shawnee,TOPEKA WARD 03 PRECINCT 01,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,212
+Shawnee,TOPEKA WARD 03 PRECINCT 02,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,204
+Shawnee,TOPEKA WARD 03 PRECINCT 03,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,153
+Shawnee,TOPEKA WARD 03 PRECINCT 04,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,183
+Shawnee,TOPEKA WARD 03 PRECINCT 05,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,152
+Shawnee,TOPEKA WARD 03 PRECINCT 06,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,143
+Shawnee,TOPEKA WARD 03 PRECINCT 07,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,189
+Shawnee,TOPEKA WARD 03 PRECINCT 08,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,179
+Shawnee,TOPEKA WARD 03 PRECINCT 09,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,206
+Shawnee,TOPEKA WARD 03 PRECINCT 10,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,18
+Shawnee,TOPEKA WARD 04 PRECINCT 06,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,231
+Shawnee,TOPEKA WARD 04 PRECINCT 14,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,18
+Shawnee,TOPEKA WARD 07 PRECINCT 01,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,252
+Shawnee,TOPEKA WARD 07 PRECINCT 02,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,213
+Shawnee,TOPEKA WARD 07 PRECINCT 03,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,211
+Shawnee,TOPEKA WARD 07 PRECINCT 04,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,229
+Shawnee,TOPEKA WARD 07 PRECINCT 05,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,167
+Shawnee,TOPEKA WARD 07 PRECINCT 06,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,152
+Shawnee,TOPEKA WARD 07 PRECINCT 07,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,167
+Shawnee,TOPEKA WARD 07 PRECINCT 09,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,159
+Shawnee,TOPEKA WARD 07 PRECINCT 10,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,166
+Shawnee,TOPEKA WARD 07 PRECINCT 11,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,278
+Shawnee,TOPEKA WARD 08 PRECINCT 01,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,216
+Shawnee,TOPEKA WARD 08 PRECINCT 02,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,236
+Shawnee,TOPEKA WARD 08 PRECINCT 03,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,290
+Shawnee,TOPEKA WARD 08 PRECINCT 04,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,255
+Shawnee,TOPEKA WARD 08 PRECINCT 05,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,325
+Shawnee,TOPEKA WARD 08 PRECINCT 07,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,229
+Shawnee,TOPEKA WARD 08 PRECINCT 08,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,198
+Shawnee,TOPEKA WARD 08 PRECINCT 09,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,231
+Shawnee,TOPEKA WARD 10 PRECINCT 01,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,254
+Shawnee,TOPEKA WARD 10 PRECINCT 02,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,196
+Shawnee,TOPEKA WARD 10 PRECINCT 04,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,222
+Shawnee,TOPEKA WARD 10 PRECINCT 11,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,301
+Shawnee,TOPEKA WARD 10 PRECINCT 14,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,208
+Shawnee,TOPEKA WARD 13 PRECINCT 30,State Senate,18,"Kelly, Laura",Laura,,Kelly,,Democratic,69
+Shawnee,STINSON CREEK,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,95
+Shawnee,NORTH TECUMSEH,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,249
+Shawnee,SOUTH TECUMSEH,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,255
+Shawnee,PAWNEE,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,282
+Shawnee,KAW,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,281
+Shawnee,PECK,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,198
+Shawnee,EAST PECK,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,163
+Shawnee,KIOWA,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,385
+Shawnee,CHEYENNE,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,264
+Shawnee,PONCA,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,196
+Shawnee,DEER CREEK,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,7
+Shawnee,PAULINE,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,114
+Shawnee,NW MONMOUTH,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,341
+Shawnee,NE MONMOUTH,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,275
+Shawnee,S MONMOUTH,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,324
+Shawnee,FORBES,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,28
+Shawnee,KINGSTON,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,52
+Shawnee,TOPEKA WARD 02 PRECINCT 01,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,215
+Shawnee,TOPEKA WARD 02 PRECINCT 02,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,187
+Shawnee,TOPEKA WARD 02 PRECINCT 03,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,209
+Shawnee,TOPEKA WARD 02 PRECINCT 04,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,206
+Shawnee,TOPEKA WARD 02 PRECINCT 05,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,185
+Shawnee,TOPEKA WARD 02 PRECINCT 06,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,195
+Shawnee,TOPEKA WARD 02 PRECINCT 07,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,134
+Shawnee,TOPEKA WARD 02 PRECINCT 08,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,158
+Shawnee,TOPEKA WARD 02 PRECINCT 09,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,233
+Shawnee,TOPEKA WARD 02 PRECINCT 10,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,275
+Shawnee,TOPEKA WARD 04 PRECINCT 01,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,212
+Shawnee,TOPEKA WARD 04 PRECINCT 02,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,264
+Shawnee,TOPEKA WARD 04 PRECINCT 03,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,176
+Shawnee,TOPEKA WARD 04 PRECINCT 04,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,319
+Shawnee,TOPEKA WARD 04 PRECINCT 07,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,171
+Shawnee,TOPEKA WARD 04 PRECINCT 08,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,209
+Shawnee,TOPEKA WARD 04 PRECINCT 09,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,233
+Shawnee,TOPEKA WARD 04 PRECINCT 10,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,293
+Shawnee,TOPEKA WARD 04 PRECINCT 11,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,73
+Shawnee,TOPEKA WARD 04 PRECINCT 15,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,140
+Shawnee,TOPEKA WARD 05 PRECINCT 01,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,186
+Shawnee,TOPEKA WARD 05 PRECINCT 02,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,223
+Shawnee,TOPEKA WARD 05 PRECINCT 03,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,203
+Shawnee,TOPEKA WARD 05 PRECINCT 04,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,218
+Shawnee,TOPEKA WARD 05 PRECINCT 05,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,242
+Shawnee,TOPEKA WARD 05 PRECINCT 06,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,189
+Shawnee,TOPEKA WARD 05 PRECINCT 07,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,222
+Shawnee,TOPEKA WARD 05 PRECINCT 08,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,173
+Shawnee,TOPEKA WARD 05 PRECINCT 09,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,282
+Shawnee,TOPEKA WARD 05 PRECINCT 10,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,317
+Shawnee,TOPEKA WARD 05 PRECINCT 11,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,242
+Shawnee,TOPEKA WARD 05 PRECINCT 14,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,122
+Shawnee,TOPEKA WARD 05 PRECINCT 15,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,30
+Shawnee,TOPEKA WARD 05 PRECINCT 91,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,72
+Shawnee,TOPEKA WARD 06 PRECINCT 01,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,221
+Shawnee,TOPEKA WARD 06 PRECINCT 02,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,222
+Shawnee,TOPEKA WARD 06 PRECINCT 08,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,285
+Shawnee,TOPEKA WARD 09 PRECINCT 01,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,57
+Shawnee,TOPEKA WARD 15 PRECINCT 01,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,345
+Shawnee,TOPEKA WARD 15 PRECINCT 02,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,236
+Shawnee,TOPEKA WARD 15 PRECINCT 03,State Senate,19,"Hensley, Anthony  ",Anthony,,Hensley,,Democratic,16
+Shawnee,STINSON CREEK,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,90
+Shawnee,NORTH TECUMSEH,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,194
+Shawnee,SOUTH TECUMSEH,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,192
+Shawnee,PAWNEE,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,310
+Shawnee,KAW,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,224
+Shawnee,PECK,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,143
+Shawnee,EAST PECK,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,148
+Shawnee,KIOWA,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,320
+Shawnee,CHEYENNE,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,248
+Shawnee,PONCA,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,136
+Shawnee,DEER CREEK,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,16
+Shawnee,PAULINE,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,85
+Shawnee,NW MONMOUTH,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,322
+Shawnee,NE MONMOUTH,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,240
+Shawnee,S MONMOUTH,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,339
+Shawnee,FORBES,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,30
+Shawnee,KINGSTON,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,76
+Shawnee,TOPEKA WARD 02 PRECINCT 01,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,110
+Shawnee,TOPEKA WARD 02 PRECINCT 02,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,83
+Shawnee,TOPEKA WARD 02 PRECINCT 03,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,90
+Shawnee,TOPEKA WARD 02 PRECINCT 04,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,77
+Shawnee,TOPEKA WARD 02 PRECINCT 05,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,57
+Shawnee,TOPEKA WARD 02 PRECINCT 06,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,47
+Shawnee,TOPEKA WARD 02 PRECINCT 07,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,20
+Shawnee,TOPEKA WARD 02 PRECINCT 08,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,11
+Shawnee,TOPEKA WARD 02 PRECINCT 09,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,92
+Shawnee,TOPEKA WARD 02 PRECINCT 10,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,61
+Shawnee,TOPEKA WARD 04 PRECINCT 01,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,57
+Shawnee,TOPEKA WARD 04 PRECINCT 02,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,51
+Shawnee,TOPEKA WARD 04 PRECINCT 03,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,28
+Shawnee,TOPEKA WARD 04 PRECINCT 04,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,59
+Shawnee,TOPEKA WARD 04 PRECINCT 07,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,49
+Shawnee,TOPEKA WARD 04 PRECINCT 08,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,66
+Shawnee,TOPEKA WARD 04 PRECINCT 09,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,59
+Shawnee,TOPEKA WARD 04 PRECINCT 10,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,85
+Shawnee,TOPEKA WARD 04 PRECINCT 11,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,47
+Shawnee,TOPEKA WARD 04 PRECINCT 15,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,71
+Shawnee,TOPEKA WARD 05 PRECINCT 01,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,60
+Shawnee,TOPEKA WARD 05 PRECINCT 02,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,57
+Shawnee,TOPEKA WARD 05 PRECINCT 03,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,57
+Shawnee,TOPEKA WARD 05 PRECINCT 04,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,65
+Shawnee,TOPEKA WARD 05 PRECINCT 05,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,77
+Shawnee,TOPEKA WARD 05 PRECINCT 06,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,42
+Shawnee,TOPEKA WARD 05 PRECINCT 07,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,57
+Shawnee,TOPEKA WARD 05 PRECINCT 08,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,55
+Shawnee,TOPEKA WARD 05 PRECINCT 09,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,177
+Shawnee,TOPEKA WARD 05 PRECINCT 10,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,228
+Shawnee,TOPEKA WARD 05 PRECINCT 11,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,143
+Shawnee,TOPEKA WARD 05 PRECINCT 14,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,133
+Shawnee,TOPEKA WARD 05 PRECINCT 15,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,26
+Shawnee,TOPEKA WARD 05 PRECINCT 91,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,44
+Shawnee,TOPEKA WARD 06 PRECINCT 01,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,42
+Shawnee,TOPEKA WARD 06 PRECINCT 02,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,38
+Shawnee,TOPEKA WARD 06 PRECINCT 08,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,80
+Shawnee,TOPEKA WARD 09 PRECINCT 01,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,26
+Shawnee,TOPEKA WARD 15 PRECINCT 01,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,220
+Shawnee,TOPEKA WARD 15 PRECINCT 02,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,126
+Shawnee,TOPEKA WARD 15 PRECINCT 03,State Senate,19,"Moore, Casey W. ",Casey,W.,Moore,,Republican,16
+Shawnee,WEST POTTER,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,15
+Shawnee,CENTRAL PAULINE,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,28
+Shawnee,MONTARA,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,140
+Shawnee,CULLEN,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,166
+Shawnee,WAKARUSA,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,100
+Shawnee,CITY OF AUBURN,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,122
+Shawnee,MEADOWLARK,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,166
+Shawnee,BUFFALO,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,112
+Shawnee,GAILLARDIA,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,96
+Shawnee,DOVER,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,96
+Shawnee,YUCCA,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,33
+Shawnee,ALDERSGATE,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,63
+Shawnee,SUNFLOWER,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,140
+Shawnee,WASHBURN,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,94
+Shawnee,SOUTH MISSION,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,88
+Shawnee,CENTRAL MISSION,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,157
+Shawnee,SHERWOOD,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,102
+Shawnee,SOUTH SHERWOOD,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,57
+Shawnee,INDIAN HILLS,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,92
+Shawnee,YORK,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,136
+Shawnee,VACQUERO,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,112
+Shawnee,YORK OUTER,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,19
+Shawnee,VERBENA,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,18
+Shawnee,TOPEKA WARD 06 PRECINCT 03,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,72
+Shawnee,TOPEKA WARD 06 PRECINCT 04,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,127
+Shawnee,TOPEKA WARD 06 PRECINCT 05,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,155
+Shawnee,TOPEKA WARD 06 PRECINCT 06,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,110
+Shawnee,TOPEKA WARD 06 PRECINCT 07,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,94
+Shawnee,TOPEKA WARD 06 PRECINCT 09,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,251
+Shawnee,TOPEKA WARD 08 PRECINCT 06,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,73
+Shawnee,TOPEKA WARD 08 PRECINCT 10,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,71
+Shawnee,TOPEKA WARD 08 PRECINCT 11,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,128
+Shawnee,TOPEKA WARD 09 PRECINCT 02,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,117
+Shawnee,TOPEKA WARD 09 PRECINCT 03,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,158
+Shawnee,TOPEKA WARD 09 PRECINCT 04,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,149
+Shawnee,TOPEKA WARD 09 PRECINCT 05,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,170
+Shawnee,TOPEKA WARD 09 PRECINCT 06,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,138
+Shawnee,TOPEKA WARD 09 PRECINCT 08,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,225
+Shawnee,TOPEKA WARD 09 PRECINCT 09,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,75
+Shawnee,TOPEKA WARD 09 PRECINCT 10,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,178
+Shawnee,TOPEKA WARD 09 PRECINCT 11,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,73
+Shawnee,TOPEKA WARD 09 PRECINCT 12,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,86
+Shawnee,TOPEKA WARD 10 PRECINCT 03,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,183
+Shawnee,TOPEKA WARD 10 PRECINCT 05,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,110
+Shawnee,TOPEKA WARD 10 PRECINCT 06,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,93
+Shawnee,TOPEKA WARD 10 PRECINCT 07,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,116
+Shawnee,TOPEKA WARD 10 PRECINCT 08,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,121
+Shawnee,TOPEKA WARD 10 PRECINCT 09,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,100
+Shawnee,TOPEKA WARD 10 PRECINCT 10,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,140
+Shawnee,TOPEKA WARD 11 PRECINCT 01,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,99
+Shawnee,TOPEKA WARD 11 PRECINCT 02,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,130
+Shawnee,TOPEKA WARD 11 PRECINCT 03,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,100
+Shawnee,TOPEKA WARD 11 PRECINCT 04,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,154
+Shawnee,TOPEKA WARD 11 PRECINCT 05,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,133
+Shawnee,TOPEKA WARD 11 PRECINCT 06,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,139
+Shawnee,TOPEKA WARD 11 PRECINCT 07,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,127
+Shawnee,TOPEKA WARD 11 PRECINCT 08,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,98
+Shawnee,TOPEKA WARD 11 PRECINCT 09,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,141
+Shawnee,TOPEKA WARD 11 PRECINCT 10,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,108
+Shawnee,TOPEKA WARD 12 PRECINCT 01,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,167
+Shawnee,TOPEKA WARD 12 PRECINCT 02,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,118
+Shawnee,TOPEKA WARD 12 PRECINCT 03,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,112
+Shawnee,TOPEKA WARD 12 PRECINCT 04,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,140
+Shawnee,TOPEKA WARD 12 PRECINCT 05,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,79
+Shawnee,TOPEKA WARD 12 PRECINCT 06,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,156
+Shawnee,TOPEKA WARD 12 PRECINCT 07,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,167
+Shawnee,TOPEKA WARD 12 PRECINCT 08,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,195
+Shawnee,TOPEKA WARD 12 PRECINCT 09,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,242
+Shawnee,TOPEKA WARD 12 PRECINCT 11,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,142
+Shawnee,TOPEKA WARD 12 PRECINCT 13,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,97
+Shawnee,TOPEKA WARD 12 PRECINCT 14,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,90
+Shawnee,TOPEKA WARD 12 PRECINCT 15,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,174
+Shawnee,TOPEKA WARD 12 PRECINCT 16,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,204
+Shawnee,TOPEKA WARD 12 PRECINCT 19,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,40
+Shawnee,TOPEKA WARD 12 PRECINCT 20,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,143
+Shawnee,TOPEKA WARD 12 PRECINCT 31,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,78
+Shawnee,TOPEKA WARD 13 PRECINCT 02,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,55
+Shawnee,TOPEKA WARD 13 PRECINCT 05,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,8
+Shawnee,TOPEKA WARD 13 PRECINCT 06,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,18
+Shawnee,TOPEKA WARD 13 PRECINCT 09,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,12
+Shawnee,TOPEKA WARD 13 PRECINCT 12,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,132
+Shawnee,TOPEKA WARD 13 PRECINCT 21,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,30
+Shawnee,TOPEKA WARD 13 PRECINCT 22,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,18
+Shawnee,TOPEKA WARD 14 PRECINCT 01,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,218
+Shawnee,TOPEKA WARD 14 PRECINCT 02,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,122
+Shawnee,TOPEKA WARD 14 PRECINCT 03,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,84
+Shawnee,TOPEKA WARD 14 PRECINCT 04,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,105
+Shawnee,TOPEKA WARD 14 PRECINCT 05,State Senate,20,"Crowder, Terry L.",Terry,L.,Crowder,,Democratic,53
+Shawnee,WEST POTTER,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,6
+Shawnee,CENTRAL PAULINE,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,4
+Shawnee,MONTARA,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,20
+Shawnee,CULLEN,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,35
+Shawnee,WAKARUSA,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,34
+Shawnee,CITY OF AUBURN,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,52
+Shawnee,MEADOWLARK,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,46
+Shawnee,BUFFALO,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,57
+Shawnee,GAILLARDIA,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,35
+Shawnee,DOVER,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,42
+Shawnee,YUCCA,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,9
+Shawnee,ALDERSGATE,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,4
+Shawnee,SUNFLOWER,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,35
+Shawnee,WASHBURN,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,28
+Shawnee,SOUTH MISSION,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,27
+Shawnee,CENTRAL MISSION,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,44
+Shawnee,SHERWOOD,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,25
+Shawnee,SOUTH SHERWOOD,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,14
+Shawnee,INDIAN HILLS,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,22
+Shawnee,YORK,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,34
+Shawnee,VACQUERO,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,33
+Shawnee,YORK OUTER,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,2
+Shawnee,VERBENA,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,6
+Shawnee,TOPEKA WARD 06 PRECINCT 03,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,18
+Shawnee,TOPEKA WARD 06 PRECINCT 04,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,17
+Shawnee,TOPEKA WARD 06 PRECINCT 05,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,17
+Shawnee,TOPEKA WARD 06 PRECINCT 06,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,18
+Shawnee,TOPEKA WARD 06 PRECINCT 07,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,13
+Shawnee,TOPEKA WARD 06 PRECINCT 09,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,28
+Shawnee,TOPEKA WARD 08 PRECINCT 06,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,17
+Shawnee,TOPEKA WARD 08 PRECINCT 10,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,17
+Shawnee,TOPEKA WARD 08 PRECINCT 11,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,30
+Shawnee,TOPEKA WARD 09 PRECINCT 02,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,11
+Shawnee,TOPEKA WARD 09 PRECINCT 03,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,22
+Shawnee,TOPEKA WARD 09 PRECINCT 04,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,25
+Shawnee,TOPEKA WARD 09 PRECINCT 05,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,22
+Shawnee,TOPEKA WARD 09 PRECINCT 06,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,24
+Shawnee,TOPEKA WARD 09 PRECINCT 08,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,28
+Shawnee,TOPEKA WARD 09 PRECINCT 09,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,15
+Shawnee,TOPEKA WARD 09 PRECINCT 10,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,23
+Shawnee,TOPEKA WARD 09 PRECINCT 11,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,12
+Shawnee,TOPEKA WARD 09 PRECINCT 12,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,14
+Shawnee,TOPEKA WARD 10 PRECINCT 03,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,30
+Shawnee,TOPEKA WARD 10 PRECINCT 05,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,22
+Shawnee,TOPEKA WARD 10 PRECINCT 06,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,17
+Shawnee,TOPEKA WARD 10 PRECINCT 07,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,28
+Shawnee,TOPEKA WARD 10 PRECINCT 08,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,14
+Shawnee,TOPEKA WARD 10 PRECINCT 09,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,10
+Shawnee,TOPEKA WARD 10 PRECINCT 10,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,20
+Shawnee,TOPEKA WARD 11 PRECINCT 01,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,9
+Shawnee,TOPEKA WARD 11 PRECINCT 02,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,15
+Shawnee,TOPEKA WARD 11 PRECINCT 03,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,16
+Shawnee,TOPEKA WARD 11 PRECINCT 04,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,31
+Shawnee,TOPEKA WARD 11 PRECINCT 05,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,28
+Shawnee,TOPEKA WARD 11 PRECINCT 06,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,22
+Shawnee,TOPEKA WARD 11 PRECINCT 07,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,23
+Shawnee,TOPEKA WARD 11 PRECINCT 08,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,18
+Shawnee,TOPEKA WARD 11 PRECINCT 09,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,22
+Shawnee,TOPEKA WARD 11 PRECINCT 10,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,22
+Shawnee,TOPEKA WARD 12 PRECINCT 01,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,13
+Shawnee,TOPEKA WARD 12 PRECINCT 02,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,14
+Shawnee,TOPEKA WARD 12 PRECINCT 03,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,10
+Shawnee,TOPEKA WARD 12 PRECINCT 04,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,22
+Shawnee,TOPEKA WARD 12 PRECINCT 05,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,20
+Shawnee,TOPEKA WARD 12 PRECINCT 06,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,22
+Shawnee,TOPEKA WARD 12 PRECINCT 07,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,24
+Shawnee,TOPEKA WARD 12 PRECINCT 08,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,25
+Shawnee,TOPEKA WARD 12 PRECINCT 09,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,35
+Shawnee,TOPEKA WARD 12 PRECINCT 11,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,30
+Shawnee,TOPEKA WARD 12 PRECINCT 13,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,12
+Shawnee,TOPEKA WARD 12 PRECINCT 14,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,20
+Shawnee,TOPEKA WARD 12 PRECINCT 15,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,31
+Shawnee,TOPEKA WARD 12 PRECINCT 16,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,26
+Shawnee,TOPEKA WARD 12 PRECINCT 19,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,2
+Shawnee,TOPEKA WARD 12 PRECINCT 20,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,33
+Shawnee,TOPEKA WARD 12 PRECINCT 31,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,21
+Shawnee,TOPEKA WARD 13 PRECINCT 02,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,7
+Shawnee,TOPEKA WARD 13 PRECINCT 05,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,1
+Shawnee,TOPEKA WARD 13 PRECINCT 06,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,4
+Shawnee,TOPEKA WARD 13 PRECINCT 09,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,5
+Shawnee,TOPEKA WARD 13 PRECINCT 12,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,22
+Shawnee,TOPEKA WARD 13 PRECINCT 21,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,2
+Shawnee,TOPEKA WARD 13 PRECINCT 22,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,1
+Shawnee,TOPEKA WARD 14 PRECINCT 01,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,39
+Shawnee,TOPEKA WARD 14 PRECINCT 02,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,18
+Shawnee,TOPEKA WARD 14 PRECINCT 03,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,16
+Shawnee,TOPEKA WARD 14 PRECINCT 04,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,22
+Shawnee,TOPEKA WARD 14 PRECINCT 05,State Senate,20,"Hinchey, Clarence",Clarence,,Hinchey,,Libertarian,18
+Shawnee,WEST POTTER,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,48
+Shawnee,CENTRAL PAULINE,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,39
+Shawnee,MONTARA,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,180
+Shawnee,CULLEN,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,204
+Shawnee,WAKARUSA,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,322
+Shawnee,CITY OF AUBURN,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,291
+Shawnee,MEADOWLARK,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,441
+Shawnee,BUFFALO,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,295
+Shawnee,GAILLARDIA,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,320
+Shawnee,DOVER,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,206
+Shawnee,YUCCA,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,84
+Shawnee,ALDERSGATE,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,174
+Shawnee,SUNFLOWER,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,567
+Shawnee,WASHBURN,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,247
+Shawnee,SOUTH MISSION,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,219
+Shawnee,CENTRAL MISSION,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,393
+Shawnee,SHERWOOD,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,302
+Shawnee,SOUTH SHERWOOD,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,283
+Shawnee,INDIAN HILLS,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,335
+Shawnee,YORK,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,328
+Shawnee,VACQUERO,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,215
+Shawnee,YORK OUTER,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,34
+Shawnee,VERBENA,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,68
+Shawnee,TOPEKA WARD 06 PRECINCT 03,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,272
+Shawnee,TOPEKA WARD 06 PRECINCT 04,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,159
+Shawnee,TOPEKA WARD 06 PRECINCT 05,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,197
+Shawnee,TOPEKA WARD 06 PRECINCT 06,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,115
+Shawnee,TOPEKA WARD 06 PRECINCT 07,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,80
+Shawnee,TOPEKA WARD 06 PRECINCT 09,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,414
+Shawnee,TOPEKA WARD 08 PRECINCT 06,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,185
+Shawnee,TOPEKA WARD 08 PRECINCT 10,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,230
+Shawnee,TOPEKA WARD 08 PRECINCT 11,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,251
+Shawnee,TOPEKA WARD 09 PRECINCT 02,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,131
+Shawnee,TOPEKA WARD 09 PRECINCT 03,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,287
+Shawnee,TOPEKA WARD 09 PRECINCT 04,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,226
+Shawnee,TOPEKA WARD 09 PRECINCT 05,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,159
+Shawnee,TOPEKA WARD 09 PRECINCT 06,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,228
+Shawnee,TOPEKA WARD 09 PRECINCT 08,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,251
+Shawnee,TOPEKA WARD 09 PRECINCT 09,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,207
+Shawnee,TOPEKA WARD 09 PRECINCT 10,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,390
+Shawnee,TOPEKA WARD 09 PRECINCT 11,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,256
+Shawnee,TOPEKA WARD 09 PRECINCT 12,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,94
+Shawnee,TOPEKA WARD 10 PRECINCT 03,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,322
+Shawnee,TOPEKA WARD 10 PRECINCT 05,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,168
+Shawnee,TOPEKA WARD 10 PRECINCT 06,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,188
+Shawnee,TOPEKA WARD 10 PRECINCT 07,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,226
+Shawnee,TOPEKA WARD 10 PRECINCT 08,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,181
+Shawnee,TOPEKA WARD 10 PRECINCT 09,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,131
+Shawnee,TOPEKA WARD 10 PRECINCT 10,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,229
+Shawnee,TOPEKA WARD 11 PRECINCT 01,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,157
+Shawnee,TOPEKA WARD 11 PRECINCT 02,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,192
+Shawnee,TOPEKA WARD 11 PRECINCT 03,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,152
+Shawnee,TOPEKA WARD 11 PRECINCT 04,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,275
+Shawnee,TOPEKA WARD 11 PRECINCT 05,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,199
+Shawnee,TOPEKA WARD 11 PRECINCT 06,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,200
+Shawnee,TOPEKA WARD 11 PRECINCT 07,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,188
+Shawnee,TOPEKA WARD 11 PRECINCT 08,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,200
+Shawnee,TOPEKA WARD 11 PRECINCT 09,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,207
+Shawnee,TOPEKA WARD 11 PRECINCT 10,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,143
+Shawnee,TOPEKA WARD 12 PRECINCT 01,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,150
+Shawnee,TOPEKA WARD 12 PRECINCT 02,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,133
+Shawnee,TOPEKA WARD 12 PRECINCT 03,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,254
+Shawnee,TOPEKA WARD 12 PRECINCT 04,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,320
+Shawnee,TOPEKA WARD 12 PRECINCT 05,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,305
+Shawnee,TOPEKA WARD 12 PRECINCT 06,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,312
+Shawnee,TOPEKA WARD 12 PRECINCT 07,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,288
+Shawnee,TOPEKA WARD 12 PRECINCT 08,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,256
+Shawnee,TOPEKA WARD 12 PRECINCT 09,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,439
+Shawnee,TOPEKA WARD 12 PRECINCT 11,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,518
+Shawnee,TOPEKA WARD 12 PRECINCT 13,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,357
+Shawnee,TOPEKA WARD 12 PRECINCT 14,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,269
+Shawnee,TOPEKA WARD 12 PRECINCT 15,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,435
+Shawnee,TOPEKA WARD 12 PRECINCT 16,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,432
+Shawnee,TOPEKA WARD 12 PRECINCT 19,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,38
+Shawnee,TOPEKA WARD 12 PRECINCT 20,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,349
+Shawnee,TOPEKA WARD 12 PRECINCT 31,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,224
+Shawnee,TOPEKA WARD 13 PRECINCT 02,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,91
+Shawnee,TOPEKA WARD 13 PRECINCT 05,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,18
+Shawnee,TOPEKA WARD 13 PRECINCT 06,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,85
+Shawnee,TOPEKA WARD 13 PRECINCT 09,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,66
+Shawnee,TOPEKA WARD 13 PRECINCT 12,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,450
+Shawnee,TOPEKA WARD 13 PRECINCT 21,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,60
+Shawnee,TOPEKA WARD 13 PRECINCT 22,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,56
+Shawnee,TOPEKA WARD 14 PRECINCT 01,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,421
+Shawnee,TOPEKA WARD 14 PRECINCT 02,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,376
+Shawnee,TOPEKA WARD 14 PRECINCT 03,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,238
+Shawnee,TOPEKA WARD 14 PRECINCT 04,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,511
+Shawnee,TOPEKA WARD 14 PRECINCT 05,State Senate,20,"Schmidt, Vicki",Vicki,,Schmidt,,Republican,306
+Shawnee,KAW,State House,47,"Gonzalez, Ramon",Ramon,,Gonzalez,,Republican,237
+Shawnee,KILMER,State House,47,"Gonzalez, Ramon",Ramon,,Gonzalez,,Republican,73
+Shawnee,NORTH TECUMSEH,State House,47,"Gonzalez, Ramon",Ramon,,Gonzalez,,Republican,182
+Shawnee,SIOUX,State House,47,"Gonzalez, Ramon",Ramon,,Gonzalez,,Republican,233
+Shawnee,STINSON CREEK,State House,47,"Gonzalez, Ramon",Ramon,,Gonzalez,,Republican,89
+Shawnee,KAW,State House,47,"Hanson, Bruce",Bruce,,Hanson,,Democratic,253
+Shawnee,KILMER,State House,47,"Hanson, Bruce",Bruce,,Hanson,,Democratic,67
+Shawnee,NORTH TECUMSEH,State House,47,"Hanson, Bruce",Bruce,,Hanson,,Democratic,244
+Shawnee,SIOUX,State House,47,"Hanson, Bruce",Bruce,,Hanson,,Democratic,198
+Shawnee,STINSON CREEK,State House,47,"Hanson, Bruce",Bruce,,Hanson,,Democratic,84
+Shawnee,APACHE,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,202
+Shawnee,DOVER,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,140
+Shawnee,EAST SILVER LAKE,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,275
+Shawnee,EAST SOLDIER,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,263
+Shawnee,EAST WICHITA,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,434
+Shawnee,ELMONT,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,292
+Shawnee,FOX,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,230
+Shawnee,GROVE,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,117
+Shawnee,INDIANOLA,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,215
+Shawnee,IROQUIS,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,204
+Shawnee,KIRO,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,211
+Shawnee,LITTLE MUDDY CREEK,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,130
+Shawnee,MESSHOSS CREEK,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,97
+Shawnee,POTTAWATOMIE,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,254
+Shawnee,ROCHESTER,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,196
+Shawnee,SAC,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,226
+Shawnee,SHERMAN,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,214
+Shawnee,TOPEKA WARD 01 PRECINCT 05,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,267
+Shawnee,TOPEKA WARD 01 PRECINCT 06,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,260
+Shawnee,WEST SILVER LAKE,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,179
+Shawnee,WEST WICHITA,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,117
+Shawnee,WHITFIELD,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,207
+Shawnee,WILLARD,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,143
+Shawnee,YUCCA,State House,50,"Gatewood, Sean",Sean,,Gatewood,,Democratic,40
+Shawnee,APACHE,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,237
+Shawnee,DOVER,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,204
+Shawnee,EAST SILVER LAKE,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,285
+Shawnee,EAST SOLDIER,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,258
+Shawnee,EAST WICHITA,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,488
+Shawnee,ELMONT,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,345
+Shawnee,FOX,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,287
+Shawnee,GROVE,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,197
+Shawnee,INDIANOLA,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,298
+Shawnee,IROQUIS,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,299
+Shawnee,KIRO,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,304
+Shawnee,LITTLE MUDDY CREEK,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,175
+Shawnee,MESSHOSS CREEK,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,191
+Shawnee,POTTAWATOMIE,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,295
+Shawnee,ROCHESTER,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,228
+Shawnee,SAC,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,320
+Shawnee,SHERMAN,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,268
+Shawnee,TOPEKA WARD 01 PRECINCT 05,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,224
+Shawnee,TOPEKA WARD 01 PRECINCT 06,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,269
+Shawnee,WEST SILVER LAKE,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,207
+Shawnee,WEST WICHITA,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,120
+Shawnee,WHITFIELD,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,195
+Shawnee,WILLARD,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,212
+Shawnee,YUCCA,State House,50,"Powell, Joshua",Joshua,,Powell,,Republican,80
+Shawnee,EAST ROSSVILLE,State House,51,"Highland, Ron  ",Ron,,Highland,,Republican,281
+Shawnee,WEST ROSSVILLE,State House,51,"Highland, Ron  ",Ron,,Highland,,Republican,220
+Shawnee,EAST ROSSVILLE,State House,51,"Pikul, Richard R ",Richard,R,Pikul,,Democratic,160
+Shawnee,WEST ROSSVILLE,State House,51,"Pikul, Richard R ",Richard,R,Pikul,,Democratic,106
+Shawnee,ALDERSGATE,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,120
+Shawnee,CENTRAL MISSION,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,242
+Shawnee,GAILLARDIA,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,187
+Shawnee,INDIAN HILLS,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,201
+Shawnee,NORTH MISSION,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,56
+Shawnee,SHERWOOD,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,199
+Shawnee,SOUTH MISSION,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,154
+Shawnee,SOUTH SHERWOOD,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,130
+Shawnee,SUNFLOWER,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,267
+Shawnee,TOPEKA WARD 12 PRECINCT 05,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,198
+Shawnee,TOPEKA WARD 12 PRECINCT 06,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,287
+Shawnee,TOPEKA WARD 12 PRECINCT 07,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,262
+Shawnee,TOPEKA WARD 12 PRECINCT 08,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,264
+Shawnee,TOPEKA WARD 12 PRECINCT 11,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,308
+Shawnee,TOPEKA WARD 12 PRECINCT 14,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,175
+Shawnee,TOPEKA WARD 12 PRECINCT 15,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,339
+Shawnee,TOPEKA WARD 12 PRECINCT 16,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,382
+Shawnee,TOPEKA WARD 12 PRECINCT 20,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,263
+Shawnee,TOPEKA WARD 13 PRECINCT 02,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,83
+Shawnee,TOPEKA WARD 13 PRECINCT 06,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,23
+Shawnee,TOPEKA WARD 13 PRECINCT 09,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,32
+Shawnee,TOPEKA WARD 13 PRECINCT 12,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,241
+Shawnee,TOPEKA WARD 13 PRECINCT 21,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,58
+Shawnee,TOPEKA WARD 13 PRECINCT 22,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,38
+Shawnee,TOPEKA WARD 14 PRECINCT 04,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,235
+Shawnee,TOPEKA WARD 14 PRECINCT 05,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,98
+Shawnee,VACQUERO,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,180
+Shawnee,WASHBURN,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,160
+Shawnee,YORK,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,221
+Shawnee,YORK OUTER,State House,52,"Gandhi, Shanti",Shanti,,Gandhi,,Republican,22
+Shawnee,ALDERSGATE,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,115
+Shawnee,CENTRAL MISSION,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,351
+Shawnee,GAILLARDIA,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,260
+Shawnee,INDIAN HILLS,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,256
+Shawnee,NORTH MISSION,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,88
+Shawnee,SHERWOOD,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,238
+Shawnee,SOUTH MISSION,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,181
+Shawnee,SOUTH SHERWOOD,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,223
+Shawnee,SUNFLOWER,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,479
+Shawnee,TOPEKA WARD 12 PRECINCT 05,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,198
+Shawnee,TOPEKA WARD 12 PRECINCT 06,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,199
+Shawnee,TOPEKA WARD 12 PRECINCT 07,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,209
+Shawnee,TOPEKA WARD 12 PRECINCT 08,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,211
+Shawnee,TOPEKA WARD 12 PRECINCT 11,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,386
+Shawnee,TOPEKA WARD 12 PRECINCT 14,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,211
+Shawnee,TOPEKA WARD 12 PRECINCT 15,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,304
+Shawnee,TOPEKA WARD 12 PRECINCT 16,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,282
+Shawnee,TOPEKA WARD 12 PRECINCT 20,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,263
+Shawnee,TOPEKA WARD 13 PRECINCT 02,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,68
+Shawnee,TOPEKA WARD 13 PRECINCT 06,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,81
+Shawnee,TOPEKA WARD 13 PRECINCT 09,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,52
+Shawnee,TOPEKA WARD 13 PRECINCT 12,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,359
+Shawnee,TOPEKA WARD 13 PRECINCT 21,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,31
+Shawnee,TOPEKA WARD 13 PRECINCT 22,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,38
+Shawnee,TOPEKA WARD 14 PRECINCT 04,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,412
+Shawnee,TOPEKA WARD 14 PRECINCT 05,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,283
+Shawnee,VACQUERO,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,178
+Shawnee,WASHBURN,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,203
+Shawnee,YORK,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,277
+Shawnee,YORK OUTER,State House,52,"Ensley, Ted",Ted,,Ensley,,Democratic,36
+Shawnee,TOPEKA WARD 10 PRECINCT 01,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,143
+Shawnee,TOPEKA WARD 10 PRECINCT 02,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,202
+Shawnee,TOPEKA WARD 10 PRECINCT 03,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,243
+Shawnee,TOPEKA WARD 10 PRECINCT 04,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,146
+Shawnee,TOPEKA WARD 10 PRECINCT 05,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,130
+Shawnee,TOPEKA WARD 10 PRECINCT 06,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,151
+Shawnee,TOPEKA WARD 10 PRECINCT 07,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,179
+Shawnee,TOPEKA WARD 10 PRECINCT 08,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,122
+Shawnee,TOPEKA WARD 10 PRECINCT 09,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,111
+Shawnee,TOPEKA WARD 10 PRECINCT 10,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,184
+Shawnee,TOPEKA WARD 10 PRECINCT 11,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,207
+Shawnee,TOPEKA WARD 10 PRECINCT 14,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,163
+Shawnee,TOPEKA WARD 11 PRECINCT 01,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,122
+Shawnee,TOPEKA WARD 11 PRECINCT 02,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,145
+Shawnee,TOPEKA WARD 11 PRECINCT 03,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,122
+Shawnee,TOPEKA WARD 11 PRECINCT 04,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,205
+Shawnee,TOPEKA WARD 11 PRECINCT 05,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,159
+Shawnee,TOPEKA WARD 11 PRECINCT 06,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,159
+Shawnee,TOPEKA WARD 11 PRECINCT 07,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,156
+Shawnee,TOPEKA WARD 11 PRECINCT 08,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,152
+Shawnee,TOPEKA WARD 11 PRECINCT 09,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,170
+Shawnee,TOPEKA WARD 11 PRECINCT 10,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,111
+Shawnee,TOPEKA WARD 12 PRECINCT 01,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,127
+Shawnee,TOPEKA WARD 12 PRECINCT 02,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,113
+Shawnee,TOPEKA WARD 12 PRECINCT 03,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,201
+Shawnee,TOPEKA WARD 12 PRECINCT 04,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,243
+Shawnee,TOPEKA WARD 12 PRECINCT 13,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,294
+Shawnee,TOPEKA WARD 12 PRECINCT 19,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,45
+Shawnee,TOPEKA WARD 12 PRECINCT 31,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,197
+Shawnee,TOPEKA WARD 13 PRECINCT 05,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,15
+Shawnee,TOPEKA WARD 13 PRECINCT 30,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,74
+Shawnee,VERBENA,State House,53,"Burgess, Mike",Mike,,Burgess,,Republican,62
+Shawnee,TOPEKA WARD 10 PRECINCT 01,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,255
+Shawnee,TOPEKA WARD 10 PRECINCT 02,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,186
+Shawnee,TOPEKA WARD 10 PRECINCT 03,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,297
+Shawnee,TOPEKA WARD 10 PRECINCT 04,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,204
+Shawnee,TOPEKA WARD 10 PRECINCT 05,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,176
+Shawnee,TOPEKA WARD 10 PRECINCT 06,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,152
+Shawnee,TOPEKA WARD 10 PRECINCT 07,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,195
+Shawnee,TOPEKA WARD 10 PRECINCT 08,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,198
+Shawnee,TOPEKA WARD 10 PRECINCT 09,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,133
+Shawnee,TOPEKA WARD 10 PRECINCT 10,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,209
+Shawnee,TOPEKA WARD 10 PRECINCT 11,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,299
+Shawnee,TOPEKA WARD 10 PRECINCT 14,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,211
+Shawnee,TOPEKA WARD 11 PRECINCT 01,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,150
+Shawnee,TOPEKA WARD 11 PRECINCT 02,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,195
+Shawnee,TOPEKA WARD 11 PRECINCT 03,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,149
+Shawnee,TOPEKA WARD 11 PRECINCT 04,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,259
+Shawnee,TOPEKA WARD 11 PRECINCT 05,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,206
+Shawnee,TOPEKA WARD 11 PRECINCT 06,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,198
+Shawnee,TOPEKA WARD 11 PRECINCT 07,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,182
+Shawnee,TOPEKA WARD 11 PRECINCT 08,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,165
+Shawnee,TOPEKA WARD 11 PRECINCT 09,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,204
+Shawnee,TOPEKA WARD 11 PRECINCT 10,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,160
+Shawnee,TOPEKA WARD 12 PRECINCT 01,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,207
+Shawnee,TOPEKA WARD 12 PRECINCT 02,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,147
+Shawnee,TOPEKA WARD 12 PRECINCT 03,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,185
+Shawnee,TOPEKA WARD 12 PRECINCT 04,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,242
+Shawnee,TOPEKA WARD 12 PRECINCT 13,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,181
+Shawnee,TOPEKA WARD 12 PRECINCT 19,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,36
+Shawnee,TOPEKA WARD 12 PRECINCT 31,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,127
+Shawnee,TOPEKA WARD 13 PRECINCT 05,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,9
+Shawnee,TOPEKA WARD 13 PRECINCT 30,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,64
+Shawnee,VERBENA,State House,53,"Tietze, Annie",Annie,,Tietze,,Democratic,34
+Shawnee,BUFFALO,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,300
+Shawnee,CITY OF AUBURN,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,264
+Shawnee,CULLEN,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,160
+Shawnee,FORBES,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,30
+Shawnee,KINGSTON,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,79
+Shawnee,KIOWA,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,258
+Shawnee,MEADOWLARK,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,404
+Shawnee,MONTARA,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,126
+Shawnee,NE MONMOUTH,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,229
+Shawnee,NW MONMOUTH,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,290
+Shawnee,PAWNEE,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,276
+Shawnee,PONCA,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,130
+Shawnee,S MONMOUTH,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,318
+Shawnee,SOUTH TECUMSEH,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,177
+Shawnee,TOPEKA WARD 05 PRECINCT 15,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,22
+Shawnee,TOPEKA WARD 05 PRECINCT 91,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,44
+Shawnee,WAKARUSA,State House,54,"Corbet, Ken",Ken,,Corbet,,Republican,245
+Shawnee,BUFFALO,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,174
+Shawnee,CITY OF AUBURN,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,207
+Shawnee,CULLEN,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,248
+Shawnee,FORBES,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,27
+Shawnee,KINGSTON,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,47
+Shawnee,KIOWA,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,449
+Shawnee,MEADOWLARK,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,248
+Shawnee,MONTARA,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,213
+Shawnee,NE MONMOUTH,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,282
+Shawnee,NW MONMOUTH,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,371
+Shawnee,PAWNEE,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,317
+Shawnee,PONCA,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,204
+Shawnee,S MONMOUTH,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,346
+Shawnee,SOUTH TECUMSEH,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,269
+Shawnee,TOPEKA WARD 05 PRECINCT 15,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,34
+Shawnee,TOPEKA WARD 05 PRECINCT 91,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,72
+Shawnee,WAKARUSA,State House,54,"Mah, Ann",Ann,,Mah,,Democratic,220
+Shawnee,TOPEKA WARD 03 PRECINCT 01,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,174
+Shawnee,TOPEKA WARD 03 PRECINCT 02,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,187
+Shawnee,TOPEKA WARD 03 PRECINCT 03,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,145
+Shawnee,TOPEKA WARD 03 PRECINCT 04,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,172
+Shawnee,TOPEKA WARD 03 PRECINCT 05,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,143
+Shawnee,TOPEKA WARD 03 PRECINCT 06,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,133
+Shawnee,TOPEKA WARD 03 PRECINCT 07,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,190
+Shawnee,TOPEKA WARD 07 PRECINCT 01,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,236
+Shawnee,TOPEKA WARD 07 PRECINCT 02,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,180
+Shawnee,TOPEKA WARD 07 PRECINCT 03,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,186
+Shawnee,TOPEKA WARD 07 PRECINCT 04,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,199
+Shawnee,TOPEKA WARD 07 PRECINCT 05,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,129
+Shawnee,TOPEKA WARD 07 PRECINCT 06,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,123
+Shawnee,TOPEKA WARD 07 PRECINCT 07,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,159
+Shawnee,TOPEKA WARD 07 PRECINCT 09,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,122
+Shawnee,TOPEKA WARD 07 PRECINCT 10,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,149
+Shawnee,TOPEKA WARD 07 PRECINCT 11,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,261
+Shawnee,TOPEKA WARD 08 PRECINCT 01,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,198
+Shawnee,TOPEKA WARD 08 PRECINCT 02,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,226
+Shawnee,TOPEKA WARD 08 PRECINCT 03,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,274
+Shawnee,TOPEKA WARD 08 PRECINCT 04,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,230
+Shawnee,TOPEKA WARD 08 PRECINCT 05,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,293
+Shawnee,TOPEKA WARD 08 PRECINCT 06,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,156
+Shawnee,TOPEKA WARD 08 PRECINCT 07,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,223
+Shawnee,TOPEKA WARD 08 PRECINCT 08,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,182
+Shawnee,TOPEKA WARD 08 PRECINCT 09,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,209
+Shawnee,TOPEKA WARD 08 PRECINCT 10,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,172
+Shawnee,TOPEKA WARD 08 PRECINCT 11,State House,55,"Kuether, Annie",Annie,,Kuether,,Democratic,206
+Shawnee,TOPEKA WARD 03 PRECINCT 01,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,144
+Shawnee,TOPEKA WARD 03 PRECINCT 02,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,100
+Shawnee,TOPEKA WARD 03 PRECINCT 03,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,43
+Shawnee,TOPEKA WARD 03 PRECINCT 04,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,86
+Shawnee,TOPEKA WARD 03 PRECINCT 05,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,60
+Shawnee,TOPEKA WARD 03 PRECINCT 06,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,59
+Shawnee,TOPEKA WARD 03 PRECINCT 07,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,75
+Shawnee,TOPEKA WARD 07 PRECINCT 01,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,121
+Shawnee,TOPEKA WARD 07 PRECINCT 02,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,130
+Shawnee,TOPEKA WARD 07 PRECINCT 03,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,124
+Shawnee,TOPEKA WARD 07 PRECINCT 04,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,169
+Shawnee,TOPEKA WARD 07 PRECINCT 05,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,168
+Shawnee,TOPEKA WARD 07 PRECINCT 06,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,147
+Shawnee,TOPEKA WARD 07 PRECINCT 07,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,105
+Shawnee,TOPEKA WARD 07 PRECINCT 09,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,138
+Shawnee,TOPEKA WARD 07 PRECINCT 10,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,112
+Shawnee,TOPEKA WARD 07 PRECINCT 11,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,176
+Shawnee,TOPEKA WARD 08 PRECINCT 01,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,90
+Shawnee,TOPEKA WARD 08 PRECINCT 02,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,100
+Shawnee,TOPEKA WARD 08 PRECINCT 03,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,147
+Shawnee,TOPEKA WARD 08 PRECINCT 04,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,151
+Shawnee,TOPEKA WARD 08 PRECINCT 05,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,221
+Shawnee,TOPEKA WARD 08 PRECINCT 06,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,120
+Shawnee,TOPEKA WARD 08 PRECINCT 07,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,105
+Shawnee,TOPEKA WARD 08 PRECINCT 08,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,126
+Shawnee,TOPEKA WARD 08 PRECINCT 09,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,166
+Shawnee,TOPEKA WARD 08 PRECINCT 10,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,150
+Shawnee,TOPEKA WARD 08 PRECINCT 11,State House,55,"Nioce, Becky",Becky,,Nioce,,Republican,201
+Shawnee,CENTRAL PAULINE,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,37
+Shawnee,PAULINE,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,94
+Shawnee,TOPEKA WARD 04 PRECINCT 15,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,95
+Shawnee,TOPEKA WARD 06 PRECINCT 03,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,207
+Shawnee,TOPEKA WARD 06 PRECINCT 04,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,115
+Shawnee,TOPEKA WARD 06 PRECINCT 05,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,164
+Shawnee,TOPEKA WARD 06 PRECINCT 06,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,101
+Shawnee,TOPEKA WARD 06 PRECINCT 07,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,73
+Shawnee,TOPEKA WARD 06 PRECINCT 09,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,326
+Shawnee,TOPEKA WARD 09 PRECINCT 01,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,32
+Shawnee,TOPEKA WARD 09 PRECINCT 02,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,127
+Shawnee,TOPEKA WARD 09 PRECINCT 03,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,228
+Shawnee,TOPEKA WARD 09 PRECINCT 04,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,185
+Shawnee,TOPEKA WARD 09 PRECINCT 05,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,137
+Shawnee,TOPEKA WARD 09 PRECINCT 06,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,189
+Shawnee,TOPEKA WARD 09 PRECINCT 08,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,188
+Shawnee,TOPEKA WARD 09 PRECINCT 09,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,135
+Shawnee,TOPEKA WARD 09 PRECINCT 10,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,255
+Shawnee,TOPEKA WARD 09 PRECINCT 11,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,183
+Shawnee,TOPEKA WARD 09 PRECINCT 12,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,73
+Shawnee,TOPEKA WARD 12 PRECINCT 09,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,344
+Shawnee,TOPEKA WARD 14 PRECINCT 01,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,357
+Shawnee,TOPEKA WARD 14 PRECINCT 02,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,279
+Shawnee,TOPEKA WARD 14 PRECINCT 03,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,205
+Shawnee,TOPEKA WARD 15 PRECINCT 01,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,264
+Shawnee,TOPEKA WARD 15 PRECINCT 02,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,168
+Shawnee,TOPEKA WARD 15 PRECINCT 03,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,17
+Shawnee,WEST POTTER,State House,56,"Mitchell, Janet",Janet,,Mitchell,,Republican,50
+Shawnee,CENTRAL PAULINE,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,36
+Shawnee,PAULINE,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,105
+Shawnee,TOPEKA WARD 04 PRECINCT 15,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,111
+Shawnee,TOPEKA WARD 06 PRECINCT 03,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,149
+Shawnee,TOPEKA WARD 06 PRECINCT 04,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,184
+Shawnee,TOPEKA WARD 06 PRECINCT 05,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,197
+Shawnee,TOPEKA WARD 06 PRECINCT 06,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,139
+Shawnee,TOPEKA WARD 06 PRECINCT 07,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,111
+Shawnee,TOPEKA WARD 06 PRECINCT 09,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,345
+Shawnee,TOPEKA WARD 09 PRECINCT 01,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,46
+Shawnee,TOPEKA WARD 09 PRECINCT 02,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,134
+Shawnee,TOPEKA WARD 09 PRECINCT 03,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,234
+Shawnee,TOPEKA WARD 09 PRECINCT 04,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,217
+Shawnee,TOPEKA WARD 09 PRECINCT 05,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,212
+Shawnee,TOPEKA WARD 09 PRECINCT 06,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,197
+Shawnee,TOPEKA WARD 09 PRECINCT 08,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,304
+Shawnee,TOPEKA WARD 09 PRECINCT 09,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,156
+Shawnee,TOPEKA WARD 09 PRECINCT 10,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,313
+Shawnee,TOPEKA WARD 09 PRECINCT 11,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,156
+Shawnee,TOPEKA WARD 09 PRECINCT 12,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,118
+Shawnee,TOPEKA WARD 12 PRECINCT 09,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,348
+Shawnee,TOPEKA WARD 14 PRECINCT 01,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,311
+Shawnee,TOPEKA WARD 14 PRECINCT 02,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,234
+Shawnee,TOPEKA WARD 14 PRECINCT 03,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,133
+Shawnee,TOPEKA WARD 15 PRECINCT 01,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,290
+Shawnee,TOPEKA WARD 15 PRECINCT 02,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,175
+Shawnee,TOPEKA WARD 15 PRECINCT 03,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,14
+Shawnee,WEST POTTER,State House,56,"Weigel, Virgil",Virgil,,Weigel,,Democratic,20
+Shawnee,CHEYENNE,State House,57,"Alcala, John",John,,Alcala,,Democratic,271
+Shawnee,EAST PECK,State House,57,"Alcala, John",John,,Alcala,,Democratic,167
+Shawnee,PECK,State House,57,"Alcala, John",John,,Alcala,,Democratic,190
+Shawnee,TOPEKA WARD 01 PRECINCT 01,State House,57,"Alcala, John",John,,Alcala,,Democratic,179
+Shawnee,TOPEKA WARD 01 PRECINCT 02,State House,57,"Alcala, John",John,,Alcala,,Democratic,213
+Shawnee,TOPEKA WARD 01 PRECINCT 03,State House,57,"Alcala, John",John,,Alcala,,Democratic,156
+Shawnee,TOPEKA WARD 01 PRECINCT 04,State House,57,"Alcala, John",John,,Alcala,,Democratic,264
+Shawnee,TOPEKA WARD 02 PRECINCT 01,State House,57,"Alcala, John",John,,Alcala,,Democratic,232
+Shawnee,TOPEKA WARD 02 PRECINCT 02,State House,57,"Alcala, John",John,,Alcala,,Democratic,187
+Shawnee,TOPEKA WARD 02 PRECINCT 03,State House,57,"Alcala, John",John,,Alcala,,Democratic,218
+Shawnee,TOPEKA WARD 02 PRECINCT 04,State House,57,"Alcala, John",John,,Alcala,,Democratic,212
+Shawnee,TOPEKA WARD 02 PRECINCT 05,State House,57,"Alcala, John",John,,Alcala,,Democratic,188
+Shawnee,TOPEKA WARD 02 PRECINCT 06,State House,57,"Alcala, John",John,,Alcala,,Democratic,189
+Shawnee,TOPEKA WARD 02 PRECINCT 07,State House,57,"Alcala, John",John,,Alcala,,Democratic,133
+Shawnee,TOPEKA WARD 02 PRECINCT 08,State House,57,"Alcala, John",John,,Alcala,,Democratic,151
+Shawnee,TOPEKA WARD 02 PRECINCT 09,State House,57,"Alcala, John",John,,Alcala,,Democratic,232
+Shawnee,TOPEKA WARD 02 PRECINCT 10,State House,57,"Alcala, John",John,,Alcala,,Democratic,283
+Shawnee,TOPEKA WARD 02 PRECINCT 11,State House,57,"Alcala, John",John,,Alcala,,Democratic,125
+Shawnee,TOPEKA WARD 03 PRECINCT 10,State House,57,"Alcala, John",John,,Alcala,,Democratic,16
+Shawnee,TOPEKA WARD 04 PRECINCT 01,State House,57,"Alcala, John",John,,Alcala,,Democratic,219
+Shawnee,TOPEKA WARD 04 PRECINCT 02,State House,57,"Alcala, John",John,,Alcala,,Democratic,254
+Shawnee,TOPEKA WARD 04 PRECINCT 03,State House,57,"Alcala, John",John,,Alcala,,Democratic,180
+Shawnee,TOPEKA WARD 05 PRECINCT 11,State House,57,"Alcala, John",John,,Alcala,,Democratic,242
+Shawnee,TOPEKA WARD 05 PRECINCT 14,State House,57,"Alcala, John",John,,Alcala,,Democratic,125
+Shawnee,CHEYENNE,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,233
+Shawnee,EAST PECK,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,140
+Shawnee,PECK,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,149
+Shawnee,TOPEKA WARD 01 PRECINCT 01,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,52
+Shawnee,TOPEKA WARD 01 PRECINCT 02,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,54
+Shawnee,TOPEKA WARD 01 PRECINCT 03,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,70
+Shawnee,TOPEKA WARD 01 PRECINCT 04,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,85
+Shawnee,TOPEKA WARD 02 PRECINCT 01,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,96
+Shawnee,TOPEKA WARD 02 PRECINCT 02,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,83
+Shawnee,TOPEKA WARD 02 PRECINCT 03,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,74
+Shawnee,TOPEKA WARD 02 PRECINCT 04,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,66
+Shawnee,TOPEKA WARD 02 PRECINCT 05,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,51
+Shawnee,TOPEKA WARD 02 PRECINCT 06,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,52
+Shawnee,TOPEKA WARD 02 PRECINCT 07,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,22
+Shawnee,TOPEKA WARD 02 PRECINCT 08,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,16
+Shawnee,TOPEKA WARD 02 PRECINCT 09,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,92
+Shawnee,TOPEKA WARD 02 PRECINCT 10,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,56
+Shawnee,TOPEKA WARD 02 PRECINCT 11,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,80
+Shawnee,TOPEKA WARD 03 PRECINCT 10,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,9
+Shawnee,TOPEKA WARD 04 PRECINCT 01,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,46
+Shawnee,TOPEKA WARD 04 PRECINCT 02,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,53
+Shawnee,TOPEKA WARD 04 PRECINCT 03,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,21
+Shawnee,TOPEKA WARD 05 PRECINCT 11,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,141
+Shawnee,TOPEKA WARD 05 PRECINCT 14,State House,57,"Rosenow, Aimee",Aimee,,Rosenow,,Republican,128
+Shawnee,DEER CREEK,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,9
+Shawnee,TOPEKA WARD 03 PRECINCT 08,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,177
+Shawnee,TOPEKA WARD 03 PRECINCT 09,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,213
+Shawnee,TOPEKA WARD 04 PRECINCT 04,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,313
+Shawnee,TOPEKA WARD 04 PRECINCT 06,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,244
+Shawnee,TOPEKA WARD 04 PRECINCT 07,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,173
+Shawnee,TOPEKA WARD 04 PRECINCT 08,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,200
+Shawnee,TOPEKA WARD 04 PRECINCT 09,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,233
+Shawnee,TOPEKA WARD 04 PRECINCT 10,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,283
+Shawnee,TOPEKA WARD 04 PRECINCT 11,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,65
+Shawnee,TOPEKA WARD 04 PRECINCT 14,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,21
+Shawnee,TOPEKA WARD 05 PRECINCT 01,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,178
+Shawnee,TOPEKA WARD 05 PRECINCT 02,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,215
+Shawnee,TOPEKA WARD 05 PRECINCT 03,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,187
+Shawnee,TOPEKA WARD 05 PRECINCT 04,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,210
+Shawnee,TOPEKA WARD 05 PRECINCT 05,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,227
+Shawnee,TOPEKA WARD 05 PRECINCT 06,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,186
+Shawnee,TOPEKA WARD 05 PRECINCT 07,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,215
+Shawnee,TOPEKA WARD 05 PRECINCT 08,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,160
+Shawnee,TOPEKA WARD 05 PRECINCT 09,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,262
+Shawnee,TOPEKA WARD 05 PRECINCT 10,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,307
+Shawnee,TOPEKA WARD 06 PRECINCT 01,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,220
+Shawnee,TOPEKA WARD 06 PRECINCT 02,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,205
+Shawnee,TOPEKA WARD 06 PRECINCT 08,State House,58,"Lane, Harold",Harold,,Lane,,Democratic,275
+Shawnee,DEER CREEK,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,14
+Shawnee,TOPEKA WARD 03 PRECINCT 08,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,79
+Shawnee,TOPEKA WARD 03 PRECINCT 09,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,80
+Shawnee,TOPEKA WARD 04 PRECINCT 04,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,54
+Shawnee,TOPEKA WARD 04 PRECINCT 06,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,60
+Shawnee,TOPEKA WARD 04 PRECINCT 07,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,42
+Shawnee,TOPEKA WARD 04 PRECINCT 08,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,69
+Shawnee,TOPEKA WARD 04 PRECINCT 09,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,60
+Shawnee,TOPEKA WARD 04 PRECINCT 10,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,84
+Shawnee,TOPEKA WARD 04 PRECINCT 11,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,50
+Shawnee,TOPEKA WARD 04 PRECINCT 14,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,3
+Shawnee,TOPEKA WARD 05 PRECINCT 01,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,63
+Shawnee,TOPEKA WARD 05 PRECINCT 02,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,61
+Shawnee,TOPEKA WARD 05 PRECINCT 03,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,64
+Shawnee,TOPEKA WARD 05 PRECINCT 04,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,69
+Shawnee,TOPEKA WARD 05 PRECINCT 05,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,85
+Shawnee,TOPEKA WARD 05 PRECINCT 06,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,41
+Shawnee,TOPEKA WARD 05 PRECINCT 07,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,57
+Shawnee,TOPEKA WARD 05 PRECINCT 08,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,65
+Shawnee,TOPEKA WARD 05 PRECINCT 09,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,175
+Shawnee,TOPEKA WARD 05 PRECINCT 10,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,222
+Shawnee,TOPEKA WARD 06 PRECINCT 01,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,39
+Shawnee,TOPEKA WARD 06 PRECINCT 02,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,55
+Shawnee,TOPEKA WARD 06 PRECINCT 08,State House,58,"Martin, Quentin",Quentin,,Martin,,Republican,82

--- a/2012/20121106__ks__general__sheridan__precinct.csv
+++ b/2012/20121106__ks__general__sheridan__precinct.csv
@@ -1,0 +1,137 @@
+county,precinct,office,district,party,candidate,votes,vtd
+SHERIDAN,Adell Township,Kansas House of Representatives,118,Republican,"Hineman, Don",7,000010
+SHERIDAN,Bloomfield Township,Kansas House of Representatives,118,Republican,"Hineman, Don",9,000020
+SHERIDAN,Bow Creek Township,Kansas House of Representatives,118,Republican,"Hineman, Don",16,000030
+SHERIDAN,East Kenneth,Kansas House of Representatives,118,Republican,"Hineman, Don",306,000040
+SHERIDAN,East Saline,Kansas House of Representatives,118,Republican,"Hineman, Don",29,000050
+SHERIDAN,Logan Township,Kansas House of Representatives,118,Republican,"Hineman, Don",43,000060
+SHERIDAN,Parnell Township,Kansas House of Representatives,118,Republican,"Hineman, Don",44,000070
+SHERIDAN,Prairie Dog Township,Kansas House of Representatives,118,Republican,"Hineman, Don",23,000080
+SHERIDAN,Sheridan Township,Kansas House of Representatives,118,Republican,"Hineman, Don",99,000090
+SHERIDAN,Solomon Township,Kansas House of Representatives,118,Republican,"Hineman, Don",93,000100
+SHERIDAN,Springbrook Township,Kansas House of Representatives,118,Republican,"Hineman, Don",43,000110
+SHERIDAN,Union Township,Kansas House of Representatives,118,Republican,"Hineman, Don",15,000120
+SHERIDAN,Valley Township,Kansas House of Representatives,118,Republican,"Hineman, Don",43,000130
+SHERIDAN,West Kenneth,Kansas House of Representatives,118,Republican,"Hineman, Don",261,000140
+SHERIDAN,West Saline,Kansas House of Representatives,118,Republican,"Hineman, Don",34,000150
+SHERIDAN,Adell Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",5,000010
+SHERIDAN,Adell Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",5,000010
+SHERIDAN,Bloomfield Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",1,000020
+SHERIDAN,Bloomfield Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",12,000020
+SHERIDAN,Bow Creek Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",7,000030
+SHERIDAN,Bow Creek Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",14,000030
+SHERIDAN,East Kenneth,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",96,000040
+SHERIDAN,East Kenneth,Kansas Senate,40,Republican,"Ostmeyer, Ralph",285,000040
+SHERIDAN,East Saline,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",6,000050
+SHERIDAN,East Saline,Kansas Senate,40,Republican,"Ostmeyer, Ralph",26,000050
+SHERIDAN,Logan Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",7,000060
+SHERIDAN,Logan Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",47,000060
+SHERIDAN,Parnell Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",11,000070
+SHERIDAN,Parnell Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",44,000070
+SHERIDAN,Prairie Dog Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000080
+SHERIDAN,Prairie Dog Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",24,000080
+SHERIDAN,Sheridan Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",41,000090
+SHERIDAN,Sheridan Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",89,000090
+SHERIDAN,Solomon Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",26,000100
+SHERIDAN,Solomon Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",75,000100
+SHERIDAN,Springbrook Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",10,000110
+SHERIDAN,Springbrook Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",43,000110
+SHERIDAN,Union Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",1,000120
+SHERIDAN,Union Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",17,000120
+SHERIDAN,Valley Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",14,000130
+SHERIDAN,Valley Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",37,000130
+SHERIDAN,West Kenneth,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",83,000140
+SHERIDAN,West Kenneth,Kansas Senate,40,Republican,"Ostmeyer, Ralph",247,000140
+SHERIDAN,West Saline,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",17,000150
+SHERIDAN,West Saline,Kansas Senate,40,Republican,"Ostmeyer, Ralph",20,000150
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+SHERIDAN,Adell Township,President / Vice President,,Democratic,"Obama, Barack",4,000010
+SHERIDAN,Adell Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+SHERIDAN,Adell Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+SHERIDAN,Adell Township,President / Vice President,,Republican,"Romney, Mitt",5,000010
+SHERIDAN,Bloomfield Township,President / Vice President,,Democratic,"Obama, Barack",2,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,Republican,"Romney, Mitt",11,000020
+SHERIDAN,Bow Creek Township,President / Vice President,,Democratic,"Obama, Barack",1,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,Republican,"Romney, Mitt",20,000030
+SHERIDAN,East Kenneth,President / Vice President,,Democratic,"Obama, Barack",50,000040
+SHERIDAN,East Kenneth,President / Vice President,,Libertarian,"Johnson, Gary",4,000040
+SHERIDAN,East Kenneth,President / Vice President,,Reform,"Baldwin, Chuck",2,000040
+SHERIDAN,East Kenneth,President / Vice President,,Republican,"Romney, Mitt",335,000040
+SHERIDAN,East Saline,President / Vice President,,Democratic,"Obama, Barack",1,000050
+SHERIDAN,East Saline,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+SHERIDAN,East Saline,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+SHERIDAN,East Saline,President / Vice President,,Republican,"Romney, Mitt",32,000050
+SHERIDAN,Logan Township,President / Vice President,,Democratic,"Obama, Barack",4,000060
+SHERIDAN,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+SHERIDAN,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+SHERIDAN,Logan Township,President / Vice President,,Republican,"Romney, Mitt",51,000060
+SHERIDAN,Parnell Township,President / Vice President,,Democratic,"Obama, Barack",3,000070
+SHERIDAN,Parnell Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+SHERIDAN,Parnell Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,Republican,"Romney, Mitt",51,000070
+SHERIDAN,Prairie Dog Township,President / Vice President,,Democratic,"Obama, Barack",3,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,Republican,"Romney, Mitt",25,000080
+SHERIDAN,Sheridan Township,President / Vice President,,Democratic,"Obama, Barack",27,000090
+SHERIDAN,Sheridan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,Republican,"Romney, Mitt",107,000090
+SHERIDAN,Solomon Township,President / Vice President,,Democratic,"Obama, Barack",6,000100
+SHERIDAN,Solomon Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+SHERIDAN,Solomon Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,Republican,"Romney, Mitt",95,000100
+SHERIDAN,Springbrook Township,President / Vice President,,Democratic,"Obama, Barack",4,000110
+SHERIDAN,Springbrook Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+SHERIDAN,Springbrook Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,Republican,"Romney, Mitt",48,000110
+SHERIDAN,Union Township,President / Vice President,,Democratic,"Obama, Barack",0,000120
+SHERIDAN,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+SHERIDAN,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+SHERIDAN,Union Township,President / Vice President,,Republican,"Romney, Mitt",19,000120
+SHERIDAN,Valley Township,President / Vice President,,Democratic,"Obama, Barack",8,000130
+SHERIDAN,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000130
+SHERIDAN,Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+SHERIDAN,Valley Township,President / Vice President,,Republican,"Romney, Mitt",42,000130
+SHERIDAN,West Kenneth,President / Vice President,,Democratic,"Obama, Barack",55,000140
+SHERIDAN,West Kenneth,President / Vice President,,Libertarian,"Johnson, Gary",6,000140
+SHERIDAN,West Kenneth,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+SHERIDAN,West Kenneth,President / Vice President,,Republican,"Romney, Mitt",275,000140
+SHERIDAN,West Saline,President / Vice President,,Democratic,"Obama, Barack",0,000150
+SHERIDAN,West Saline,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+SHERIDAN,West Saline,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+SHERIDAN,West Saline,President / Vice President,,Republican,"Romney, Mitt",38,000150
+SHERIDAN,Adell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",5,000010
+SHERIDAN,Bloomfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",10,000020
+SHERIDAN,Bow Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000030
+SHERIDAN,East Kenneth,United States House of Representatives,1,Republican,"Huelskamp, Tim",321,000040
+SHERIDAN,East Saline,United States House of Representatives,1,Republican,"Huelskamp, Tim",29,000050
+SHERIDAN,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",46,000060
+SHERIDAN,Parnell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",46,000070
+SHERIDAN,Prairie Dog Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000080
+SHERIDAN,Sheridan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",104,000090
+SHERIDAN,Solomon Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",95,000100
+SHERIDAN,Springbrook Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000110
+SHERIDAN,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",17,000120
+SHERIDAN,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000130
+SHERIDAN,West Kenneth,United States House of Representatives,1,Republican,"Huelskamp, Tim",275,000140
+SHERIDAN,West Saline,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000150

--- a/2012/20121106__ks__general__sherman__precinct.csv
+++ b/2012/20121106__ks__general__sherman__precinct.csv
@@ -1,0 +1,457 @@
+county,precinct,office,district,party,candidate,votes,vtd
+SHERMAN,Goodland Ward 1,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",482,000010
+SHERMAN,Goodland Ward 2,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",273,000020
+SHERMAN,Goodland Ward 3,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",308,000030
+SHERMAN,Goodland Ward 4,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",468,000040
+SHERMAN,Grant Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",27,000050
+SHERMAN,Iowa Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",14,000060
+SHERMAN,Itasca Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",147,000070
+SHERMAN,Kanorado City,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",43,000080
+SHERMAN,Lincoln Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",32,000090
+SHERMAN,Llanos Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",20,000100
+SHERMAN,Logan Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",103,00011A
+SHERMAN,Logan Township Enclave (B),Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",0,00011C
+SHERMAN,McPherson Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",18,000120
+SHERMAN,Shermanville Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",19,000130
+SHERMAN,Smoky Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",30,000140
+SHERMAN,State Line Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",33,000150
+SHERMAN,Union Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",33,000160
+SHERMAN,Voltaire Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",114,000170
+SHERMAN,Washington Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",40,000180
+SHERMAN,Goodland Ward 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",148,000010
+SHERMAN,Goodland Ward 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",421,000010
+SHERMAN,Goodland Ward 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",87,000020
+SHERMAN,Goodland Ward 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",227,000020
+SHERMAN,Goodland Ward 3,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",100,000030
+SHERMAN,Goodland Ward 3,Kansas Senate,40,Republican,"Ostmeyer, Ralph",245,000030
+SHERMAN,Goodland Ward 4,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",126,000040
+SHERMAN,Goodland Ward 4,Kansas Senate,40,Republican,"Ostmeyer, Ralph",407,000040
+SHERMAN,Grant Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",7,000050
+SHERMAN,Grant Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",33,000050
+SHERMAN,Iowa Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",2,000060
+SHERMAN,Iowa Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",12,000060
+SHERMAN,Itasca Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",37,000070
+SHERMAN,Itasca Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",136,000070
+SHERMAN,Kanorado City,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",11,000080
+SHERMAN,Kanorado City,Kansas Senate,40,Republican,"Ostmeyer, Ralph",42,000080
+SHERMAN,Lincoln Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",12,000090
+SHERMAN,Lincoln Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",32,000090
+SHERMAN,Llanos Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",3,000100
+SHERMAN,Llanos Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",20,000100
+SHERMAN,Logan Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",19,00011A
+SHERMAN,Logan Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",97,00011A
+SHERMAN,Logan Township Enclave (B),Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,00011C
+SHERMAN,Logan Township Enclave (B),Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,00011C
+SHERMAN,McPherson Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000120
+SHERMAN,McPherson Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",18,000120
+SHERMAN,Shermanville Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,000130
+SHERMAN,Shermanville Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",19,000130
+SHERMAN,Smoky Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",5,000140
+SHERMAN,Smoky Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",30,000140
+SHERMAN,State Line Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000150
+SHERMAN,State Line Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",37,000150
+SHERMAN,Union Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",1,000160
+SHERMAN,Union Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",32,000160
+SHERMAN,Voltaire Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",23,000170
+SHERMAN,Voltaire Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",105,000170
+SHERMAN,Washington Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",4,000180
+SHERMAN,Washington Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",39,000180
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Stein, Jill E",1,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,Democratic,"Obama, Barack",146,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",7,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",6,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,Republican,"Romney, Mitt",426,000010
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",2,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,Democratic,"Obama, Barack",91,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",11,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,Republican,"Romney, Mitt",215,000020
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Stein, Jill E",1,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,Democratic,"Obama, Barack",79,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",9,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,Republican,"Romney, Mitt",262,000030
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,Democratic,"Obama, Barack",140,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",8,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",3,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,Republican,"Romney, Mitt",406,000040
+SHERMAN,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+SHERMAN,Grant Township,President / Vice President,,Democratic,"Obama, Barack",5,000050
+SHERMAN,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+SHERMAN,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+SHERMAN,Grant Township,President / Vice President,,Republican,"Romney, Mitt",33,000050
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+SHERMAN,Iowa Township,President / Vice President,,Democratic,"Obama, Barack",1,000060
+SHERMAN,Iowa Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+SHERMAN,Iowa Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+SHERMAN,Iowa Township,President / Vice President,,Republican,"Romney, Mitt",14,000060
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+SHERMAN,Itasca Township,President / Vice President,,Democratic,"Obama, Barack",31,000070
+SHERMAN,Itasca Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000070
+SHERMAN,Itasca Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+SHERMAN,Itasca Township,President / Vice President,,Republican,"Romney, Mitt",142,000070
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Barnett, Andre",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Bush, Kent W",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Christensen, Will",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Goode, Virgil",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Stein, Jill E",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+SHERMAN,Kanorado City,President / Vice President,,Democratic,"Obama, Barack",17,000080
+SHERMAN,Kanorado City,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+SHERMAN,Kanorado City,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+SHERMAN,Kanorado City,President / Vice President,,Republican,"Romney, Mitt",43,000080
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",8,000090
+SHERMAN,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",35,000090
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+SHERMAN,Llanos Township,President / Vice President,,Democratic,"Obama, Barack",1,000100
+SHERMAN,Llanos Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+SHERMAN,Llanos Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+SHERMAN,Llanos Township,President / Vice President,,Republican,"Romney, Mitt",19,000100
+SHERMAN,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00011A
+SHERMAN,Logan Township,President / Vice President,,Democratic,"Obama, Barack",17,00011A
+SHERMAN,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",3,00011A
+SHERMAN,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,00011A
+SHERMAN,Logan Township,President / Vice President,,Republican,"Romney, Mitt",102,00011A
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Ayers, Avery L",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Barnett, Andre",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Barr, Roseanne C",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Bush, Kent W",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Christensen, Will",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Duncan, Richard A",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Goode, Virgil",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Hoefling, Tom",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Knill, Dennis J",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Reed, Jill A.",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Rogers, Rick L",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Stein, Jill E",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Thorne, Kevin M",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Warner, Gerald L.",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,Democratic,"Obama, Barack",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,Libertarian,"Johnson, Gary",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,Reform,"Baldwin, Chuck",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,Republican,"Romney, Mitt",0,00011C
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+SHERMAN,McPherson Township,President / Vice President,,Democratic,"Obama, Barack",1,000120
+SHERMAN,McPherson Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+SHERMAN,McPherson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+SHERMAN,McPherson Township,President / Vice President,,Republican,"Romney, Mitt",19,000120
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,Democratic,"Obama, Barack",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000130
+SHERMAN,Shermanville Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,Republican,"Romney, Mitt",17,000130
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+SHERMAN,Smoky Township,President / Vice President,,Democratic,"Obama, Barack",4,000140
+SHERMAN,Smoky Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+SHERMAN,Smoky Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+SHERMAN,Smoky Township,President / Vice President,,Republican,"Romney, Mitt",31,000140
+SHERMAN,State Line Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+SHERMAN,State Line Township,President / Vice President,,Democratic,"Obama, Barack",10,000150
+SHERMAN,State Line Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+SHERMAN,State Line Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+SHERMAN,State Line Township,President / Vice President,,Republican,"Romney, Mitt",34,000150
+SHERMAN,Union Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+SHERMAN,Union Township,President / Vice President,,Democratic,"Obama, Barack",0,000160
+SHERMAN,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+SHERMAN,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+SHERMAN,Union Township,President / Vice President,,Republican,"Romney, Mitt",34,000160
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,Democratic,"Obama, Barack",20,000170
+SHERMAN,Voltaire Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000170
+SHERMAN,Voltaire Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000170
+SHERMAN,Voltaire Township,President / Vice President,,Republican,"Romney, Mitt",107,000170
+SHERMAN,Washington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+SHERMAN,Washington Township,President / Vice President,,Democratic,"Obama, Barack",6,000180
+SHERMAN,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+SHERMAN,Washington Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+SHERMAN,Washington Township,President / Vice President,,Republican,"Romney, Mitt",37,000180
+SHERMAN,Goodland Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",471,000010
+SHERMAN,Goodland Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",268,000020
+SHERMAN,Goodland Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",290,000030
+SHERMAN,Goodland Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",463,000040
+SHERMAN,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000050
+SHERMAN,Iowa Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000060
+SHERMAN,Itasca Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",138,000070
+SHERMAN,Kanorado City,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000080
+SHERMAN,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000090
+SHERMAN,Llanos Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000100
+SHERMAN,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",103,00011A
+SHERMAN,Logan Township Enclave (B),United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00011C
+SHERMAN,McPherson Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000120
+SHERMAN,Shermanville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",19,000130
+SHERMAN,Smoky Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000140
+SHERMAN,State Line Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",35,000150
+SHERMAN,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000160
+SHERMAN,Voltaire Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",114,000170
+SHERMAN,Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000180

--- a/2012/20121106__ks__general__smith__precinct.csv
+++ b/2012/20121106__ks__general__smith__precinct.csv
@@ -1,0 +1,217 @@
+county,precinct,office,district,party,candidate,votes,vtd
+SMITH,Banner Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",30,000010
+SMITH,Beaver Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",25,000020
+SMITH,Blaine Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",21,000030
+SMITH,Cedar Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",228,000040
+SMITH,Center 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",430,000050
+SMITH,Center 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",316,000060
+SMITH,Cora Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",13,000070
+SMITH,Crystal Plains Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",12,000080
+SMITH,Dor Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",20,000090
+SMITH,Garfield Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",14,000100
+SMITH,German Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",13,000110
+SMITH,Harlan Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",38,000120
+SMITH,Harvey Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",60,000130
+SMITH,Houston Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",72,000140
+SMITH,Lane Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",46,000150
+SMITH,Lincoln Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",36,000160
+SMITH,Logan Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",14,000170
+SMITH,Martin Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",4,000180
+SMITH,Oak 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",53,000190
+SMITH,Oak 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",70,000200
+SMITH,Pawnee Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",8,000210
+SMITH,Pleasant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",15,000220
+SMITH,Swan Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",15,000230
+SMITH,Valley Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",24,000240
+SMITH,Washington Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",20,000250
+SMITH,Webster Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",24,000260
+SMITH,White Rock Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",23,000270
+SMITH,Banner Township,Kansas Senate,36,Democratic,"Clark, Marquis",6,000010
+SMITH,Banner Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",30,000010
+SMITH,Beaver Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000020
+SMITH,Beaver Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",24,000020
+SMITH,Blaine Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000030
+SMITH,Blaine Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",24,000030
+SMITH,Cedar Township,Kansas Senate,36,Democratic,"Clark, Marquis",50,000040
+SMITH,Cedar Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",208,000040
+SMITH,Center 1,Kansas Senate,36,Democratic,"Clark, Marquis",71,000050
+SMITH,Center 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",415,000050
+SMITH,Center 2,Kansas Senate,36,Democratic,"Clark, Marquis",77,000060
+SMITH,Center 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",308,000060
+SMITH,Cora Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000070
+SMITH,Cora Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000070
+SMITH,Crystal Plains Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000080
+SMITH,Crystal Plains Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",11,000080
+SMITH,Dor Township,Kansas Senate,36,Democratic,"Clark, Marquis",6,000090
+SMITH,Dor Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",17,000090
+SMITH,Garfield Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000100
+SMITH,Garfield Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",14,000100
+SMITH,German Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000110
+SMITH,German Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",12,000110
+SMITH,Harlan Township,Kansas Senate,36,Democratic,"Clark, Marquis",5,000120
+SMITH,Harlan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",39,000120
+SMITH,Harvey Township,Kansas Senate,36,Democratic,"Clark, Marquis",13,000130
+SMITH,Harvey Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",52,000130
+SMITH,Houston Township,Kansas Senate,36,Democratic,"Clark, Marquis",14,000140
+SMITH,Houston Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",64,000140
+SMITH,Lane Township,Kansas Senate,36,Democratic,"Clark, Marquis",15,000150
+SMITH,Lane Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",36,000150
+SMITH,Lincoln Township,Kansas Senate,36,Democratic,"Clark, Marquis",8,000160
+SMITH,Lincoln Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",31,000160
+SMITH,Logan Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000170
+SMITH,Logan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000170
+SMITH,Martin Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000180
+SMITH,Martin Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",4,000180
+SMITH,Oak 1,Kansas Senate,36,Democratic,"Clark, Marquis",11,000190
+SMITH,Oak 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",46,000190
+SMITH,Oak 2,Kansas Senate,36,Democratic,"Clark, Marquis",14,000200
+SMITH,Oak 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",64,000200
+SMITH,Pawnee Township,Kansas Senate,36,Democratic,"Clark, Marquis",3,000210
+SMITH,Pawnee Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",7,000210
+SMITH,Pleasant Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000220
+SMITH,Pleasant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000220
+SMITH,Swan Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000230
+SMITH,Swan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",12,000230
+SMITH,Valley Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000240
+SMITH,Valley Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",24,000240
+SMITH,Washington Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000250
+SMITH,Washington Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",20,000250
+SMITH,Webster Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000260
+SMITH,Webster Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",24,000260
+SMITH,White Rock Township,Kansas Senate,36,Democratic,"Clark, Marquis",2,000270
+SMITH,White Rock Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",26,000270
+SMITH,Banner Township,President / Vice President,,Democratic,"Obama, Barack",4,000010
+SMITH,Banner Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+SMITH,Banner Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+SMITH,Banner Township,President / Vice President,,Republican,"Romney, Mitt",36,000010
+SMITH,Beaver Township,President / Vice President,,Democratic,"Obama, Barack",3,000020
+SMITH,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+SMITH,Beaver Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+SMITH,Beaver Township,President / Vice President,,Republican,"Romney, Mitt",24,000020
+SMITH,Blaine Township,President / Vice President,,Democratic,"Obama, Barack",3,000030
+SMITH,Blaine Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+SMITH,Blaine Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+SMITH,Blaine Township,President / Vice President,,Republican,"Romney, Mitt",26,000030
+SMITH,Cedar Township,President / Vice President,,Democratic,"Obama, Barack",57,000040
+SMITH,Cedar Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+SMITH,Cedar Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+SMITH,Cedar Township,President / Vice President,,Republican,"Romney, Mitt",217,000040
+SMITH,Center 1,President / Vice President,,Democratic,"Obama, Barack",86,000050
+SMITH,Center 1,President / Vice President,,Libertarian,"Johnson, Gary",6,000050
+SMITH,Center 1,President / Vice President,,Reform,"Baldwin, Chuck",3,000050
+SMITH,Center 1,President / Vice President,,Republican,"Romney, Mitt",430,000050
+SMITH,Center 2,President / Vice President,,Democratic,"Obama, Barack",96,000060
+SMITH,Center 2,President / Vice President,,Libertarian,"Johnson, Gary",5,000060
+SMITH,Center 2,President / Vice President,,Reform,"Baldwin, Chuck",5,000060
+SMITH,Center 2,President / Vice President,,Republican,"Romney, Mitt",318,000060
+SMITH,Cora Township,President / Vice President,,Democratic,"Obama, Barack",2,000070
+SMITH,Cora Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+SMITH,Cora Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+SMITH,Cora Township,President / Vice President,,Republican,"Romney, Mitt",15,000070
+SMITH,Crystal Plains Township,President / Vice President,,Democratic,"Obama, Barack",1,000080
+SMITH,Crystal Plains Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,Republican,"Romney, Mitt",14,000080
+SMITH,Dor Township,President / Vice President,,Democratic,"Obama, Barack",6,000090
+SMITH,Dor Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+SMITH,Dor Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+SMITH,Dor Township,President / Vice President,,Republican,"Romney, Mitt",17,000090
+SMITH,Garfield Township,President / Vice President,,Democratic,"Obama, Barack",0,000100
+SMITH,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+SMITH,Garfield Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+SMITH,Garfield Township,President / Vice President,,Republican,"Romney, Mitt",14,000100
+SMITH,German Township,President / Vice President,,Democratic,"Obama, Barack",1,000110
+SMITH,German Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+SMITH,German Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+SMITH,German Township,President / Vice President,,Republican,"Romney, Mitt",13,000110
+SMITH,Harlan Township,President / Vice President,,Democratic,"Obama, Barack",6,000120
+SMITH,Harlan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+SMITH,Harlan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+SMITH,Harlan Township,President / Vice President,,Republican,"Romney, Mitt",41,000120
+SMITH,Harvey Township,President / Vice President,,Democratic,"Obama, Barack",7,000130
+SMITH,Harvey Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+SMITH,Harvey Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000130
+SMITH,Harvey Township,President / Vice President,,Republican,"Romney, Mitt",58,000130
+SMITH,Houston Township,President / Vice President,,Democratic,"Obama, Barack",9,000140
+SMITH,Houston Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000140
+SMITH,Houston Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+SMITH,Houston Township,President / Vice President,,Republican,"Romney, Mitt",74,000140
+SMITH,Lane Township,President / Vice President,,Democratic,"Obama, Barack",30,000150
+SMITH,Lane Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000150
+SMITH,Lane Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+SMITH,Lane Township,President / Vice President,,Republican,"Romney, Mitt",27,000150
+SMITH,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",5,000160
+SMITH,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+SMITH,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+SMITH,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",36,000160
+SMITH,Logan Township,President / Vice President,,Democratic,"Obama, Barack",0,000170
+SMITH,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000170
+SMITH,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+SMITH,Logan Township,President / Vice President,,Republican,"Romney, Mitt",15,000170
+SMITH,Martin Township,President / Vice President,,Democratic,"Obama, Barack",1,000180
+SMITH,Martin Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+SMITH,Martin Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+SMITH,Martin Township,President / Vice President,,Republican,"Romney, Mitt",2,000180
+SMITH,Oak 1,President / Vice President,,Democratic,"Obama, Barack",10,000190
+SMITH,Oak 1,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+SMITH,Oak 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000190
+SMITH,Oak 1,President / Vice President,,Republican,"Romney, Mitt",48,000190
+SMITH,Oak 2,President / Vice President,,Democratic,"Obama, Barack",12,000200
+SMITH,Oak 2,President / Vice President,,Libertarian,"Johnson, Gary",2,000200
+SMITH,Oak 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+SMITH,Oak 2,President / Vice President,,Republican,"Romney, Mitt",64,000200
+SMITH,Pawnee Township,President / Vice President,,Democratic,"Obama, Barack",4,000210
+SMITH,Pawnee Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000210
+SMITH,Pawnee Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+SMITH,Pawnee Township,President / Vice President,,Republican,"Romney, Mitt",8,000210
+SMITH,Pleasant Township,President / Vice President,,Democratic,"Obama, Barack",3,000220
+SMITH,Pleasant Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000220
+SMITH,Pleasant Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+SMITH,Pleasant Township,President / Vice President,,Republican,"Romney, Mitt",16,000220
+SMITH,Swan Township,President / Vice President,,Democratic,"Obama, Barack",2,000230
+SMITH,Swan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+SMITH,Swan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+SMITH,Swan Township,President / Vice President,,Republican,"Romney, Mitt",15,000230
+SMITH,Valley Township,President / Vice President,,Democratic,"Obama, Barack",5,000240
+SMITH,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000240
+SMITH,Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000240
+SMITH,Valley Township,President / Vice President,,Republican,"Romney, Mitt",21,000240
+SMITH,Washington Township,President / Vice President,,Democratic,"Obama, Barack",1,000250
+SMITH,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000250
+SMITH,Washington Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000250
+SMITH,Washington Township,President / Vice President,,Republican,"Romney, Mitt",22,000250
+SMITH,Webster Township,President / Vice President,,Democratic,"Obama, Barack",0,000260
+SMITH,Webster Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+SMITH,Webster Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000260
+SMITH,Webster Township,President / Vice President,,Republican,"Romney, Mitt",27,000260
+SMITH,White Rock Township,President / Vice President,,Democratic,"Obama, Barack",4,000270
+SMITH,White Rock Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000270
+SMITH,White Rock Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000270
+SMITH,White Rock Township,President / Vice President,,Republican,"Romney, Mitt",26,000270
+SMITH,Banner Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000010
+SMITH,Beaver Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000020
+SMITH,Blaine Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",21,000030
+SMITH,Cedar Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",236,000040
+SMITH,Center 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",438,000050
+SMITH,Center 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",324,000060
+SMITH,Cora Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000070
+SMITH,Crystal Plains Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",12,000080
+SMITH,Dor Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000090
+SMITH,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000100
+SMITH,German Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000110
+SMITH,Harlan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",40,000120
+SMITH,Harvey Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",61,000130
+SMITH,Houston Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",73,000140
+SMITH,Lane Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000150
+SMITH,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000160
+SMITH,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000170
+SMITH,Martin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",4,000180
+SMITH,Oak 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000190
+SMITH,Oak 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",68,000200
+SMITH,Pawnee Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",8,000210
+SMITH,Pleasant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000220
+SMITH,Swan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,000230
+SMITH,Valley Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000240
+SMITH,Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",22,000250
+SMITH,Webster Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000260
+SMITH,White Rock Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",27,000270

--- a/2012/20121106__ks__general__stafford__precinct.csv
+++ b/2012/20121106__ks__general__stafford__precinct.csv
@@ -1,0 +1,601 @@
+county,precinct,office,district,party,candidate,votes,vtd
+STAFFORD,Albano Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",18,000010
+STAFFORD,Byron Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",30,000020
+STAFFORD,Clear Creek Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",15,000030
+STAFFORD,Cleveland Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",28,000040
+STAFFORD,Douglas Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",34,000050
+STAFFORD,East Cooper Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",14,000060
+STAFFORD,East St. John,Kansas House of Representatives,113,Republican,"Christmann, Marshall",140,000070
+STAFFORD,Fairview Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",34,000080
+STAFFORD,Farmington Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",150,000090
+STAFFORD,Hayes Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",77,000100
+STAFFORD,Lincoln Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",46,000110
+STAFFORD,North Seward Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",61,000120
+STAFFORD,North Stafford,Kansas House of Representatives,113,Republican,"Christmann, Marshall",185,000130
+STAFFORD,Ohio Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",40,000140
+STAFFORD,Putnam Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",10,000150
+STAFFORD,Richland Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",16,000160
+STAFFORD,Rose Valley Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",20,000170
+STAFFORD,South Seward Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",16,000180
+STAFFORD,South St. John,Kansas House of Representatives,113,Republican,"Christmann, Marshall",92,000190
+STAFFORD,South Stafford,Kansas House of Representatives,113,Republican,"Christmann, Marshall",152,000200
+STAFFORD,Union Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",8,000210
+STAFFORD,West Cooper Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",24,000220
+STAFFORD,West St. John,Kansas House of Representatives,113,Republican,"Christmann, Marshall",129,000230
+STAFFORD,York Township,Kansas House of Representatives,113,Republican,"Christmann, Marshall",14,000240
+STAFFORD,Albano Township,Kansas Senate,33,Republican,"Holmes, Mitch",21,000010
+STAFFORD,Byron Township,Kansas Senate,33,Republican,"Holmes, Mitch",31,000020
+STAFFORD,Clear Creek Township,Kansas Senate,33,Republican,"Holmes, Mitch",19,000030
+STAFFORD,Cleveland Township,Kansas Senate,33,Republican,"Holmes, Mitch",30,000040
+STAFFORD,Douglas Township,Kansas Senate,33,Republican,"Holmes, Mitch",39,000050
+STAFFORD,East Cooper Township,Kansas Senate,33,Republican,"Holmes, Mitch",16,000060
+STAFFORD,East St. John,Kansas Senate,33,Republican,"Holmes, Mitch",132,000070
+STAFFORD,Fairview Township,Kansas Senate,33,Republican,"Holmes, Mitch",27,000080
+STAFFORD,Farmington Township,Kansas Senate,33,Republican,"Holmes, Mitch",155,000090
+STAFFORD,Hayes Township,Kansas Senate,33,Republican,"Holmes, Mitch",65,000100
+STAFFORD,Lincoln Township,Kansas Senate,33,Republican,"Holmes, Mitch",45,000110
+STAFFORD,North Seward Township,Kansas Senate,33,Republican,"Holmes, Mitch",60,000120
+STAFFORD,North Stafford,Kansas Senate,33,Republican,"Holmes, Mitch",135,000130
+STAFFORD,Ohio Township,Kansas Senate,33,Republican,"Holmes, Mitch",36,000140
+STAFFORD,Putnam Township,Kansas Senate,33,Republican,"Holmes, Mitch",8,000150
+STAFFORD,Richland Township,Kansas Senate,33,Republican,"Holmes, Mitch",18,000160
+STAFFORD,Rose Valley Township,Kansas Senate,33,Republican,"Holmes, Mitch",18,000170
+STAFFORD,South Seward Township,Kansas Senate,33,Republican,"Holmes, Mitch",10,000180
+STAFFORD,South St. John,Kansas Senate,33,Republican,"Holmes, Mitch",94,000190
+STAFFORD,South Stafford,Kansas Senate,33,Republican,"Holmes, Mitch",104,000200
+STAFFORD,Union Township,Kansas Senate,33,Republican,"Holmes, Mitch",9,000210
+STAFFORD,West Cooper Township,Kansas Senate,33,Republican,"Holmes, Mitch",22,000220
+STAFFORD,West St. John,Kansas Senate,33,Republican,"Holmes, Mitch",114,000230
+STAFFORD,York Township,Kansas Senate,33,Republican,"Holmes, Mitch",14,000240
+STAFFORD,Albano Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+STAFFORD,Albano Township,President / Vice President,,Democratic,"Obama, Barack",3,000010
+STAFFORD,Albano Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+STAFFORD,Albano Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+STAFFORD,Albano Township,President / Vice President,,Republican,"Romney, Mitt",22,000010
+STAFFORD,Byron Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+STAFFORD,Byron Township,President / Vice President,,Democratic,"Obama, Barack",3,000020
+STAFFORD,Byron Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+STAFFORD,Byron Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+STAFFORD,Byron Township,President / Vice President,,Republican,"Romney, Mitt",35,000020
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,Democratic,"Obama, Barack",3,000030
+STAFFORD,Clear Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,Republican,"Romney, Mitt",18,000030
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,Democratic,"Obama, Barack",4,000040
+STAFFORD,Cleveland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,Republican,"Romney, Mitt",31,000040
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+STAFFORD,Douglas Township,President / Vice President,,Democratic,"Obama, Barack",13,000050
+STAFFORD,Douglas Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+STAFFORD,Douglas Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+STAFFORD,Douglas Township,President / Vice President,,Republican,"Romney, Mitt",39,000050
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,Democratic,"Obama, Barack",5,000060
+STAFFORD,East Cooper Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,Republican,"Romney, Mitt",16,000060
+STAFFORD,East St. John,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Barnett, Andre",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Bush, Kent W",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Christensen, Will",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Goode, Virgil",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Stein, Jill E",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+STAFFORD,East St. John,President / Vice President,,Democratic,"Obama, Barack",53,000070
+STAFFORD,East St. John,President / Vice President,,Libertarian,"Johnson, Gary",4,000070
+STAFFORD,East St. John,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+STAFFORD,East St. John,President / Vice President,,Republican,"Romney, Mitt",147,000070
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+STAFFORD,Fairview Township,President / Vice President,,Democratic,"Obama, Barack",6,000080
+STAFFORD,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+STAFFORD,Fairview Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+STAFFORD,Fairview Township,President / Vice President,,Republican,"Romney, Mitt",40,000080
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+STAFFORD,Farmington Township,President / Vice President,,Democratic,"Obama, Barack",39,000090
+STAFFORD,Farmington Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+STAFFORD,Farmington Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+STAFFORD,Farmington Township,President / Vice President,,Republican,"Romney, Mitt",146,000090
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Stein, Jill E",1,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+STAFFORD,Hayes Township,President / Vice President,,Democratic,"Obama, Barack",15,000100
+STAFFORD,Hayes Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000100
+STAFFORD,Hayes Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+STAFFORD,Hayes Township,President / Vice President,,Republican,"Romney, Mitt",68,000100
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",5,000110
+STAFFORD,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",45,000110
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+STAFFORD,North Seward Township,President / Vice President,,Democratic,"Obama, Barack",6,000120
+STAFFORD,North Seward Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+STAFFORD,North Seward Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+STAFFORD,North Seward Township,President / Vice President,,Republican,"Romney, Mitt",67,000120
+STAFFORD,North Stafford,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Barnett, Andre",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Bush, Kent W",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Christensen, Will",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Goode, Virgil",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Stein, Jill E",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+STAFFORD,North Stafford,President / Vice President,,Democratic,"Obama, Barack",77,000130
+STAFFORD,North Stafford,President / Vice President,,Libertarian,"Johnson, Gary",10,000130
+STAFFORD,North Stafford,President / Vice President,,Reform,"Baldwin, Chuck",6,000130
+STAFFORD,North Stafford,President / Vice President,,Republican,"Romney, Mitt",170,000130
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+STAFFORD,Ohio Township,President / Vice President,,Democratic,"Obama, Barack",6,000140
+STAFFORD,Ohio Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+STAFFORD,Ohio Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+STAFFORD,Ohio Township,President / Vice President,,Republican,"Romney, Mitt",41,000140
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+STAFFORD,Putnam Township,President / Vice President,,Democratic,"Obama, Barack",2,000150
+STAFFORD,Putnam Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+STAFFORD,Putnam Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+STAFFORD,Putnam Township,President / Vice President,,Republican,"Romney, Mitt",9,000150
+STAFFORD,Richland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+STAFFORD,Richland Township,President / Vice President,,Democratic,"Obama, Barack",3,000160
+STAFFORD,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+STAFFORD,Richland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+STAFFORD,Richland Township,President / Vice President,,Republican,"Romney, Mitt",23,000160
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,Democratic,"Obama, Barack",8,000170
+STAFFORD,Rose Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,Republican,"Romney, Mitt",20,000170
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+STAFFORD,South Seward Township,President / Vice President,,Democratic,"Obama, Barack",2,000180
+STAFFORD,South Seward Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+STAFFORD,South Seward Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+STAFFORD,South Seward Township,President / Vice President,,Republican,"Romney, Mitt",17,000180
+STAFFORD,South St. John,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Barnett, Andre",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Bush, Kent W",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Christensen, Will",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Goode, Virgil",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Stein, Jill E",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+STAFFORD,South St. John,President / Vice President,,Democratic,"Obama, Barack",36,000190
+STAFFORD,South St. John,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+STAFFORD,South St. John,President / Vice President,,Reform,"Baldwin, Chuck",2,000190
+STAFFORD,South St. John,President / Vice President,,Republican,"Romney, Mitt",98,000190
+STAFFORD,South Stafford,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Barnett, Andre",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Bush, Kent W",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Christensen, Will",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Goode, Virgil",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Reed, Jill A.",1,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Stein, Jill E",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+STAFFORD,South Stafford,President / Vice President,,Democratic,"Obama, Barack",61,000200
+STAFFORD,South Stafford,President / Vice President,,Libertarian,"Johnson, Gary",3,000200
+STAFFORD,South Stafford,President / Vice President,,Reform,"Baldwin, Chuck",4,000200
+STAFFORD,South Stafford,President / Vice President,,Republican,"Romney, Mitt",140,000200
+STAFFORD,Union Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+STAFFORD,Union Township,President / Vice President,,Democratic,"Obama, Barack",5,000210
+STAFFORD,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+STAFFORD,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+STAFFORD,Union Township,President / Vice President,,Republican,"Romney, Mitt",8,000210
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,Democratic,"Obama, Barack",7,000220
+STAFFORD,West Cooper Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000220
+STAFFORD,West Cooper Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,Republican,"Romney, Mitt",26,000220
+STAFFORD,West St. John,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Barnett, Andre",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Bush, Kent W",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Christensen, Will",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Goode, Virgil",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Stein, Jill E",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+STAFFORD,West St. John,President / Vice President,,Democratic,"Obama, Barack",39,000230
+STAFFORD,West St. John,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+STAFFORD,West St. John,President / Vice President,,Reform,"Baldwin, Chuck",2,000230
+STAFFORD,West St. John,President / Vice President,,Republican,"Romney, Mitt",144,000230
+STAFFORD,York Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+STAFFORD,York Township,President / Vice President,,Democratic,"Obama, Barack",3,000240
+STAFFORD,York Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+STAFFORD,York Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000240
+STAFFORD,York Township,President / Vice President,,Republican,"Romney, Mitt",15,000240
+STAFFORD,Albano Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000010
+STAFFORD,Albano Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000010
+STAFFORD,Albano Township,United States House of Representatives,4,Republican,"Pompeo, Mike",20,000010
+STAFFORD,Byron Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",1,000020
+STAFFORD,Byron Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000020
+STAFFORD,Byron Township,United States House of Representatives,4,Republican,"Pompeo, Mike",36,000020
+STAFFORD,Clear Creek Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",1,000030
+STAFFORD,Clear Creek Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000030
+STAFFORD,Clear Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",20,000030
+STAFFORD,Cleveland Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000040
+STAFFORD,Cleveland Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000040
+STAFFORD,Cleveland Township,United States House of Representatives,4,Republican,"Pompeo, Mike",29,000040
+STAFFORD,Douglas Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",10,000050
+STAFFORD,Douglas Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000050
+STAFFORD,Douglas Township,United States House of Representatives,4,Republican,"Pompeo, Mike",36,000050
+STAFFORD,East Cooper Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",4,000060
+STAFFORD,East Cooper Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000060
+STAFFORD,East Cooper Township,United States House of Representatives,4,Republican,"Pompeo, Mike",16,000060
+STAFFORD,East St. John,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",43,000070
+STAFFORD,East St. John,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",9,000070
+STAFFORD,East St. John,United States House of Representatives,4,Republican,"Pompeo, Mike",148,000070
+STAFFORD,Fairview Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",7,000080
+STAFFORD,Fairview Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000080
+STAFFORD,Fairview Township,United States House of Representatives,4,Republican,"Pompeo, Mike",38,000080
+STAFFORD,Farmington Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",37,000090
+STAFFORD,Farmington Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",7,000090
+STAFFORD,Farmington Township,United States House of Representatives,4,Republican,"Pompeo, Mike",133,000090
+STAFFORD,Hayes Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",16,000100
+STAFFORD,Hayes Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000100
+STAFFORD,Hayes Township,United States House of Representatives,4,Republican,"Pompeo, Mike",65,000100
+STAFFORD,Lincoln Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",5,000110
+STAFFORD,Lincoln Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000110
+STAFFORD,Lincoln Township,United States House of Representatives,4,Republican,"Pompeo, Mike",42,000110
+STAFFORD,North Seward Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",9,000120
+STAFFORD,North Seward Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000120
+STAFFORD,North Seward Township,United States House of Representatives,4,Republican,"Pompeo, Mike",63,000120
+STAFFORD,North Stafford,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",67,000130
+STAFFORD,North Stafford,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",20,000130
+STAFFORD,North Stafford,United States House of Representatives,4,Republican,"Pompeo, Mike",163,000130
+STAFFORD,Ohio Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",8,000140
+STAFFORD,Ohio Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000140
+STAFFORD,Ohio Township,United States House of Representatives,4,Republican,"Pompeo, Mike",39,000140
+STAFFORD,Putnam Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,000150
+STAFFORD,Putnam Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000150
+STAFFORD,Putnam Township,United States House of Representatives,4,Republican,"Pompeo, Mike",11,000150
+STAFFORD,Richland Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",3,000160
+STAFFORD,Richland Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000160
+STAFFORD,Richland Township,United States House of Representatives,4,Republican,"Pompeo, Mike",17,000160
+STAFFORD,Rose Valley Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",10,000170
+STAFFORD,Rose Valley Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000170
+STAFFORD,Rose Valley Township,United States House of Representatives,4,Republican,"Pompeo, Mike",16,000170
+STAFFORD,South Seward Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",1,000180
+STAFFORD,South Seward Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,000180
+STAFFORD,South Seward Township,United States House of Representatives,4,Republican,"Pompeo, Mike",16,000180
+STAFFORD,South St. John,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",26,000190
+STAFFORD,South St. John,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000190
+STAFFORD,South St. John,United States House of Representatives,4,Republican,"Pompeo, Mike",94,000190
+STAFFORD,South Stafford,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",49,000200
+STAFFORD,South Stafford,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",17,000200
+STAFFORD,South Stafford,United States House of Representatives,4,Republican,"Pompeo, Mike",134,000200
+STAFFORD,Union Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",4,000210
+STAFFORD,Union Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000210
+STAFFORD,Union Township,United States House of Representatives,4,Republican,"Pompeo, Mike",8,000210
+STAFFORD,West Cooper Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000220
+STAFFORD,West Cooper Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,000220
+STAFFORD,West Cooper Township,United States House of Representatives,4,Republican,"Pompeo, Mike",25,000220
+STAFFORD,West St. John,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",36,000230
+STAFFORD,West St. John,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,000230
+STAFFORD,West St. John,United States House of Representatives,4,Republican,"Pompeo, Mike",138,000230
+STAFFORD,York Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",3,000240
+STAFFORD,York Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000240
+STAFFORD,York Township,United States House of Representatives,4,Republican,"Pompeo, Mike",13,000240

--- a/2012/20121106__ks__general__stanton__precinct.csv
+++ b/2012/20121106__ks__general__stanton__precinct.csv
@@ -1,0 +1,70 @@
+county,precinct,office,district,party,candidate,votes,vtd
+STANTON,Big Bow,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",102,000010
+STANTON,Manter,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",91,000020
+STANTON,Stanton,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",406,000030
+STANTON,Big Bow,Kansas Senate,39,Republican,"Powell, Larry R.",103,000010
+STANTON,Manter,Kansas Senate,39,Republican,"Powell, Larry R.",87,000020
+STANTON,Stanton,Kansas Senate,39,Republican,"Powell, Larry R.",391,000030
+STANTON,Big Bow,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Barnett, Andre",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Bush, Kent W",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Christensen, Will",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Goode, Virgil",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Stein, Jill E",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+STANTON,Big Bow,President / Vice President,,Democratic,"Obama, Barack",13,000010
+STANTON,Big Bow,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+STANTON,Big Bow,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+STANTON,Big Bow,President / Vice President,,Republican,"Romney, Mitt",104,000010
+STANTON,Manter,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Barnett, Andre",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Bush, Kent W",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Christensen, Will",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Goode, Virgil",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Stein, Jill E",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+STANTON,Manter,President / Vice President,,Democratic,"Obama, Barack",25,000020
+STANTON,Manter,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+STANTON,Manter,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+STANTON,Manter,President / Vice President,,Republican,"Romney, Mitt",80,000020
+STANTON,Stanton,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Barnett, Andre",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Bush, Kent W",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Christensen, Will",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Goode, Virgil",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Stein, Jill E",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+STANTON,Stanton,President / Vice President,,Democratic,"Obama, Barack",105,000030
+STANTON,Stanton,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+STANTON,Stanton,President / Vice President,,Reform,"Baldwin, Chuck",5,000030
+STANTON,Stanton,President / Vice President,,Republican,"Romney, Mitt",421,000030
+STANTON,Big Bow,United States House of Representatives,1,Republican,"Huelskamp, Tim",101,000010
+STANTON,Manter,United States House of Representatives,1,Republican,"Huelskamp, Tim",87,000020
+STANTON,Stanton,United States House of Representatives,1,Republican,"Huelskamp, Tim",421,000030

--- a/2012/20121106__ks__general__stevens__precinct.csv
+++ b/2012/20121106__ks__general__stevens__precinct.csv
@@ -1,0 +1,323 @@
+county,precinct,office,district,party,candidate,votes,vtd
+STEVENS,Banner Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",58,000010
+STEVENS,Center Precinct 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",23,000020
+STEVENS,Center Precinct 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",128,000030
+STEVENS,Harmony Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",34,000040
+STEVENS,Hugoton Ward 1 Precinct 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",146,000050
+STEVENS,Hugoton Ward 1 Precinct 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",209,000060
+STEVENS,Hugoton Ward 2 Precinct 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",33,000070
+STEVENS,Hugoton Ward 2 Precinct 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",400,000080
+STEVENS,Moscow Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",220,000090
+STEVENS,Voorhees Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",62,000100
+STEVENS,West Center Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",45,000110
+STEVENS,Hugoton Ward 03 Precinct 02,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",53,120010
+STEVENS,Hugoton Ward 04 Precinct 02,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",209,120020
+STEVENS,Hugoton Ward 05 Precinct 02,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",14,120030
+STEVENS,Banner Township,Kansas Senate,39,Republican,"Powell, Larry R.",46,000010
+STEVENS,Center Precinct 1,Kansas Senate,39,Republican,"Powell, Larry R.",17,000020
+STEVENS,Center Precinct 2,Kansas Senate,39,Republican,"Powell, Larry R.",98,000030
+STEVENS,Harmony Township,Kansas Senate,39,Republican,"Powell, Larry R.",25,000040
+STEVENS,Hugoton Ward 1 Precinct 1,Kansas Senate,39,Republican,"Powell, Larry R.",102,000050
+STEVENS,Hugoton Ward 1 Precinct 2,Kansas Senate,39,Republican,"Powell, Larry R.",172,000060
+STEVENS,Hugoton Ward 2 Precinct 1,Kansas Senate,39,Republican,"Powell, Larry R.",20,000070
+STEVENS,Hugoton Ward 2 Precinct 2,Kansas Senate,39,Republican,"Powell, Larry R.",310,000080
+STEVENS,Moscow Township,Kansas Senate,39,Republican,"Powell, Larry R.",183,000090
+STEVENS,Voorhees Township,Kansas Senate,39,Republican,"Powell, Larry R.",50,000100
+STEVENS,West Center Township,Kansas Senate,39,Republican,"Powell, Larry R.",47,000110
+STEVENS,Hugoton Ward 03 Precinct 02,Kansas Senate,39,Republican,"Powell, Larry R.",58,120010
+STEVENS,Hugoton Ward 04 Precinct 02,Kansas Senate,39,Republican,"Powell, Larry R.",167,120020
+STEVENS,Hugoton Ward 05 Precinct 02,Kansas Senate,39,Republican,"Powell, Larry R.",12,120030
+STEVENS,Banner Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+STEVENS,Banner Township,President / Vice President,,Democratic,"Obama, Barack",4,000010
+STEVENS,Banner Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+STEVENS,Banner Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+STEVENS,Banner Township,President / Vice President,,Republican,"Romney, Mitt",63,000010
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,Democratic,"Obama, Barack",1,000020
+STEVENS,Center Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,Republican,"Romney, Mitt",23,000020
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,Democratic,"Obama, Barack",9,000030
+STEVENS,Center Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+STEVENS,Center Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+STEVENS,Center Precinct 2,President / Vice President,,Republican,"Romney, Mitt",134,000030
+STEVENS,Harmony Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+STEVENS,Harmony Township,President / Vice President,,Democratic,"Obama, Barack",1,000040
+STEVENS,Harmony Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+STEVENS,Harmony Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+STEVENS,Harmony Township,President / Vice President,,Republican,"Romney, Mitt",37,000040
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",29,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",143,000050
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",45,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",238,000060
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",5,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",36,000070
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",69,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",428,000080
+STEVENS,Moscow Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+STEVENS,Moscow Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+STEVENS,Moscow Township,President / Vice President,,Democratic,"Obama, Barack",34,000090
+STEVENS,Moscow Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000090
+STEVENS,Moscow Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000090
+STEVENS,Moscow Township,President / Vice President,,Republican,"Romney, Mitt",215,000090
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+STEVENS,Voorhees Township,President / Vice President,,Democratic,"Obama, Barack",4,000100
+STEVENS,Voorhees Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+STEVENS,Voorhees Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000100
+STEVENS,Voorhees Township,President / Vice President,,Republican,"Romney, Mitt",69,000100
+STEVENS,West Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+STEVENS,West Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+STEVENS,West Center Township,President / Vice President,,Democratic,"Obama, Barack",9,000110
+STEVENS,West Center Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+STEVENS,West Center Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000110
+STEVENS,West Center Township,President / Vice President,,Republican,"Romney, Mitt",56,000110
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",11,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",0,120010
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",60,120010
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",30,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",3,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",0,120020
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",226,120020
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",1,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",1,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",1,120030
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",21,120030
+STEVENS,Banner Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",63,000010
+STEVENS,Center Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",20,000020
+STEVENS,Center Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",121,000030
+STEVENS,Harmony Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000040
+STEVENS,Hugoton Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",136,000050
+STEVENS,Hugoton Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",215,000060
+STEVENS,Hugoton Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000070
+STEVENS,Hugoton Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",400,000080
+STEVENS,Moscow Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",221,000090
+STEVENS,Voorhees Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",63,000100
+STEVENS,West Center Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000110
+STEVENS,Hugoton Ward 03 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",58,120010
+STEVENS,Hugoton Ward 04 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",204,120020
+STEVENS,Hugoton Ward 05 Precinct 02,United States House of Representatives,1,Republican,"Huelskamp, Tim",13,120030

--- a/2012/20121106__ks__general__sumner__precinct.csv
+++ b/2012/20121106__ks__general__sumner__precinct.csv
@@ -1,0 +1,1377 @@
+county,precinct,office,district,party,candidate,votes,vtd
+SUMNER,Avon Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",119,000010
+SUMNER,Bluff Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",22,000030
+SUMNER,Caldwell City Ward 1,Kansas House of Representatives,80,Republican,"Kelley, Kasha",120,000040
+SUMNER,Caldwell City Ward 2,Kansas House of Representatives,80,Republican,"Kelley, Kasha",227,000050
+SUMNER,Caldwell Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",56,000060
+SUMNER,Chikaskia Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",26,000070
+SUMNER,Conway Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",220,000080
+SUMNER,Conway Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",223,000080
+SUMNER,Creek Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",42,000090
+SUMNER,Creek Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",34,000090
+SUMNER,Dixon Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",123,000100
+SUMNER,Dixon Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",141,000100
+SUMNER,Downs Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",46,000110
+SUMNER,Eden Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",52,000120
+SUMNER,Eden Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",88,000120
+SUMNER,Falls Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",52,000130
+SUMNER,Greene Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",24,000150
+SUMNER,Guelph Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",51,000160
+SUMNER,Harmon Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",46,000170
+SUMNER,Harmon Township,Kansas House of Representatives,79,Republican,"Alley, Larry",77,000170
+SUMNER,Illinois Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",29,000180
+SUMNER,Illinois Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",60,000180
+SUMNER,Jackson Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",56,000190
+SUMNER,London Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",110,000200
+SUMNER,London Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",192,000200
+SUMNER,Morris Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",9,000210
+SUMNER,Mulvane City,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",216,000220
+SUMNER,Osborne Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",69,000230
+SUMNER,Osborne Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",37,000230
+SUMNER,Oxford Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",242,000240
+SUMNER,Oxford Township,Kansas House of Representatives,79,Republican,"Alley, Larry",304,000240
+SUMNER,Palestine Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",32,000250
+SUMNER,Palestine Township,Kansas House of Representatives,79,Republican,"Alley, Larry",50,000250
+SUMNER,Ryan Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",32,000260
+SUMNER,Ryan Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",32,000260
+SUMNER,South Haven Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",184,000280
+SUMNER,Springdale Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",143,000290
+SUMNER,Springdale Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",145,000290
+SUMNER,Sumner Township,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",32,000300
+SUMNER,Sumner Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",28,000300
+SUMNER,Valverde Township,Kansas House of Representatives,80,Republican,"Kelley, Kasha",57,000310
+SUMNER,Walton Precinct,Kansas House of Representatives,80,Republican,"Kelley, Kasha",148,000320
+SUMNER,Wellington City Ward 1 Precinct 2,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",187,000350
+SUMNER,Wellington City Ward 1 Precinct 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",95,000350
+SUMNER,Wellington City Ward 2 Precinct 1,Kansas House of Representatives,80,Republican,"Kelley, Kasha",338,000360
+SUMNER,Wellington City Ward 2 Precinct 2,Kansas House of Representatives,80,Republican,"Kelley, Kasha",173,000370
+SUMNER,Wellington City Ward 3 Precinct 2,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",164,000390
+SUMNER,Wellington City Ward 3 Precinct 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",98,000390
+SUMNER,Wellington City Ward 4 Precinct 1,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",282,000400
+SUMNER,Wellington City Ward 4 Precinct 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",159,000400
+SUMNER,Wellington City Ward 4 Precinct 2,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",405,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",147,00041A
+SUMNER,Belle Plaine Township H79,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",466,120020
+SUMNER,Belle Plaine Township H79,Kansas House of Representatives,79,Republican,"Alley, Larry",717,120020
+SUMNER,Belle Plaine Township H82,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",7,120030
+SUMNER,Gore Township H79,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",94,120040
+SUMNER,Gore Township H79,Kansas House of Representatives,79,Republican,"Alley, Larry",196,120040
+SUMNER,Gore Township H82,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",88,120050
+SUMNER,Seventy - Six Township H116,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",58,120060
+SUMNER,Seventy - Six Township H116,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",60,120060
+SUMNER,Seventy - Six Township H80,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,120070
+SUMNER,Wellington City Ward 1 Precinct 1 H116,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H80,Kansas House of Representatives,80,Republican,"Kelley, Kasha",217,120090
+SUMNER,Wellington City Ward 3 Precinct 1 H116,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",223,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",112,120100
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,Kansas House of Representatives,80,Republican,"Kelley, Kasha",19,120110
+SUMNER,Wellington Township H116,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",40,120120
+SUMNER,Wellington Township H116,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",26,120120
+SUMNER,Wellington Township H80 A,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,12013A
+SUMNER,Wellington Township H80,Kansas House of Representatives,80,Republican,"Kelley, Kasha",23,120130
+SUMNER,Wellington Township Part B,Kansas House of Representatives,80,Republican,"Kelley, Kasha",0,900010
+SUMNER,Wellington City Airport,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",0,900020
+SUMNER,Wellington City Airport,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,900020
+SUMNER,Wellington Lake Exclave,Kansas House of Representatives,116,Democratic,"Wetta, Vincent",0,900030
+SUMNER,Wellington Lake Exclave,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,900030
+SUMNER,Gore Township Enclave,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",0,900040
+SUMNER,Mulvane City Exclave A,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",0,900050
+SUMNER,Mulvane City Exclave B,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",0,900060
+SUMNER,Mulvane City Exclave B,Kansas House of Representatives,79,Republican,"Alley, Larry",5,900060
+SUMNER,Avon Township,Kansas Senate,32,Republican,"Abrams, Steve E",126,000010
+SUMNER,Bluff Township,Kansas Senate,32,Republican,"Abrams, Steve E",24,000030
+SUMNER,Caldwell City Ward 1,Kansas Senate,32,Republican,"Abrams, Steve E",121,000040
+SUMNER,Caldwell City Ward 2,Kansas Senate,32,Republican,"Abrams, Steve E",221,000050
+SUMNER,Caldwell Township,Kansas Senate,32,Republican,"Abrams, Steve E",55,000060
+SUMNER,Chikaskia Township,Kansas Senate,32,Republican,"Abrams, Steve E",24,000070
+SUMNER,Conway Township,Kansas Senate,32,Republican,"Abrams, Steve E",378,000080
+SUMNER,Creek Township,Kansas Senate,32,Republican,"Abrams, Steve E",66,000090
+SUMNER,Dixon Township,Kansas Senate,32,Republican,"Abrams, Steve E",223,000100
+SUMNER,Downs Township,Kansas Senate,32,Republican,"Abrams, Steve E",51,000110
+SUMNER,Eden Township,Kansas Senate,32,Republican,"Abrams, Steve E",119,000120
+SUMNER,Falls Township,Kansas Senate,32,Republican,"Abrams, Steve E",50,000130
+SUMNER,Greene Township,Kansas Senate,32,Republican,"Abrams, Steve E",23,000150
+SUMNER,Guelph Township,Kansas Senate,32,Republican,"Abrams, Steve E",53,000160
+SUMNER,Harmon Township,Kansas Senate,32,Republican,"Abrams, Steve E",101,000170
+SUMNER,Illinois Township,Kansas Senate,32,Republican,"Abrams, Steve E",81,000180
+SUMNER,Jackson Township,Kansas Senate,32,Republican,"Abrams, Steve E",58,000190
+SUMNER,London Township,Kansas Senate,32,Republican,"Abrams, Steve E",255,000200
+SUMNER,Morris Township,Kansas Senate,32,Republican,"Abrams, Steve E",12,000210
+SUMNER,Mulvane City,Kansas Senate,32,Republican,"Abrams, Steve E",233,000220
+SUMNER,Osborne Township,Kansas Senate,32,Republican,"Abrams, Steve E",87,000230
+SUMNER,Oxford Township,Kansas Senate,32,Republican,"Abrams, Steve E",454,000240
+SUMNER,Palestine Township,Kansas Senate,32,Republican,"Abrams, Steve E",65,000250
+SUMNER,Ryan Township,Kansas Senate,32,Republican,"Abrams, Steve E",55,000260
+SUMNER,South Haven Township,Kansas Senate,32,Republican,"Abrams, Steve E",192,000280
+SUMNER,Springdale Township,Kansas Senate,32,Republican,"Abrams, Steve E",250,000290
+SUMNER,Sumner Township,Kansas Senate,32,Republican,"Abrams, Steve E",49,000300
+SUMNER,Valverde Township,Kansas Senate,32,Republican,"Abrams, Steve E",62,000310
+SUMNER,Walton Precinct,Kansas Senate,32,Republican,"Abrams, Steve E",142,000320
+SUMNER,Wellington City Ward 1 Precinct 2,Kansas Senate,32,Republican,"Abrams, Steve E",200,000350
+SUMNER,Wellington City Ward 2 Precinct 1,Kansas Senate,32,Republican,"Abrams, Steve E",356,000360
+SUMNER,Wellington City Ward 2 Precinct 2,Kansas Senate,32,Republican,"Abrams, Steve E",175,000370
+SUMNER,Wellington City Ward 3 Precinct 2,Kansas Senate,32,Republican,"Abrams, Steve E",211,000390
+SUMNER,Wellington City Ward 4 Precinct 1,Kansas Senate,32,Republican,"Abrams, Steve E",362,000400
+SUMNER,Wellington City Ward 4 Precinct 2,Kansas Senate,32,Republican,"Abrams, Steve E",441,00041A
+SUMNER,Belle Plaine Township H79,Kansas Senate,32,Republican,"Abrams, Steve E",957,120020
+SUMNER,Belle Plaine Township H82,Kansas Senate,32,Republican,"Abrams, Steve E",7,120030
+SUMNER,Gore Township H79,Kansas Senate,32,Republican,"Abrams, Steve E",246,120040
+SUMNER,Gore Township H82,Kansas Senate,32,Republican,"Abrams, Steve E",90,120050
+SUMNER,Seventy - Six Township H116,Kansas Senate,32,Republican,"Abrams, Steve E",102,120060
+SUMNER,Seventy - Six Township H80,Kansas Senate,32,Republican,"Abrams, Steve E",0,120070
+SUMNER,Wellington City Ward 1 Precinct 1 H116,Kansas Senate,32,Republican,"Abrams, Steve E",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H80,Kansas Senate,32,Republican,"Abrams, Steve E",223,120090
+SUMNER,Wellington City Ward 3 Precinct 1 H116,Kansas Senate,32,Republican,"Abrams, Steve E",275,120100
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,Kansas Senate,32,Republican,"Abrams, Steve E",18,120110
+SUMNER,Wellington Township H116,Kansas Senate,32,Republican,"Abrams, Steve E",53,120120
+SUMNER,Wellington Township H80 A,Kansas Senate,32,Republican,"Abrams, Steve E",0,12013A
+SUMNER,Wellington Township H80,Kansas Senate,32,Republican,"Abrams, Steve E",27,120130
+SUMNER,Wellington Township Part B,Kansas Senate,32,Republican,"Abrams, Steve E",0,900010
+SUMNER,Wellington City Airport,Kansas Senate,32,Republican,"Abrams, Steve E",0,900020
+SUMNER,Wellington Lake Exclave,Kansas Senate,32,Republican,"Abrams, Steve E",0,900030
+SUMNER,Gore Township Enclave,Kansas Senate,32,Republican,"Abrams, Steve E",0,900040
+SUMNER,Mulvane City Exclave A,Kansas Senate,32,Republican,"Abrams, Steve E",0,900050
+SUMNER,Mulvane City Exclave B,Kansas Senate,32,Republican,"Abrams, Steve E",5,900060
+SUMNER,Avon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+SUMNER,Avon Township,President / Vice President,,Democratic,"Obama, Barack",43,000010
+SUMNER,Avon Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+SUMNER,Avon Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000010
+SUMNER,Avon Township,President / Vice President,,Republican,"Romney, Mitt",100,000010
+SUMNER,Bluff Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+SUMNER,Bluff Township,President / Vice President,,Democratic,"Obama, Barack",5,000030
+SUMNER,Bluff Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+SUMNER,Bluff Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+SUMNER,Bluff Township,President / Vice President,,Republican,"Romney, Mitt",25,000030
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,Democratic,"Obama, Barack",57,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,Republican,"Romney, Mitt",91,000040
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,Democratic,"Obama, Barack",109,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,Republican,"Romney, Mitt",160,000050
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Stein, Jill E",1,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+SUMNER,Caldwell Township,President / Vice President,,Democratic,"Obama, Barack",23,000060
+SUMNER,Caldwell Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+SUMNER,Caldwell Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+SUMNER,Caldwell Township,President / Vice President,,Republican,"Romney, Mitt",42,000060
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,Democratic,"Obama, Barack",4,000070
+SUMNER,Chikaskia Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+SUMNER,Chikaskia Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000070
+SUMNER,Chikaskia Township,President / Vice President,,Republican,"Romney, Mitt",23,000070
+SUMNER,Conway Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+SUMNER,Conway Township,President / Vice President,,Democratic,"Obama, Barack",109,000080
+SUMNER,Conway Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000080
+SUMNER,Conway Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000080
+SUMNER,Conway Township,President / Vice President,,Republican,"Romney, Mitt",336,000080
+SUMNER,Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+SUMNER,Creek Township,President / Vice President,,Democratic,"Obama, Barack",10,000090
+SUMNER,Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+SUMNER,Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+SUMNER,Creek Township,President / Vice President,,Republican,"Romney, Mitt",70,000090
+SUMNER,Dixon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+SUMNER,Dixon Township,President / Vice President,,Democratic,"Obama, Barack",45,000100
+SUMNER,Dixon Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+SUMNER,Dixon Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000100
+SUMNER,Dixon Township,President / Vice President,,Republican,"Romney, Mitt",217,000100
+SUMNER,Downs Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+SUMNER,Downs Township,President / Vice President,,Democratic,"Obama, Barack",12,000110
+SUMNER,Downs Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+SUMNER,Downs Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+SUMNER,Downs Township,President / Vice President,,Republican,"Romney, Mitt",47,000110
+SUMNER,Eden Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+SUMNER,Eden Township,President / Vice President,,Democratic,"Obama, Barack",40,000120
+SUMNER,Eden Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000120
+SUMNER,Eden Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+SUMNER,Eden Township,President / Vice President,,Republican,"Romney, Mitt",109,000120
+SUMNER,Falls Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+SUMNER,Falls Township,President / Vice President,,Democratic,"Obama, Barack",14,000130
+SUMNER,Falls Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+SUMNER,Falls Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+SUMNER,Falls Township,President / Vice President,,Republican,"Romney, Mitt",44,000130
+SUMNER,Greene Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+SUMNER,Greene Township,President / Vice President,,Democratic,"Obama, Barack",4,000150
+SUMNER,Greene Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000150
+SUMNER,Greene Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+SUMNER,Greene Township,President / Vice President,,Republican,"Romney, Mitt",23,000150
+SUMNER,Guelph Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+SUMNER,Guelph Township,President / Vice President,,Democratic,"Obama, Barack",12,000160
+SUMNER,Guelph Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000160
+SUMNER,Guelph Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+SUMNER,Guelph Township,President / Vice President,,Republican,"Romney, Mitt",51,000160
+SUMNER,Harmon Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+SUMNER,Harmon Township,President / Vice President,,Democratic,"Obama, Barack",20,000170
+SUMNER,Harmon Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000170
+SUMNER,Harmon Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000170
+SUMNER,Harmon Township,President / Vice President,,Republican,"Romney, Mitt",100,000170
+SUMNER,Illinois Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+SUMNER,Illinois Township,President / Vice President,,Democratic,"Obama, Barack",19,000180
+SUMNER,Illinois Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+SUMNER,Illinois Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000180
+SUMNER,Illinois Township,President / Vice President,,Republican,"Romney, Mitt",69,000180
+SUMNER,Jackson Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+SUMNER,Jackson Township,President / Vice President,,Democratic,"Obama, Barack",16,000190
+SUMNER,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+SUMNER,Jackson Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+SUMNER,Jackson Township,President / Vice President,,Republican,"Romney, Mitt",53,000190
+SUMNER,London Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Stein, Jill E",1,000200
+SUMNER,London Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+SUMNER,London Township,President / Vice President,,Democratic,"Obama, Barack",63,000200
+SUMNER,London Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000200
+SUMNER,London Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000200
+SUMNER,London Township,President / Vice President,,Republican,"Romney, Mitt",238,000200
+SUMNER,Morris Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+SUMNER,Morris Township,President / Vice President,,Democratic,"Obama, Barack",1,000210
+SUMNER,Morris Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+SUMNER,Morris Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+SUMNER,Morris Township,President / Vice President,,Republican,"Romney, Mitt",11,000210
+SUMNER,Mulvane City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Barnett, Andre",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Bush, Kent W",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Christensen, Will",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Goode, Virgil",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Stein, Jill E",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+SUMNER,Mulvane City,President / Vice President,,Democratic,"Obama, Barack",95,000220
+SUMNER,Mulvane City,President / Vice President,,Libertarian,"Johnson, Gary",6,000220
+SUMNER,Mulvane City,President / Vice President,,Reform,"Baldwin, Chuck",3,000220
+SUMNER,Mulvane City,President / Vice President,,Republican,"Romney, Mitt",197,000220
+SUMNER,Osborne Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+SUMNER,Osborne Township,President / Vice President,,Democratic,"Obama, Barack",31,000230
+SUMNER,Osborne Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+SUMNER,Osborne Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+SUMNER,Osborne Township,President / Vice President,,Republican,"Romney, Mitt",74,000230
+SUMNER,Oxford Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Goode, Virgil",1,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+SUMNER,Oxford Township,President / Vice President,,Democratic,"Obama, Barack",148,000240
+SUMNER,Oxford Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000240
+SUMNER,Oxford Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000240
+SUMNER,Oxford Township,President / Vice President,,Republican,"Romney, Mitt",385,000240
+SUMNER,Palestine Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Ayers, Avery L",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Barnett, Andre",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Bush, Kent W",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Christensen, Will",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Duncan, Richard A",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Goode, Virgil",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Knill, Dennis J",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Reed, Jill A.",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Rogers, Rick L",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Stein, Jill E",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000250
+SUMNER,Palestine Township,President / Vice President,,Democratic,"Obama, Barack",21,000250
+SUMNER,Palestine Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000250
+SUMNER,Palestine Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000250
+SUMNER,Palestine Township,President / Vice President,,Republican,"Romney, Mitt",59,000250
+SUMNER,Ryan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Barnett, Andre",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Bush, Kent W",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Christensen, Will",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Goode, Virgil",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Stein, Jill E",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000260
+SUMNER,Ryan Township,President / Vice President,,Democratic,"Obama, Barack",16,000260
+SUMNER,Ryan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000260
+SUMNER,Ryan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000260
+SUMNER,Ryan Township,President / Vice President,,Republican,"Romney, Mitt",48,000260
+SUMNER,South Haven Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Ayers, Avery L",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Barnett, Andre",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Bush, Kent W",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Christensen, Will",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Duncan, Richard A",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Goode, Virgil",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Knill, Dennis J",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Reed, Jill A.",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Rogers, Rick L",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Stein, Jill E",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000280
+SUMNER,South Haven Township,President / Vice President,,Democratic,"Obama, Barack",47,000280
+SUMNER,South Haven Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000280
+SUMNER,South Haven Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000280
+SUMNER,South Haven Township,President / Vice President,,Republican,"Romney, Mitt",174,000280
+SUMNER,Springdale Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Ayers, Avery L",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Barnett, Andre",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Bush, Kent W",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Christensen, Will",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Duncan, Richard A",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Goode, Virgil",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Knill, Dennis J",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Reed, Jill A.",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Rogers, Rick L",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Stein, Jill E",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000290
+SUMNER,Springdale Township,President / Vice President,,Democratic,"Obama, Barack",57,000290
+SUMNER,Springdale Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000290
+SUMNER,Springdale Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000290
+SUMNER,Springdale Township,President / Vice President,,Republican,"Romney, Mitt",225,000290
+SUMNER,Sumner Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Ayers, Avery L",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Barnett, Andre",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Bush, Kent W",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Christensen, Will",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Duncan, Richard A",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Goode, Virgil",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Knill, Dennis J",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Reed, Jill A.",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Rogers, Rick L",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Stein, Jill E",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000300
+SUMNER,Sumner Township,President / Vice President,,Democratic,"Obama, Barack",21,000300
+SUMNER,Sumner Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000300
+SUMNER,Sumner Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000300
+SUMNER,Sumner Township,President / Vice President,,Republican,"Romney, Mitt",39,000300
+SUMNER,Valverde Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Ayers, Avery L",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Barnett, Andre",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Bush, Kent W",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Christensen, Will",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Duncan, Richard A",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Goode, Virgil",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Knill, Dennis J",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Reed, Jill A.",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Rogers, Rick L",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Stein, Jill E",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000310
+SUMNER,Valverde Township,President / Vice President,,Democratic,"Obama, Barack",15,000310
+SUMNER,Valverde Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000310
+SUMNER,Valverde Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000310
+SUMNER,Valverde Township,President / Vice President,,Republican,"Romney, Mitt",54,000310
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Ayers, Avery L",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Barnett, Andre",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Barr, Roseanne C",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Bush, Kent W",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Christensen, Will",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Duncan, Richard A",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Goode, Virgil",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Knill, Dennis J",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Reed, Jill A.",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Rogers, Rick L",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Stein, Jill E",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Thorne, Kevin M",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Warner, Gerald L.",0,000320
+SUMNER,Walton Precinct,President / Vice President,,Democratic,"Obama, Barack",30,000320
+SUMNER,Walton Precinct,President / Vice President,,Libertarian,"Johnson, Gary",5,000320
+SUMNER,Walton Precinct,President / Vice President,,Reform,"Baldwin, Chuck",3,000320
+SUMNER,Walton Precinct,President / Vice President,,Republican,"Romney, Mitt",120,000320
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",1,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",110,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000350
+SUMNER,Wellington City Ward 1 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",166,000350
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",187,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",13,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",4,000360
+SUMNER,Wellington City Ward 2 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",254,000360
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",115,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",4,000370
+SUMNER,Wellington City Ward 2 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",118,000370
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",99,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",7,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",3,000390
+SUMNER,Wellington City Ward 3 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",154,000390
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,Democratic,"Obama, Barack",161,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",2,000400
+SUMNER,Wellington City Ward 4 Precinct 1,President / Vice President,,Republican,"Romney, Mitt",271,000400
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,Democratic,"Obama, Barack",178,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",2,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,President / Vice President,,Republican,"Romney, Mitt",370,00041A
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Barnett, Andre",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Bush, Kent W",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Christensen, Will",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Goode, Virgil",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Stein, Jill E",2,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,Democratic,"Obama, Barack",350,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,Libertarian,"Johnson, Gary",22,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,Reform,"Baldwin, Chuck",4,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,Republican,"Romney, Mitt",851,120020
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Barnett, Andre",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Bush, Kent W",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Christensen, Will",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Goode, Virgil",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Stein, Jill E",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,Democratic,"Obama, Barack",4,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,Republican,"Romney, Mitt",5,120030
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Barnett, Andre",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Bush, Kent W",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Christensen, Will",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Goode, Virgil",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Stein, Jill E",2,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+SUMNER,Gore Township H79,President / Vice President,,Democratic,"Obama, Barack",72,120040
+SUMNER,Gore Township H79,President / Vice President,,Libertarian,"Johnson, Gary",5,120040
+SUMNER,Gore Township H79,President / Vice President,,Reform,"Baldwin, Chuck",1,120040
+SUMNER,Gore Township H79,President / Vice President,,Republican,"Romney, Mitt",229,120040
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Barnett, Andre",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Bush, Kent W",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Christensen, Will",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Goode, Virgil",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Stein, Jill E",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+SUMNER,Gore Township H82,President / Vice President,,Democratic,"Obama, Barack",22,120050
+SUMNER,Gore Township H82,President / Vice President,,Libertarian,"Johnson, Gary",2,120050
+SUMNER,Gore Township H82,President / Vice President,,Reform,"Baldwin, Chuck",0,120050
+SUMNER,Gore Township H82,President / Vice President,,Republican,"Romney, Mitt",80,120050
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Ayers, Avery L",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Barnett, Andre",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Barr, Roseanne C",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Bush, Kent W",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Christensen, Will",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Duncan, Richard A",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Goode, Virgil",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Knill, Dennis J",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Reed, Jill A.",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Rogers, Rick L",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Stein, Jill E",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Thorne, Kevin M",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Warner, Gerald L.",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,Democratic,"Obama, Barack",11,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,Libertarian,"Johnson, Gary",1,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,Reform,"Baldwin, Chuck",1,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,Republican,"Romney, Mitt",105,120060
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Ayers, Avery L",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Barnett, Andre",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Barr, Roseanne C",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Bush, Kent W",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Christensen, Will",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Duncan, Richard A",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Goode, Virgil",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Knill, Dennis J",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Reed, Jill A.",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Rogers, Rick L",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Stein, Jill E",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Thorne, Kevin M",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Warner, Gerald L.",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,Democratic,"Obama, Barack",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,Libertarian,"Johnson, Gary",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,Reform,"Baldwin, Chuck",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,Republican,"Romney, Mitt",0,120070
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Ayers, Avery L",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Barnett, Andre",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Barr, Roseanne C",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Bush, Kent W",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Christensen, Will",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Duncan, Richard A",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Goode, Virgil",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Knill, Dennis J",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Reed, Jill A.",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Rogers, Rick L",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Stein, Jill E",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Thorne, Kevin M",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,write - in,"Warner, Gerald L.",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,Democratic,"Obama, Barack",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,Libertarian,"Johnson, Gary",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,Reform,"Baldwin, Chuck",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,President / Vice President,,Republican,"Romney, Mitt",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Ayers, Avery L",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Barnett, Andre",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Barr, Roseanne C",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Bush, Kent W",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Christensen, Will",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Duncan, Richard A",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Goode, Virgil",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Knill, Dennis J",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Reed, Jill A.",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Rogers, Rick L",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Stein, Jill E",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Thorne, Kevin M",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,write - in,"Warner, Gerald L.",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,Democratic,"Obama, Barack",96,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,Libertarian,"Johnson, Gary",5,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,Reform,"Baldwin, Chuck",0,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,President / Vice President,,Republican,"Romney, Mitt",182,120090
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Ayers, Avery L",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Barnett, Andre",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Barr, Roseanne C",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Bush, Kent W",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Christensen, Will",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Duncan, Richard A",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Goode, Virgil",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Hoefling, Tom",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Knill, Dennis J",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Reed, Jill A.",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Rogers, Rick L",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Stein, Jill E",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Thorne, Kevin M",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,write - in,"Warner, Gerald L.",0,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,Democratic,"Obama, Barack",126,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,Libertarian,"Johnson, Gary",9,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,Reform,"Baldwin, Chuck",4,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,President / Vice President,,Republican,"Romney, Mitt",197,120100
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Ayers, Avery L",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Barnett, Andre",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Barr, Roseanne C",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Bush, Kent W",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Christensen, Will",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Duncan, Richard A",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Goode, Virgil",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Hoefling, Tom",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Knill, Dennis J",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Reed, Jill A.",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Rogers, Rick L",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Stein, Jill E",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Thorne, Kevin M",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,write - in,"Warner, Gerald L.",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,Democratic,"Obama, Barack",3,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,Libertarian,"Johnson, Gary",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,Reform,"Baldwin, Chuck",0,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,President / Vice President,,Republican,"Romney, Mitt",21,120110
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Ayers, Avery L",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Barnett, Andre",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Barr, Roseanne C",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Bush, Kent W",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Christensen, Will",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Duncan, Richard A",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Goode, Virgil",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Hoefling, Tom",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Knill, Dennis J",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Reed, Jill A.",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Rogers, Rick L",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Stein, Jill E",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Thorne, Kevin M",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Warner, Gerald L.",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,Democratic,"Obama, Barack",20,120120
+SUMNER,Wellington Township H116,President / Vice President,,Libertarian,"Johnson, Gary",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,Reform,"Baldwin, Chuck",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,Republican,"Romney, Mitt",46,120120
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Ayers, Avery L",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Barnett, Andre",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Bush, Kent W",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Christensen, Will",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Duncan, Richard A",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Goode, Virgil",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Hoefling, Tom",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Knill, Dennis J",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Reed, Jill A.",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Rogers, Rick L",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Stein, Jill E",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,Democratic,"Obama, Barack",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,Republican,"Romney, Mitt",0,12013A
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Ayers, Avery L",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Barnett, Andre",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Barr, Roseanne C",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Bush, Kent W",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Christensen, Will",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Duncan, Richard A",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Goode, Virgil",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Hoefling, Tom",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Knill, Dennis J",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Reed, Jill A.",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Rogers, Rick L",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Stein, Jill E",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Thorne, Kevin M",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Warner, Gerald L.",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,Democratic,"Obama, Barack",16,120130
+SUMNER,Wellington Township H80,President / Vice President,,Libertarian,"Johnson, Gary",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,Reform,"Baldwin, Chuck",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,Republican,"Romney, Mitt",22,120130
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Barnett, Andre",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Bush, Kent W",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Christensen, Will",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Goode, Virgil",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Stein, Jill E",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,Democratic,"Obama, Barack",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+SUMNER,Wellington Township Part B,President / Vice President,,Republican,"Romney, Mitt",0,900010
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Barnett, Andre",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Bush, Kent W",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Christensen, Will",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Goode, Virgil",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Stein, Jill E",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,Democratic,"Obama, Barack",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,Republican,"Romney, Mitt",0,900020
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Christensen, Will",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900030
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Barnett, Andre",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Bush, Kent W",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Christensen, Will",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Goode, Virgil",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Stein, Jill E",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,Democratic,"Obama, Barack",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,Republican,"Romney, Mitt",0,900040
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Ayers, Avery L",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Barnett, Andre",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Barr, Roseanne C",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Bush, Kent W",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Christensen, Will",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Duncan, Richard A",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Goode, Virgil",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Knill, Dennis J",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Reed, Jill A.",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Rogers, Rick L",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Stein, Jill E",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Thorne, Kevin M",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Warner, Gerald L.",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,Democratic,"Obama, Barack",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,Reform,"Baldwin, Chuck",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,Republican,"Romney, Mitt",0,900050
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Ayers, Avery L",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Barnett, Andre",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Bush, Kent W",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Christensen, Will",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Duncan, Richard A",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Goode, Virgil",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Knill, Dennis J",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Reed, Jill A.",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Rogers, Rick L",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Stein, Jill E",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,Democratic,"Obama, Barack",1,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,Republican,"Romney, Mitt",5,900060
+SUMNER,Avon Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",27,000010
+SUMNER,Avon Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000010
+SUMNER,Avon Township,United States House of Representatives,4,Republican,"Pompeo, Mike",106,000010
+SUMNER,Bluff Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",7,000030
+SUMNER,Bluff Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,000030
+SUMNER,Bluff Township,United States House of Representatives,4,Republican,"Pompeo, Mike",23,000030
+SUMNER,Caldwell City Ward 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",35,000040
+SUMNER,Caldwell City Ward 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",12,000040
+SUMNER,Caldwell City Ward 1,United States House of Representatives,4,Republican,"Pompeo, Mike",97,000040
+SUMNER,Caldwell City Ward 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",88,000050
+SUMNER,Caldwell City Ward 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",14,000050
+SUMNER,Caldwell City Ward 2,United States House of Representatives,4,Republican,"Pompeo, Mike",167,000050
+SUMNER,Caldwell Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",17,000060
+SUMNER,Caldwell Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",7,000060
+SUMNER,Caldwell Township,United States House of Representatives,4,Republican,"Pompeo, Mike",44,000060
+SUMNER,Chikaskia Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,000070
+SUMNER,Chikaskia Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000070
+SUMNER,Chikaskia Township,United States House of Representatives,4,Republican,"Pompeo, Mike",26,000070
+SUMNER,Conway Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",77,000080
+SUMNER,Conway Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",33,000080
+SUMNER,Conway Township,United States House of Representatives,4,Republican,"Pompeo, Mike",326,000080
+SUMNER,Creek Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",11,000090
+SUMNER,Creek Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000090
+SUMNER,Creek Township,United States House of Representatives,4,Republican,"Pompeo, Mike",62,000090
+SUMNER,Dixon Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",43,000100
+SUMNER,Dixon Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",20,000100
+SUMNER,Dixon Township,United States House of Representatives,4,Republican,"Pompeo, Mike",197,000100
+SUMNER,Downs Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",12,000110
+SUMNER,Downs Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000110
+SUMNER,Downs Township,United States House of Representatives,4,Republican,"Pompeo, Mike",42,000110
+SUMNER,Eden Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",28,000120
+SUMNER,Eden Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000120
+SUMNER,Eden Township,United States House of Representatives,4,Republican,"Pompeo, Mike",111,000120
+SUMNER,Falls Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",12,000130
+SUMNER,Falls Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000130
+SUMNER,Falls Township,United States House of Representatives,4,Republican,"Pompeo, Mike",44,000130
+SUMNER,Greene Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",4,000150
+SUMNER,Greene Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000150
+SUMNER,Greene Township,United States House of Representatives,4,Republican,"Pompeo, Mike",22,000150
+SUMNER,Guelph Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",11,000160
+SUMNER,Guelph Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000160
+SUMNER,Guelph Township,United States House of Representatives,4,Republican,"Pompeo, Mike",47,000160
+SUMNER,Harmon Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",14,000170
+SUMNER,Harmon Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",9,000170
+SUMNER,Harmon Township,United States House of Representatives,4,Republican,"Pompeo, Mike",103,000170
+SUMNER,Illinois Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",17,000180
+SUMNER,Illinois Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,000180
+SUMNER,Illinois Township,United States House of Representatives,4,Republican,"Pompeo, Mike",67,000180
+SUMNER,Jackson Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",19,000190
+SUMNER,Jackson Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,000190
+SUMNER,Jackson Township,United States House of Representatives,4,Republican,"Pompeo, Mike",48,000190
+SUMNER,London Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",67,000200
+SUMNER,London Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",32,000200
+SUMNER,London Township,United States House of Representatives,4,Republican,"Pompeo, Mike",211,000200
+SUMNER,Morris Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,000210
+SUMNER,Morris Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",1,000210
+SUMNER,Morris Township,United States House of Representatives,4,Republican,"Pompeo, Mike",11,000210
+SUMNER,Mulvane City,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",73,000220
+SUMNER,Mulvane City,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",24,000220
+SUMNER,Mulvane City,United States House of Representatives,4,Republican,"Pompeo, Mike",198,000220
+SUMNER,Osborne Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",25,000230
+SUMNER,Osborne Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",8,000230
+SUMNER,Osborne Township,United States House of Representatives,4,Republican,"Pompeo, Mike",71,000230
+SUMNER,Oxford Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",136,000240
+SUMNER,Oxford Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",53,000240
+SUMNER,Oxford Township,United States House of Representatives,4,Republican,"Pompeo, Mike",351,000240
+SUMNER,Palestine Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",16,000250
+SUMNER,Palestine Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",4,000250
+SUMNER,Palestine Township,United States House of Representatives,4,Republican,"Pompeo, Mike",59,000250
+SUMNER,Ryan Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",21,000260
+SUMNER,Ryan Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,000260
+SUMNER,Ryan Township,United States House of Representatives,4,Republican,"Pompeo, Mike",42,000260
+SUMNER,South Haven Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",41,000280
+SUMNER,South Haven Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",7,000280
+SUMNER,South Haven Township,United States House of Representatives,4,Republican,"Pompeo, Mike",167,000280
+SUMNER,Springdale Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",41,000290
+SUMNER,Springdale Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",18,000290
+SUMNER,Springdale Township,United States House of Representatives,4,Republican,"Pompeo, Mike",225,000290
+SUMNER,Sumner Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",16,000300
+SUMNER,Sumner Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",6,000300
+SUMNER,Sumner Township,United States House of Representatives,4,Republican,"Pompeo, Mike",38,000300
+SUMNER,Valverde Township,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",16,000310
+SUMNER,Valverde Township,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",10,000310
+SUMNER,Valverde Township,United States House of Representatives,4,Republican,"Pompeo, Mike",43,000310
+SUMNER,Walton Precinct,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",30,000320
+SUMNER,Walton Precinct,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",14,000320
+SUMNER,Walton Precinct,United States House of Representatives,4,Republican,"Pompeo, Mike",111,000320
+SUMNER,Wellington City Ward 1 Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",98,000350
+SUMNER,Wellington City Ward 1 Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",18,000350
+SUMNER,Wellington City Ward 1 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",152,000350
+SUMNER,Wellington City Ward 2 Precinct 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",149,000360
+SUMNER,Wellington City Ward 2 Precinct 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",30,000360
+SUMNER,Wellington City Ward 2 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",260,000360
+SUMNER,Wellington City Ward 2 Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",86,000370
+SUMNER,Wellington City Ward 2 Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",24,000370
+SUMNER,Wellington City Ward 2 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",119,000370
+SUMNER,Wellington City Ward 3 Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",76,000390
+SUMNER,Wellington City Ward 3 Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",21,000390
+SUMNER,Wellington City Ward 3 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",156,000390
+SUMNER,Wellington City Ward 4 Precinct 1,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",123,000400
+SUMNER,Wellington City Ward 4 Precinct 1,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",25,000400
+SUMNER,Wellington City Ward 4 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Mike",277,000400
+SUMNER,Wellington City Ward 4 Precinct 2,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",144,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",29,00041A
+SUMNER,Wellington City Ward 4 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Mike",364,00041A
+SUMNER,Belle Plaine Township H79,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",325,120020
+SUMNER,Belle Plaine Township H79,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",111,120020
+SUMNER,Belle Plaine Township H79,United States House of Representatives,4,Republican,"Pompeo, Mike",767,120020
+SUMNER,Belle Plaine Township H82,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",3,120030
+SUMNER,Belle Plaine Township H82,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,120030
+SUMNER,Belle Plaine Township H82,United States House of Representatives,4,Republican,"Pompeo, Mike",6,120030
+SUMNER,Gore Township H79,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",60,120040
+SUMNER,Gore Township H79,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",26,120040
+SUMNER,Gore Township H79,United States House of Representatives,4,Republican,"Pompeo, Mike",215,120040
+SUMNER,Gore Township H82,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",20,120050
+SUMNER,Gore Township H82,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,120050
+SUMNER,Gore Township H82,United States House of Representatives,4,Republican,"Pompeo, Mike",77,120050
+SUMNER,Seventy - Six Township H116,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",12,120060
+SUMNER,Seventy - Six Township H116,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",5,120060
+SUMNER,Seventy - Six Township H116,United States House of Representatives,4,Republican,"Pompeo, Mike",99,120060
+SUMNER,Seventy - Six Township H80,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,120070
+SUMNER,Seventy - Six Township H80,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,120070
+SUMNER,Seventy - Six Township H80,United States House of Representatives,4,Republican,"Pompeo, Mike",0,120070
+SUMNER,Wellington City Ward 1 Precinct 1 H116,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H116,United States House of Representatives,4,Republican,"Pompeo, Mike",0,120080
+SUMNER,Wellington City Ward 1 Precinct 1 H80,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",84,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",19,120090
+SUMNER,Wellington City Ward 1 Precinct 1 H80,United States House of Representatives,4,Republican,"Pompeo, Mike",173,120090
+SUMNER,Wellington City Ward 3 Precinct 1 H116,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",99,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",21,120100
+SUMNER,Wellington City Ward 3 Precinct 1 H116,United States House of Representatives,4,Republican,"Pompeo, Mike",209,120100
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",2,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",3,120110
+SUMNER,Wellington City Ward 3 Precicnt 1 H80,United States House of Representatives,4,Republican,"Pompeo, Mike",17,120110
+SUMNER,Wellington Township H116,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",19,120120
+SUMNER,Wellington Township H116,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",2,120120
+SUMNER,Wellington Township H116,United States House of Representatives,4,Republican,"Pompeo, Mike",43,120120
+SUMNER,Wellington Township H80 A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,12013A
+SUMNER,Wellington Township H80 A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,12013A
+SUMNER,Wellington Township H80 A,United States House of Representatives,4,Republican,"Pompeo, Mike",0,12013A
+SUMNER,Wellington Township H80,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",17,120130
+SUMNER,Wellington Township H80,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,120130
+SUMNER,Wellington Township H80,United States House of Representatives,4,Republican,"Pompeo, Mike",21,120130
+SUMNER,Wellington Township Part B,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900010
+SUMNER,Wellington Township Part B,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900010
+SUMNER,Wellington Township Part B,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900010
+SUMNER,Wellington City Airport,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900020
+SUMNER,Wellington City Airport,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900020
+SUMNER,Wellington City Airport,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900020
+SUMNER,Wellington Lake Exclave,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900030
+SUMNER,Wellington Lake Exclave,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900030
+SUMNER,Wellington Lake Exclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900030
+SUMNER,Gore Township Enclave,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900040
+SUMNER,Gore Township Enclave,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900040
+SUMNER,Gore Township Enclave,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900040
+SUMNER,Mulvane City Exclave A,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900050
+SUMNER,Mulvane City Exclave A,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900050
+SUMNER,Mulvane City Exclave A,United States House of Representatives,4,Republican,"Pompeo, Mike",0,900050
+SUMNER,Mulvane City Exclave B,United States House of Representatives,4,Democratic,"Tillman, Robert Leon",0,900060
+SUMNER,Mulvane City Exclave B,United States House of Representatives,4,Libertarian,"Jefferson, Thomas",0,900060
+SUMNER,Mulvane City Exclave B,United States House of Representatives,4,Republican,"Pompeo, Mike",6,900060

--- a/2012/20121106__ks__general__thomas__precinct.csv
+++ b/2012/20121106__ks__general__thomas__precinct.csv
@@ -1,0 +1,545 @@
+county,precinct,office,district,party,candidate,votes,vtd
+THOMAS,East Morgan Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",122,00007A
+THOMAS,East Morgan Township Enclave Voting District,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",0,00007B
+THOMAS,Kingery Township,Kansas House of Representatives,118,Republican,"Hineman, Don",42,000080
+THOMAS,Lacey Township,Kansas House of Representatives,118,Republican,"Hineman, Don",55,000090
+THOMAS,Menlo Township,Kansas House of Representatives,118,Republican,"Hineman, Don",27,000100
+THOMAS,North Randall Township,Kansas House of Representatives,118,Republican,"Hineman, Don",43,000110
+THOMAS,Rovohl Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",80,000120
+THOMAS,Smith Township,Kansas House of Representatives,118,Republican,"Hineman, Don",78,000130
+THOMAS,South Randall Township,Kansas House of Representatives,118,Republican,"Hineman, Don",107,000140
+THOMAS,Summers Township,Kansas House of Representatives,118,Republican,"Hineman, Don",97,000150
+THOMAS,Wendell Township,Kansas House of Representatives,118,Republican,"Hineman, Don",36,000160
+THOMAS,West Hale Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",146,000170
+THOMAS,West Morgan Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",198,000180
+THOMAS,Colby Ward 4 Exclave,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",0,900010
+THOMAS,East Morgan Township Enclave 2,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",0,900020
+THOMAS,Barrett Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",12,000010
+THOMAS,Barrett Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",49,000010
+THOMAS,Colby Ward 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",129,000020
+THOMAS,Colby Ward 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",308,000020
+THOMAS,Colby Ward 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",141,00003A
+THOMAS,Colby Ward 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",363,00003A
+THOMAS,Colby Ward 2 Exclave,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,00003B
+THOMAS,Colby Ward 2 Exclave,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,00003B
+THOMAS,Colby Ward 3,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",196,00004A
+THOMAS,Colby Ward 3,Kansas Senate,40,Republican,"Ostmeyer, Ralph",473,00004A
+THOMAS,Colby Ward 3 Exclave,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,00004B
+THOMAS,Colby Ward 3 Exclave,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,00004B
+THOMAS,Colby Ward 4,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",169,000050
+THOMAS,Colby Ward 4,Kansas Senate,40,Republican,"Ostmeyer, Ralph",401,000050
+THOMAS,East Hale Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",13,000060
+THOMAS,East Hale Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",47,000060
+THOMAS,East Morgan Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",36,00007A
+THOMAS,East Morgan Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",98,00007A
+THOMAS,East Morgan Township Enclave Voting District,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,00007B
+THOMAS,Kingery Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",15,000080
+THOMAS,Kingery Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",33,000080
+THOMAS,Lacey Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",7,000090
+THOMAS,Lacey Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",57,000090
+THOMAS,Menlo Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",9,000100
+THOMAS,Menlo Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",21,000100
+THOMAS,North Randall Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",2,000110
+THOMAS,North Randall Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",42,000110
+THOMAS,Rovohl Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",15,000120
+THOMAS,Rovohl Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",71,000120
+THOMAS,Smith Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",10,000130
+THOMAS,Smith Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",77,000130
+THOMAS,South Randall Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",25,000140
+THOMAS,South Randall Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",99,000140
+THOMAS,Summers Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",15,000150
+THOMAS,Summers Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",93,000150
+THOMAS,Wendell Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",12,000160
+THOMAS,Wendell Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",28,000160
+THOMAS,West Hale Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",37,000170
+THOMAS,West Hale Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",121,000170
+THOMAS,West Morgan Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",56,000180
+THOMAS,West Morgan Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",159,000180
+THOMAS,Colby Ward 4 Exclave,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,900010
+THOMAS,Colby Ward 4 Exclave,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,900010
+THOMAS,East Morgan Township Enclave 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",0,900020
+THOMAS,East Morgan Township Enclave 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",0,900020
+THOMAS,Barrett Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+THOMAS,Barrett Township,President / Vice President,,Democratic,"Obama, Barack",5,000010
+THOMAS,Barrett Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+THOMAS,Barrett Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+THOMAS,Barrett Township,President / Vice President,,Republican,"Romney, Mitt",54,000010
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,Democratic,"Obama, Barack",98,000020
+THOMAS,Colby Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",17,000020
+THOMAS,Colby Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",4,000020
+THOMAS,Colby Ward 1,President / Vice President,,Republican,"Romney, Mitt",331,000020
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Christensen, Will",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,Democratic,"Obama, Barack",99,00003A
+THOMAS,Colby Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",8,00003A
+THOMAS,Colby Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",6,00003A
+THOMAS,Colby Ward 2,President / Vice President,,Republican,"Romney, Mitt",397,00003A
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00003B
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,Democratic,"Obama, Barack",134,00004A
+THOMAS,Colby Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",12,00004A
+THOMAS,Colby Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",4,00004A
+THOMAS,Colby Ward 3,President / Vice President,,Republican,"Romney, Mitt",521,00004A
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00004B
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,Democratic,"Obama, Barack",118,000050
+THOMAS,Colby Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",16,000050
+THOMAS,Colby Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",3,000050
+THOMAS,Colby Ward 4,President / Vice President,,Republican,"Romney, Mitt",438,000050
+THOMAS,East Hale Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+THOMAS,East Hale Township,President / Vice President,,Democratic,"Obama, Barack",4,000060
+THOMAS,East Hale Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+THOMAS,East Hale Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+THOMAS,East Hale Township,President / Vice President,,Republican,"Romney, Mitt",56,000060
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Ayers, Avery L",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Barnett, Andre",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Bush, Kent W",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Christensen, Will",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Duncan, Richard A",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Goode, Virgil",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Hoefling, Tom",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Knill, Dennis J",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Reed, Jill A.",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Rogers, Rick L",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Stein, Jill E",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,Democratic,"Obama, Barack",22,00007A
+THOMAS,East Morgan Township,President / Vice President,,Libertarian,"Johnson, Gary",2,00007A
+THOMAS,East Morgan Township,President / Vice President,,Reform,"Baldwin, Chuck",1,00007A
+THOMAS,East Morgan Township,President / Vice President,,Republican,"Romney, Mitt",114,00007A
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Ayers, Avery L",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Barnett, Andre",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Barr, Roseanne C",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Bush, Kent W",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Christensen, Will",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Duncan, Richard A",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Goode, Virgil",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Hoefling, Tom",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Knill, Dennis J",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Reed, Jill A.",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Rogers, Rick L",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Stein, Jill E",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Thorne, Kevin M",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Warner, Gerald L.",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,Democratic,"Obama, Barack",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,Libertarian,"Johnson, Gary",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,Reform,"Baldwin, Chuck",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,Republican,"Romney, Mitt",0,00007B
+THOMAS,Kingery Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+THOMAS,Kingery Township,President / Vice President,,Democratic,"Obama, Barack",4,000080
+THOMAS,Kingery Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+THOMAS,Kingery Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+THOMAS,Kingery Township,President / Vice President,,Republican,"Romney, Mitt",43,000080
+THOMAS,Lacey Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+THOMAS,Lacey Township,President / Vice President,,Democratic,"Obama, Barack",10,000090
+THOMAS,Lacey Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+THOMAS,Lacey Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+THOMAS,Lacey Township,President / Vice President,,Republican,"Romney, Mitt",55,000090
+THOMAS,Menlo Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+THOMAS,Menlo Township,President / Vice President,,Democratic,"Obama, Barack",4,000100
+THOMAS,Menlo Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+THOMAS,Menlo Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+THOMAS,Menlo Township,President / Vice President,,Republican,"Romney, Mitt",25,000100
+THOMAS,North Randall Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+THOMAS,North Randall Township,President / Vice President,,Democratic,"Obama, Barack",2,000110
+THOMAS,North Randall Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000110
+THOMAS,North Randall Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000110
+THOMAS,North Randall Township,President / Vice President,,Republican,"Romney, Mitt",40,000110
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+THOMAS,Rovohl Township,President / Vice President,,Democratic,"Obama, Barack",6,000120
+THOMAS,Rovohl Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000120
+THOMAS,Rovohl Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+THOMAS,Rovohl Township,President / Vice President,,Republican,"Romney, Mitt",80,000120
+THOMAS,Smith Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+THOMAS,Smith Township,President / Vice President,,Democratic,"Obama, Barack",10,000130
+THOMAS,Smith Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+THOMAS,Smith Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+THOMAS,Smith Township,President / Vice President,,Republican,"Romney, Mitt",77,000130
+THOMAS,South Randall Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+THOMAS,South Randall Township,President / Vice President,,Democratic,"Obama, Barack",21,000140
+THOMAS,South Randall Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+THOMAS,South Randall Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+THOMAS,South Randall Township,President / Vice President,,Republican,"Romney, Mitt",102,000140
+THOMAS,Summers Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+THOMAS,Summers Township,President / Vice President,,Democratic,"Obama, Barack",7,000150
+THOMAS,Summers Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000150
+THOMAS,Summers Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+THOMAS,Summers Township,President / Vice President,,Republican,"Romney, Mitt",99,000150
+THOMAS,Wendell Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+THOMAS,Wendell Township,President / Vice President,,Democratic,"Obama, Barack",7,000160
+THOMAS,Wendell Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+THOMAS,Wendell Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+THOMAS,Wendell Township,President / Vice President,,Republican,"Romney, Mitt",33,000160
+THOMAS,West Hale Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+THOMAS,West Hale Township,President / Vice President,,Democratic,"Obama, Barack",24,000170
+THOMAS,West Hale Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000170
+THOMAS,West Hale Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+THOMAS,West Hale Township,President / Vice President,,Republican,"Romney, Mitt",129,000170
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+THOMAS,West Morgan Township,President / Vice President,,Democratic,"Obama, Barack",23,000180
+THOMAS,West Morgan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+THOMAS,West Morgan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+THOMAS,West Morgan Township,President / Vice President,,Republican,"Romney, Mitt",194,000180
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900010
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Christensen, Will",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900020
+THOMAS,Barrett Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,000010
+THOMAS,Colby Ward 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",389,000020
+THOMAS,Colby Ward 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",437,00003A
+THOMAS,Colby Ward 2 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00003B
+THOMAS,Colby Ward 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",612,00004A
+THOMAS,Colby Ward 3 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00004B
+THOMAS,Colby Ward 4,United States House of Representatives,1,Republican,"Huelskamp, Tim",520,000050
+THOMAS,East Hale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",57,000060
+THOMAS,East Morgan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",130,00007A
+THOMAS,East Morgan Township Enclave Voting District,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00007B
+THOMAS,Kingery Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000080
+THOMAS,Lacey Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",60,000090
+THOMAS,Menlo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",26,000100
+THOMAS,North Randall Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000110
+THOMAS,Rovohl Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",81,000120
+THOMAS,Smith Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",82,000130
+THOMAS,South Randall Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",103,000140
+THOMAS,Summers Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",100,000150
+THOMAS,Wendell Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",37,000160
+THOMAS,West Hale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",142,000170
+THOMAS,West Morgan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",190,000180
+THOMAS,Colby Ward 4 Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010
+THOMAS,East Morgan Township Enclave 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900020

--- a/2012/20121106__ks__general__trego__precinct.csv
+++ b/2012/20121106__ks__general__trego__precinct.csv
@@ -1,0 +1,266 @@
+county,precinct,office,district,party,candidate,votes,vtd
+TREGO,Collyer City,Kansas House of Representatives,118,Republican,"Hineman, Don",46,000010
+TREGO,Collyer Township,Kansas House of Representatives,118,Republican,"Hineman, Don",90,000020
+TREGO,Franklin Township,Kansas House of Representatives,118,Republican,"Hineman, Don",18,000030
+TREGO,Glencoe Township,Kansas House of Representatives,118,Republican,"Hineman, Don",40,000040
+TREGO,Ogallah Township,Kansas House of Representatives,118,Republican,"Hineman, Don",78,000050
+TREGO,Riverside Township,Kansas House of Representatives,118,Republican,"Hineman, Don",37,000060
+TREGO,WaKeeney City Central Precinct,Kansas House of Representatives,118,Republican,"Hineman, Don",281,000070
+TREGO,WaKeeney City East Precinct,Kansas House of Representatives,118,Republican,"Hineman, Don",239,000080
+TREGO,WaKeeney City West Precinct,Kansas House of Representatives,118,Republican,"Hineman, Don",270,000090
+TREGO,WaKeeney Township,Kansas House of Representatives,118,Republican,"Hineman, Don",201,000100
+TREGO,Wilcox Township,Kansas House of Representatives,118,Republican,"Hineman, Don",33,000110
+TREGO,Collyer City,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",10,000010
+TREGO,Collyer City,Kansas Senate,40,Republican,"Ostmeyer, Ralph",41,000010
+TREGO,Collyer Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",30,000020
+TREGO,Collyer Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",74,000020
+TREGO,Franklin Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",6,000030
+TREGO,Franklin Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",16,000030
+TREGO,Glencoe Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",8,000040
+TREGO,Glencoe Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",31,000040
+TREGO,Ogallah Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",36,000050
+TREGO,Ogallah Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",62,000050
+TREGO,Riverside Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",16,000060
+TREGO,Riverside Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",24,000060
+TREGO,WaKeeney City Central Precinct,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",91,000070
+TREGO,WaKeeney City Central Precinct,Kansas Senate,40,Republican,"Ostmeyer, Ralph",230,000070
+TREGO,WaKeeney City East Precinct,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",90,000080
+TREGO,WaKeeney City East Precinct,Kansas Senate,40,Republican,"Ostmeyer, Ralph",198,000080
+TREGO,WaKeeney City West Precinct,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",127,000090
+TREGO,WaKeeney City West Precinct,Kansas Senate,40,Republican,"Ostmeyer, Ralph",202,000090
+TREGO,WaKeeney Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",61,000100
+TREGO,WaKeeney Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",162,000100
+TREGO,Wilcox Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",14,000110
+TREGO,Wilcox Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",25,000110
+TREGO,Collyer City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Barnett, Andre",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Bush, Kent W",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Christensen, Will",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Goode, Virgil",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Stein, Jill E",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+TREGO,Collyer City,President / Vice President,,Democratic,"Obama, Barack",4,000010
+TREGO,Collyer City,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+TREGO,Collyer City,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+TREGO,Collyer City,President / Vice President,,Republican,"Romney, Mitt",47,000010
+TREGO,Collyer Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+TREGO,Collyer Township,President / Vice President,,Democratic,"Obama, Barack",15,000020
+TREGO,Collyer Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+TREGO,Collyer Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+TREGO,Collyer Township,President / Vice President,,Republican,"Romney, Mitt",85,000020
+TREGO,Franklin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+TREGO,Franklin Township,President / Vice President,,Democratic,"Obama, Barack",6,000030
+TREGO,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+TREGO,Franklin Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+TREGO,Franklin Township,President / Vice President,,Republican,"Romney, Mitt",16,000030
+TREGO,Glencoe Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+TREGO,Glencoe Township,President / Vice President,,Democratic,"Obama, Barack",1,000040
+TREGO,Glencoe Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+TREGO,Glencoe Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+TREGO,Glencoe Township,President / Vice President,,Republican,"Romney, Mitt",39,000040
+TREGO,Ogallah Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+TREGO,Ogallah Township,President / Vice President,,Democratic,"Obama, Barack",34,000050
+TREGO,Ogallah Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+TREGO,Ogallah Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000050
+TREGO,Ogallah Township,President / Vice President,,Republican,"Romney, Mitt",64,000050
+TREGO,Riverside Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+TREGO,Riverside Township,President / Vice President,,Democratic,"Obama, Barack",12,000060
+TREGO,Riverside Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000060
+TREGO,Riverside Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+TREGO,Riverside Township,President / Vice President,,Republican,"Romney, Mitt",26,000060
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Barnett, Andre",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Bush, Kent W",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Christensen, Will",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Goode, Virgil",1,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Stein, Jill E",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,Democratic,"Obama, Barack",58,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,Republican,"Romney, Mitt",265,000070
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Barnett, Andre",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Bush, Kent W",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Christensen, Will",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Goode, Virgil",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Stein, Jill E",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,Democratic,"Obama, Barack",54,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,Republican,"Romney, Mitt",236,000080
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Barnett, Andre",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Bush, Kent W",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Christensen, Will",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Goode, Virgil",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Stein, Jill E",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,Democratic,"Obama, Barack",63,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,Libertarian,"Johnson, Gary",7,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,Reform,"Baldwin, Chuck",4,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,Republican,"Romney, Mitt",260,000090
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+TREGO,WaKeeney Township,President / Vice President,,Democratic,"Obama, Barack",37,000100
+TREGO,WaKeeney Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+TREGO,WaKeeney Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000100
+TREGO,WaKeeney Township,President / Vice President,,Republican,"Romney, Mitt",190,000100
+TREGO,Wilcox Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+TREGO,Wilcox Township,President / Vice President,,Democratic,"Obama, Barack",7,000110
+TREGO,Wilcox Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+TREGO,Wilcox Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000110
+TREGO,Wilcox Township,President / Vice President,,Republican,"Romney, Mitt",33,000110
+TREGO,ADVANCED,President / Vice President,,write - in,"Goode, Virgil",0,999998
+TREGO,Collyer City,United States House of Representatives,1,Republican,"Huelskamp, Tim",43,000010
+TREGO,Collyer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",86,000020
+TREGO,Franklin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000030
+TREGO,Glencoe Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",39,000040
+TREGO,Ogallah Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",76,000050
+TREGO,Riverside Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",33,000060
+TREGO,WaKeeney City Central Precinct,United States House of Representatives,1,Republican,"Huelskamp, Tim",273,000070
+TREGO,WaKeeney City East Precinct,United States House of Representatives,1,Republican,"Huelskamp, Tim",236,000080
+TREGO,WaKeeney City West Precinct,United States House of Representatives,1,Republican,"Huelskamp, Tim",259,000090
+TREGO,WaKeeney Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",187,000100
+TREGO,Wilcox Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",34,000110

--- a/2012/20121106__ks__general__wabaunsee__precinct.csv
+++ b/2012/20121106__ks__general__wabaunsee__precinct.csv
@@ -1,0 +1,380 @@
+county,precinct,office,district,party,candidate,votes,vtd
+WABAUNSEE,Alma Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",173,000010
+WABAUNSEE,Alma Township,Kansas House of Representatives,51,Republican,"Highland, Ron",393,000010
+WABAUNSEE,Chalk Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",4,000020
+WABAUNSEE,Chalk Township,Kansas House of Representatives,51,Republican,"Highland, Ron",14,000020
+WABAUNSEE,Farmer Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",19,000030
+WABAUNSEE,Farmer Township,Kansas House of Representatives,51,Republican,"Highland, Ron",49,000030
+WABAUNSEE,Garfield Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",67,000040
+WABAUNSEE,Garfield Township,Kansas House of Representatives,51,Republican,"Highland, Ron",185,000040
+WABAUNSEE,Harveyville Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",97,000050
+WABAUNSEE,Harveyville Township,Kansas House of Representatives,51,Republican,"Highland, Ron",178,000050
+WABAUNSEE,Hessdale Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",45,000060
+WABAUNSEE,Hessdale Township,Kansas House of Representatives,51,Republican,"Highland, Ron",71,000060
+WABAUNSEE,Kaw Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",15,000070
+WABAUNSEE,Kaw Township,Kansas House of Representatives,51,Republican,"Highland, Ron",99,000070
+WABAUNSEE,Keene Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",78,000080
+WABAUNSEE,Keene Township,Kansas House of Representatives,51,Republican,"Highland, Ron",155,000080
+WABAUNSEE,Maple Hill Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",122,000090
+WABAUNSEE,Maple Hill Township,Kansas House of Representatives,51,Republican,"Highland, Ron",336,000090
+WABAUNSEE,McFarland Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",39,000100
+WABAUNSEE,McFarland Township,Kansas House of Representatives,51,Republican,"Highland, Ron",89,000100
+WABAUNSEE,Paxico Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",82,000110
+WABAUNSEE,Paxico Township,Kansas House of Representatives,51,Republican,"Highland, Ron",300,000110
+WABAUNSEE,Washington Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",10,000130
+WABAUNSEE,Washington Township,Kansas House of Representatives,51,Republican,"Highland, Ron",36,000130
+WABAUNSEE,Wilmington Township,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",79,000140
+WABAUNSEE,Wilmington Township,Kansas House of Representatives,51,Republican,"Highland, Ron",163,000140
+WABAUNSEE,Wabaunsee Township S17,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",83,120020
+WABAUNSEE,Wabaunsee Township S17,Kansas House of Representatives,51,Republican,"Highland, Ron",167,120020
+WABAUNSEE,Wabaunsee Township S18,Kansas House of Representatives,51,Democratic,"Pikul, Richard R",0,120030
+WABAUNSEE,Wabaunsee Township S18,Kansas House of Representatives,51,Republican,"Highland, Ron",0,120030
+WABAUNSEE,Alma Township,Kansas Senate,17,Democratic,"Moran, Susan K.",164,000010
+WABAUNSEE,Alma Township,Kansas Senate,17,Republican,"Longbine, Jeff",394,000010
+WABAUNSEE,Chalk Township,Kansas Senate,17,Democratic,"Moran, Susan K.",5,000020
+WABAUNSEE,Chalk Township,Kansas Senate,17,Republican,"Longbine, Jeff",15,000020
+WABAUNSEE,Farmer Township,Kansas Senate,17,Democratic,"Moran, Susan K.",17,000030
+WABAUNSEE,Farmer Township,Kansas Senate,17,Republican,"Longbine, Jeff",53,000030
+WABAUNSEE,Garfield Township,Kansas Senate,17,Democratic,"Moran, Susan K.",78,000040
+WABAUNSEE,Garfield Township,Kansas Senate,17,Republican,"Longbine, Jeff",178,000040
+WABAUNSEE,Harveyville Township,Kansas Senate,20,Democratic,"Crowder, Terry L.",61,000050
+WABAUNSEE,Harveyville Township,Kansas Senate,20,Libertarian,"Hinchey, Clarence",45,000050
+WABAUNSEE,Harveyville Township,Kansas Senate,20,Republican,"Schmidt, Vicki L.",175,000050
+WABAUNSEE,Hessdale Township,Kansas Senate,20,Democratic,"Crowder, Terry L.",11,000060
+WABAUNSEE,Hessdale Township,Kansas Senate,20,Libertarian,"Hinchey, Clarence",31,000060
+WABAUNSEE,Hessdale Township,Kansas Senate,20,Republican,"Schmidt, Vicki L.",76,000060
+WABAUNSEE,Kaw Township,Kansas Senate,18,Democratic,"Kelly, Laura",31,000070
+WABAUNSEE,Kaw Township,Kansas Senate,18,Republican,"Barta, Dick",83,000070
+WABAUNSEE,Keene Township,Kansas Senate,20,Democratic,"Crowder, Terry L.",57,000080
+WABAUNSEE,Keene Township,Kansas Senate,20,Libertarian,"Hinchey, Clarence",46,000080
+WABAUNSEE,Keene Township,Kansas Senate,20,Republican,"Schmidt, Vicki L.",135,000080
+WABAUNSEE,Maple Hill Township,Kansas Senate,18,Democratic,"Kelly, Laura",204,000090
+WABAUNSEE,Maple Hill Township,Kansas Senate,18,Republican,"Barta, Dick",283,000090
+WABAUNSEE,McFarland Township,Kansas Senate,18,Democratic,"Kelly, Laura",74,000100
+WABAUNSEE,McFarland Township,Kansas Senate,18,Republican,"Barta, Dick",61,000100
+WABAUNSEE,Paxico Township,Kansas Senate,18,Democratic,"Kelly, Laura",125,000110
+WABAUNSEE,Paxico Township,Kansas Senate,18,Republican,"Barta, Dick",263,000110
+WABAUNSEE,Washington Township,Kansas Senate,17,Democratic,"Moran, Susan K.",6,000130
+WABAUNSEE,Washington Township,Kansas Senate,17,Republican,"Longbine, Jeff",41,000130
+WABAUNSEE,Wilmington Township,Kansas Senate,20,Democratic,"Crowder, Terry L.",49,000140
+WABAUNSEE,Wilmington Township,Kansas Senate,20,Libertarian,"Hinchey, Clarence",64,000140
+WABAUNSEE,Wilmington Township,Kansas Senate,20,Republican,"Schmidt, Vicki L.",131,000140
+WABAUNSEE,Wabaunsee Township S17,Kansas Senate,17,Democratic,"Moran, Susan K.",75,120020
+WABAUNSEE,Wabaunsee Township S17,Kansas Senate,17,Republican,"Longbine, Jeff",152,120020
+WABAUNSEE,Wabaunsee Township S18,Kansas Senate,18,Democratic,"Kelly, Laura",10,120030
+WABAUNSEE,Wabaunsee Township S18,Kansas Senate,18,Republican,"Barta, Dick",9,120030
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,Democratic,"Obama, Barack",177,000010
+WABAUNSEE,Alma Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000010
+WABAUNSEE,Alma Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000010
+WABAUNSEE,Alma Township,President / Vice President,,Republican,"Romney, Mitt",388,000010
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,Democratic,"Obama, Barack",3,000020
+WABAUNSEE,Chalk Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,Republican,"Romney, Mitt",19,000020
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,Democratic,"Obama, Barack",17,000030
+WABAUNSEE,Farmer Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,Republican,"Romney, Mitt",53,000030
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,Democratic,"Obama, Barack",72,000040
+WABAUNSEE,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000040
+WABAUNSEE,Garfield Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+WABAUNSEE,Garfield Township,President / Vice President,,Republican,"Romney, Mitt",184,000040
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,Democratic,"Obama, Barack",95,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,Republican,"Romney, Mitt",181,000050
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,Democratic,"Obama, Barack",36,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,Republican,"Romney, Mitt",81,000060
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,Democratic,"Obama, Barack",17,000070
+WABAUNSEE,Kaw Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+WABAUNSEE,Kaw Township,President / Vice President,,Reform,"Baldwin, Chuck",9,000070
+WABAUNSEE,Kaw Township,President / Vice President,,Republican,"Romney, Mitt",89,000070
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,Democratic,"Obama, Barack",78,000080
+WABAUNSEE,Keene Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000080
+WABAUNSEE,Keene Township,President / Vice President,,Reform,"Baldwin, Chuck",4,000080
+WABAUNSEE,Keene Township,President / Vice President,,Republican,"Romney, Mitt",161,000080
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,Democratic,"Obama, Barack",135,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,Republican,"Romney, Mitt",338,000090
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,Democratic,"Obama, Barack",38,000100
+WABAUNSEE,McFarland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+WABAUNSEE,McFarland Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000100
+WABAUNSEE,McFarland Township,President / Vice President,,Republican,"Romney, Mitt",93,000100
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,Democratic,"Obama, Barack",79,000110
+WABAUNSEE,Paxico Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000110
+WABAUNSEE,Paxico Township,President / Vice President,,Reform,"Baldwin, Chuck",6,000110
+WABAUNSEE,Paxico Township,President / Vice President,,Republican,"Romney, Mitt",299,000110
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,Democratic,"Obama, Barack",10,000130
+WABAUNSEE,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,Republican,"Romney, Mitt",41,000130
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,Democratic,"Obama, Barack",84,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,Republican,"Romney, Mitt",161,000140
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Barnett, Andre",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Bush, Kent W",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Christensen, Will",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Goode, Virgil",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Stein, Jill E",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,Democratic,"Obama, Barack",77,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,Libertarian,"Johnson, Gary",3,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,Reform,"Baldwin, Chuck",4,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,Republican,"Romney, Mitt",168,120020
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Barnett, Andre",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Bush, Kent W",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Christensen, Will",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Goode, Virgil",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Stein, Jill E",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,Democratic,"Obama, Barack",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,Republican,"Romney, Mitt",0,120030
+WABAUNSEE,Alma Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",479,000010
+WABAUNSEE,Chalk Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,000020
+WABAUNSEE,Farmer Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",55,000030
+WABAUNSEE,Garfield Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",219,000040
+WABAUNSEE,Harveyville Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",236,000050
+WABAUNSEE,Hessdale Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",94,000060
+WABAUNSEE,Kaw Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",103,000070
+WABAUNSEE,Keene Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",200,000080
+WABAUNSEE,Maple Hill Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",388,000090
+WABAUNSEE,McFarland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",113,000100
+WABAUNSEE,Paxico Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",337,000110
+WABAUNSEE,Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",38,000130
+WABAUNSEE,Wilmington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",208,000140
+WABAUNSEE,Wabaunsee Township S17,United States House of Representatives,1,Republican,"Huelskamp, Tim",202,120020
+WABAUNSEE,Wabaunsee Township S18,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,120030

--- a/2012/20121106__ks__general__wallace__precinct.csv
+++ b/2012/20121106__ks__general__wallace__precinct.csv
@@ -1,0 +1,169 @@
+county,precinct,office,district,party,candidate,votes,vtd
+WALLACE,Harrison Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",25,000010
+WALLACE,Sharon Springs Precinct 1,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",86,000020
+WALLACE,Sharon Springs Precinct 2,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",212,000030
+WALLACE,Wallace Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",48,000040
+WALLACE,Weskan Township,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",103,000050
+WALLACE,ADVANCED,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",15,999998
+WALLACE,PROVISIONAL,Kansas House of Representatives,120,Republican,"Cassidy, Ward M.",202,999999
+WALLACE,Harrison Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",6,000010
+WALLACE,Harrison Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",18,000010
+WALLACE,Sharon Springs Precinct 1,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",26,000020
+WALLACE,Sharon Springs Precinct 1,Kansas Senate,40,Republican,"Ostmeyer, Ralph",75,000020
+WALLACE,Sharon Springs Precinct 2,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",59,000030
+WALLACE,Sharon Springs Precinct 2,Kansas Senate,40,Republican,"Ostmeyer, Ralph",178,000030
+WALLACE,Wallace Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",16,000040
+WALLACE,Wallace Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",45,000040
+WALLACE,Weskan Township,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",39,000050
+WALLACE,Weskan Township,Kansas Senate,40,Republican,"Ostmeyer, Ralph",75,000050
+WALLACE,ADVANCED,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",13,999998
+WALLACE,ADVANCED,Kansas Senate,40,Republican,"Ostmeyer, Ralph",3,999998
+WALLACE,PROVISIONAL,Kansas Senate,40,Democratic,"Schmidt, Allen Clark",60,999999
+WALLACE,PROVISIONAL,Kansas Senate,40,Republican,"Ostmeyer, Ralph",165,999999
+WALLACE,Harrison Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+WALLACE,Harrison Township,President / Vice President,,Democratic,"Obama, Barack",0,000010
+WALLACE,Harrison Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+WALLACE,Harrison Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+WALLACE,Harrison Township,President / Vice President,,Republican,"Romney, Mitt",24,000010
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,Democratic,"Obama, Barack",7,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,Republican,"Romney, Mitt",97,000020
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,Democratic,"Obama, Barack",24,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,Republican,"Romney, Mitt",211,000030
+WALLACE,Wallace Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+WALLACE,Wallace Township,President / Vice President,,Democratic,"Obama, Barack",2,000040
+WALLACE,Wallace Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+WALLACE,Wallace Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+WALLACE,Wallace Township,President / Vice President,,Republican,"Romney, Mitt",59,000040
+WALLACE,Weskan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+WALLACE,Weskan Township,President / Vice President,,Democratic,"Obama, Barack",7,000050
+WALLACE,Weskan Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+WALLACE,Weskan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+WALLACE,Weskan Township,President / Vice President,,Republican,"Romney, Mitt",108,000050
+WALLACE,ADVANCED,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Ayers, Avery L",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Barnett, Andre",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Barr, Roseanne C",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Bush, Kent W",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Christensen, Will",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Duncan, Richard A",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Goode, Virgil",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Hoefling, Tom",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Knill, Dennis J",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Reed, Jill A.",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Rogers, Rick L",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Stein, Jill E",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Thorne, Kevin M",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,999998
+WALLACE,ADVANCED,President / Vice President,,write - in,"Warner, Gerald L.",0,999998
+WALLACE,ADVANCED,President / Vice President,,Democratic,"Obama, Barack",0,999998
+WALLACE,ADVANCED,President / Vice President,,Libertarian,"Johnson, Gary",0,999998
+WALLACE,ADVANCED,President / Vice President,,Reform,"Baldwin, Chuck",0,999998
+WALLACE,ADVANCED,President / Vice President,,Republican,"Romney, Mitt",17,999998
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Ayers, Avery L",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Barnett, Andre",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Barr, Roseanne C",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Bush, Kent W",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Christensen, Will",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Duncan, Richard A",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Goode, Virgil",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Hoefling, Tom",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Knill, Dennis J",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Reed, Jill A.",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Rogers, Rick L",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Stein, Jill E",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Thorne, Kevin M",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,write - in,"Warner, Gerald L.",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,Democratic,"Obama, Barack",28,999999
+WALLACE,PROVISIONAL,President / Vice President,,Libertarian,"Johnson, Gary",3,999999
+WALLACE,PROVISIONAL,President / Vice President,,Reform,"Baldwin, Chuck",0,999999
+WALLACE,PROVISIONAL,President / Vice President,,Republican,"Romney, Mitt",203,999999
+WALLACE,Harrison Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",25,000010
+WALLACE,Sharon Springs Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",94,000020
+WALLACE,Sharon Springs Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",222,000030
+WALLACE,Wallace Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",57,000040
+WALLACE,Weskan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",106,000050
+WALLACE,ADVANCED,United States House of Representatives,1,Republican,"Huelskamp, Tim",15,999998
+WALLACE,PROVISIONAL,United States House of Representatives,1,Republican,"Huelskamp, Tim",206,999999

--- a/2012/20121106__ks__general__washington__precinct.csv
+++ b/2012/20121106__ks__general__washington__precinct.csv
@@ -1,0 +1,726 @@
+county,precinct,office,district,party,candidate,votes,vtd
+WASHINGTON,Barnes Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",23,000010
+WASHINGTON,Barnes Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",53,000010
+WASHINGTON,Brantford Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",18,000020
+WASHINGTON,Brantford Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",25,000020
+WASHINGTON,Charleston Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",4,000030
+WASHINGTON,Charleston Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",37,000030
+WASHINGTON,Clifton Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",58,000040
+WASHINGTON,Clifton Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",133,000040
+WASHINGTON,Coleman Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",6,000050
+WASHINGTON,Coleman Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",28,000050
+WASHINGTON,Farmington Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",21,000060
+WASHINGTON,Farmington Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",82,000060
+WASHINGTON,Franklin Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",13,000070
+WASHINGTON,Franklin Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",45,000070
+WASHINGTON,Grant Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",5,000080
+WASHINGTON,Grant Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",11,000080
+WASHINGTON,Greenleaf Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",52,000090
+WASHINGTON,Greenleaf Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",118,000090
+WASHINGTON,Haddam Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",29,000100
+WASHINGTON,Haddam Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",57,000100
+WASHINGTON,Hanover Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",100,000110
+WASHINGTON,Hanover Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",334,000110
+WASHINGTON,Highland Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",8,000120
+WASHINGTON,Highland Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",7,000120
+WASHINGTON,Independence Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",8,000130
+WASHINGTON,Independence Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",56,000130
+WASHINGTON,Kimeo Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",5,000140
+WASHINGTON,Kimeo Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",32,000140
+WASHINGTON,Lincoln Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",4,000150
+WASHINGTON,Lincoln Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",20,000150
+WASHINGTON,Linn Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",49,000160
+WASHINGTON,Linn Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",184,000160
+WASHINGTON,Little Blue Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",20,000170
+WASHINGTON,Little Blue Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",24,000170
+WASHINGTON,Logan Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",22,000180
+WASHINGTON,Logan Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",39,000180
+WASHINGTON,Lowe Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",5,000190
+WASHINGTON,Lowe Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",26,000190
+WASHINGTON,Mill Creek Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",27,000200
+WASHINGTON,Mill Creek Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",81,000200
+WASHINGTON,Sheridan Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",10,000210
+WASHINGTON,Sheridan Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",37,000210
+WASHINGTON,Sherman Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",21,000220
+WASHINGTON,Sherman Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",119,000220
+WASHINGTON,Strawberry Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",20,000230
+WASHINGTON,Strawberry Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",34,000230
+WASHINGTON,Union Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",15,000240
+WASHINGTON,Union Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",24,000240
+WASHINGTON,Washington Township,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",25,00025A
+WASHINGTON,Washington Township,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",90,00025A
+WASHINGTON,Washington Township Rural Enclave,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",0,00025B
+WASHINGTON,Washington Township Rural Enclave,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",0,00025B
+WASHINGTON,Washington City,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",175,00026A
+WASHINGTON,Washington City,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",388,00026A
+WASHINGTON,Washington City Exclave,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",0,00026B
+WASHINGTON,Washington City Exclave,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,Kansas House of Representatives,106,Democratic,"Levendofsky, Nick",0,900010
+WASHINGTON,Washington Township Rural Enclave B,Kansas House of Representatives,106,Republican,"Schwartz, Sharon",0,900010
+WASHINGTON,Barnes Township,Kansas Senate,36,Democratic,"Clark, Marquis",17,000010
+WASHINGTON,Barnes Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",57,000010
+WASHINGTON,Brantford Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000020
+WASHINGTON,Brantford Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",42,000020
+WASHINGTON,Charleston Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000030
+WASHINGTON,Charleston Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",32,000030
+WASHINGTON,Clifton Township,Kansas Senate,36,Democratic,"Clark, Marquis",40,000040
+WASHINGTON,Clifton Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",147,000040
+WASHINGTON,Coleman Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000050
+WASHINGTON,Coleman Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",34,000050
+WASHINGTON,Farmington Township,Kansas Senate,36,Democratic,"Clark, Marquis",15,000060
+WASHINGTON,Farmington Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",77,000060
+WASHINGTON,Franklin Township,Kansas Senate,36,Democratic,"Clark, Marquis",8,000070
+WASHINGTON,Franklin Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",44,000070
+WASHINGTON,Grant Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000080
+WASHINGTON,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000080
+WASHINGTON,Greenleaf Township,Kansas Senate,36,Democratic,"Clark, Marquis",33,000090
+WASHINGTON,Greenleaf Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",134,000090
+WASHINGTON,Haddam Township,Kansas Senate,36,Democratic,"Clark, Marquis",19,000100
+WASHINGTON,Haddam Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",62,000100
+WASHINGTON,Hanover Township,Kansas Senate,36,Democratic,"Clark, Marquis",70,000110
+WASHINGTON,Hanover Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",336,000110
+WASHINGTON,Highland Township,Kansas Senate,36,Democratic,"Clark, Marquis",1,000120
+WASHINGTON,Highland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000120
+WASHINGTON,Independence Township,Kansas Senate,36,Democratic,"Clark, Marquis",7,000130
+WASHINGTON,Independence Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",53,000130
+WASHINGTON,Kimeo Township,Kansas Senate,36,Democratic,"Clark, Marquis",5,000140
+WASHINGTON,Kimeo Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",31,000140
+WASHINGTON,Lincoln Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000150
+WASHINGTON,Lincoln Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",25,000150
+WASHINGTON,Linn Township,Kansas Senate,36,Democratic,"Clark, Marquis",19,000160
+WASHINGTON,Linn Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",205,000160
+WASHINGTON,Little Blue Township,Kansas Senate,36,Democratic,"Clark, Marquis",14,000170
+WASHINGTON,Little Blue Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",26,000170
+WASHINGTON,Logan Township,Kansas Senate,36,Democratic,"Clark, Marquis",6,000180
+WASHINGTON,Logan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",52,000180
+WASHINGTON,Lowe Township,Kansas Senate,36,Democratic,"Clark, Marquis",0,000190
+WASHINGTON,Lowe Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",30,000190
+WASHINGTON,Mill Creek Township,Kansas Senate,36,Democratic,"Clark, Marquis",11,000200
+WASHINGTON,Mill Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",93,000200
+WASHINGTON,Sheridan Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000210
+WASHINGTON,Sheridan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",43,000210
+WASHINGTON,Sherman Township,Kansas Senate,36,Democratic,"Clark, Marquis",15,000220
+WASHINGTON,Sherman Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",123,000220
+WASHINGTON,Strawberry Township,Kansas Senate,36,Democratic,"Clark, Marquis",4,000230
+WASHINGTON,Strawberry Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",50,000230
+WASHINGTON,Union Township,Kansas Senate,36,Democratic,"Clark, Marquis",10,000240
+WASHINGTON,Union Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",28,000240
+WASHINGTON,Washington Township,Kansas Senate,36,Democratic,"Clark, Marquis",13,00025A
+WASHINGTON,Washington Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",101,00025A
+WASHINGTON,Washington Township Rural Enclave,Kansas Senate,36,Democratic,"Clark, Marquis",0,00025B
+WASHINGTON,Washington Township Rural Enclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00025B
+WASHINGTON,Washington City,Kansas Senate,36,Democratic,"Clark, Marquis",105,00026A
+WASHINGTON,Washington City,Kansas Senate,36,Republican,"Bowers, Elaine S.",436,00026A
+WASHINGTON,Washington City Exclave,Kansas Senate,36,Democratic,"Clark, Marquis",0,00026B
+WASHINGTON,Washington City Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,Kansas Senate,36,Democratic,"Clark, Marquis",0,900010
+WASHINGTON,Washington Township Rural Enclave B,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,900010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,Democratic,"Obama, Barack",16,000010
+WASHINGTON,Barnes Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+WASHINGTON,Barnes Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,Republican,"Romney, Mitt",62,000010
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,Democratic,"Obama, Barack",6,000020
+WASHINGTON,Brantford Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+WASHINGTON,Brantford Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,Republican,"Romney, Mitt",37,000020
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,Democratic,"Obama, Barack",5,000030
+WASHINGTON,Charleston Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,Republican,"Romney, Mitt",36,000030
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,Democratic,"Obama, Barack",50,000040
+WASHINGTON,Clifton Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+WASHINGTON,Clifton Township,President / Vice President,,Republican,"Romney, Mitt",143,000040
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,Democratic,"Obama, Barack",2,000050
+WASHINGTON,Coleman Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,Republican,"Romney, Mitt",34,000050
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,Democratic,"Obama, Barack",20,000060
+WASHINGTON,Farmington Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+WASHINGTON,Farmington Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+WASHINGTON,Farmington Township,President / Vice President,,Republican,"Romney, Mitt",79,000060
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,Democratic,"Obama, Barack",13,000070
+WASHINGTON,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+WASHINGTON,Franklin Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,Republican,"Romney, Mitt",45,000070
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Barnett, Andre",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Bush, Kent W",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Christensen, Will",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Goode, Virgil",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Stein, Jill E",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+WASHINGTON,Grant Township,President / Vice President,,Democratic,"Obama, Barack",2,000080
+WASHINGTON,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+WASHINGTON,Grant Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000080
+WASHINGTON,Grant Township,President / Vice President,,Republican,"Romney, Mitt",15,000080
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Barnett, Andre",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Bush, Kent W",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Christensen, Will",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Goode, Virgil",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Stein, Jill E",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,Democratic,"Obama, Barack",39,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,Republican,"Romney, Mitt",131,000090
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Ayers, Avery L",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Barnett, Andre",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Bush, Kent W",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Christensen, Will",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Duncan, Richard A",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Goode, Virgil",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Knill, Dennis J",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Reed, Jill A.",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Rogers, Rick L",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Stein, Jill E",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,Democratic,"Obama, Barack",17,000100
+WASHINGTON,Haddam Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000100
+WASHINGTON,Haddam Township,President / Vice President,,Republican,"Romney, Mitt",67,000100
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Barnett, Andre",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Bush, Kent W",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Christensen, Will",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Goode, Virgil",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Stein, Jill E",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,Democratic,"Obama, Barack",75,000110
+WASHINGTON,Hanover Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000110
+WASHINGTON,Hanover Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000110
+WASHINGTON,Hanover Township,President / Vice President,,Republican,"Romney, Mitt",350,000110
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+WASHINGTON,Highland Township,President / Vice President,,Democratic,"Obama, Barack",4,000120
+WASHINGTON,Highland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+WASHINGTON,Highland Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+WASHINGTON,Highland Township,President / Vice President,,Republican,"Romney, Mitt",13,000120
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+WASHINGTON,Independence Township,President / Vice President,,Democratic,"Obama, Barack",15,000130
+WASHINGTON,Independence Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+WASHINGTON,Independence Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000130
+WASHINGTON,Independence Township,President / Vice President,,Republican,"Romney, Mitt",47,000130
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Ayers, Avery L",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Barnett, Andre",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Bush, Kent W",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Christensen, Will",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Duncan, Richard A",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Goode, Virgil",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Knill, Dennis J",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Reed, Jill A.",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Rogers, Rick L",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Stein, Jill E",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,Democratic,"Obama, Barack",9,000140
+WASHINGTON,Kimeo Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+WASHINGTON,Kimeo Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,Republican,"Romney, Mitt",30,000140
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Barnett, Andre",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Bush, Kent W",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Christensen, Will",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Goode, Virgil",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Stein, Jill E",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,Democratic,"Obama, Barack",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,Republican,"Romney, Mitt",25,000150
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Barnett, Andre",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Bush, Kent W",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Christensen, Will",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Goode, Virgil",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Stein, Jill E",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+WASHINGTON,Linn Township,President / Vice President,,Democratic,"Obama, Barack",29,000160
+WASHINGTON,Linn Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000160
+WASHINGTON,Linn Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000160
+WASHINGTON,Linn Township,President / Vice President,,Republican,"Romney, Mitt",208,000160
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Barnett, Andre",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Bush, Kent W",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Christensen, Will",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Goode, Virgil",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Stein, Jill E",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,Democratic,"Obama, Barack",11,000170
+WASHINGTON,Little Blue Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000170
+WASHINGTON,Little Blue Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,Republican,"Romney, Mitt",32,000170
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+WASHINGTON,Logan Township,President / Vice President,,Democratic,"Obama, Barack",11,000180
+WASHINGTON,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+WASHINGTON,Logan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000180
+WASHINGTON,Logan Township,President / Vice President,,Republican,"Romney, Mitt",50,000180
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,Democratic,"Obama, Barack",4,000190
+WASHINGTON,Lowe Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,Republican,"Romney, Mitt",30,000190
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,Democratic,"Obama, Barack",20,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,Republican,"Romney, Mitt",84,000200
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,Democratic,"Obama, Barack",4,000210
+WASHINGTON,Sheridan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,Republican,"Romney, Mitt",43,000210
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,Democratic,"Obama, Barack",11,000220
+WASHINGTON,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000220
+WASHINGTON,Sherman Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000220
+WASHINGTON,Sherman Township,President / Vice President,,Republican,"Romney, Mitt",131,000220
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,Democratic,"Obama, Barack",7,000230
+WASHINGTON,Strawberry Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,Republican,"Romney, Mitt",51,000230
+WASHINGTON,Union Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Ayers, Avery L",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Barnett, Andre",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Bush, Kent W",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Christensen, Will",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Duncan, Richard A",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Goode, Virgil",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Knill, Dennis J",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Reed, Jill A.",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Rogers, Rick L",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Stein, Jill E",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000240
+WASHINGTON,Union Township,President / Vice President,,Democratic,"Obama, Barack",7,000240
+WASHINGTON,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+WASHINGTON,Union Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000240
+WASHINGTON,Union Township,President / Vice President,,Republican,"Romney, Mitt",34,000240
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Ayers, Avery L",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Barnett, Andre",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Barr, Roseanne C",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Bush, Kent W",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Christensen, Will",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Duncan, Richard A",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Goode, Virgil",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Knill, Dennis J",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Reed, Jill A.",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Rogers, Rick L",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Stein, Jill E",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Thorne, Kevin M",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Warner, Gerald L.",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,Democratic,"Obama, Barack",16,00025A
+WASHINGTON,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,Reform,"Baldwin, Chuck",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,Republican,"Romney, Mitt",103,00025A
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Ayers, Avery L",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Barnett, Andre",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Bush, Kent W",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Christensen, Will",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Duncan, Richard A",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Goode, Virgil",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Knill, Dennis J",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Reed, Jill A.",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Rogers, Rick L",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Stein, Jill E",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,Democratic,"Obama, Barack",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,Republican,"Romney, Mitt",0,00025B
+WASHINGTON,Washington City,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Ayers, Avery L",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Barnett, Andre",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Barr, Roseanne C",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Bush, Kent W",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Christensen, Will",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Duncan, Richard A",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Goode, Virgil",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Hoefling, Tom",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Knill, Dennis J",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Reed, Jill A.",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Rogers, Rick L",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Stein, Jill E",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Thorne, Kevin M",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Warner, Gerald L.",0,00026A
+WASHINGTON,Washington City,President / Vice President,,Democratic,"Obama, Barack",131,00026A
+WASHINGTON,Washington City,President / Vice President,,Libertarian,"Johnson, Gary",12,00026A
+WASHINGTON,Washington City,President / Vice President,,Reform,"Baldwin, Chuck",3,00026A
+WASHINGTON,Washington City,President / Vice President,,Republican,"Romney, Mitt",436,00026A
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Christensen, Will",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Barnett, Andre",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Bush, Kent W",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Christensen, Will",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Goode, Virgil",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Stein, Jill E",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,Democratic,"Obama, Barack",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,Republican,"Romney, Mitt",0,900010
+WASHINGTON,Barnes Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",65,000010
+WASHINGTON,Brantford Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",42,000020
+WASHINGTON,Charleston Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",32,000030
+WASHINGTON,Clifton Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",164,000040
+WASHINGTON,Coleman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000050
+WASHINGTON,Farmington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",81,000060
+WASHINGTON,Franklin Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",47,000070
+WASHINGTON,Grant Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",16,000080
+WASHINGTON,Greenleaf Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",155,000090
+WASHINGTON,Haddam Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",70,000100
+WASHINGTON,Hanover Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",384,000110
+WASHINGTON,Highland Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",14,000120
+WASHINGTON,Independence Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",52,000130
+WASHINGTON,Kimeo Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000140
+WASHINGTON,Lincoln Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",24,000150
+WASHINGTON,Linn Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",212,000160
+WASHINGTON,Little Blue Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",31,000170
+WASHINGTON,Logan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",53,000180
+WASHINGTON,Lowe Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",30,000190
+WASHINGTON,Mill Creek Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",94,000200
+WASHINGTON,Sheridan Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",44,000210
+WASHINGTON,Sherman Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",129,000220
+WASHINGTON,Strawberry Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",51,000230
+WASHINGTON,Union Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",36,000240
+WASHINGTON,Washington Township,United States House of Representatives,1,Republican,"Huelskamp, Tim",104,00025A
+WASHINGTON,Washington Township Rural Enclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00025B
+WASHINGTON,Washington City,United States House of Representatives,1,Republican,"Huelskamp, Tim",467,00026A
+WASHINGTON,Washington City Exclave,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,United States House of Representatives,1,Republican,"Huelskamp, Tim",0,900010

--- a/2012/20121106__ks__general__wichita__precinct.csv
+++ b/2012/20121106__ks__general__wichita__precinct.csv
@@ -1,0 +1,77 @@
+county,precinct,office,district,party,candidate,votes,vtd
+WICHITA,Leoti Precinct 1,Kansas House of Representatives,118,Republican,"Hineman, Don",271,000010
+WICHITA,Leoti Precinct 2,Kansas House of Representatives,118,Republican,"Hineman, Don",302,000020
+WICHITA,Leoti Precinct 3,Kansas House of Representatives,118,Republican,"Hineman, Don",205,000030
+WICHITA,ADVANCED,Kansas House of Representatives,118,Republican,"Hineman, Don",103,999998
+WICHITA,Leoti Precinct 1,Kansas Senate,39,Republican,"Powell, Larry R.",254,000010
+WICHITA,Leoti Precinct 2,Kansas Senate,39,Republican,"Powell, Larry R.",300,000020
+WICHITA,Leoti Precinct 3,Kansas Senate,39,Republican,"Powell, Larry R.",197,000030
+WICHITA,ADVANCED,Kansas Senate,39,Republican,"Powell, Larry R.",95,999998
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Barnett, Andre",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Bush, Kent W",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Christensen, Will",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Goode, Virgil",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Stein, Jill E",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,Democratic,"Obama, Barack",61,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,Republican,"Romney, Mitt",235,000010
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Barnett, Andre",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Bush, Kent W",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Christensen, Will",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Goode, Virgil",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Stein, Jill E",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,Democratic,"Obama, Barack",52,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,Republican,"Romney, Mitt",297,000020
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Barnett, Andre",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Bush, Kent W",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Christensen, Will",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Goode, Virgil",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Stein, Jill E",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,Democratic,"Obama, Barack",21,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,Reform,"Baldwin, Chuck",2,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,Republican,"Romney, Mitt",192,000030
+WICHITA,ADVANCED,President / Vice President,,Democratic,"Obama, Barack",23,999998
+WICHITA,ADVANCED,President / Vice President,,Libertarian,"Johnson, Gary",0,999998
+WICHITA,ADVANCED,President / Vice President,,Reform,"Baldwin, Chuck",1,999998
+WICHITA,ADVANCED,President / Vice President,,Republican,"Romney, Mitt",97,999998
+WICHITA,Leoti Precinct 1,United States House of Representatives,1,Republican,"Huelskamp, Tim",262,000010
+WICHITA,Leoti Precinct 2,United States House of Representatives,1,Republican,"Huelskamp, Tim",312,000020
+WICHITA,Leoti Precinct 3,United States House of Representatives,1,Republican,"Huelskamp, Tim",197,000030
+WICHITA,ADVANCED,United States House of Representatives,1,Republican,"Huelskamp, Tim",97,999998

--- a/2012/20121106__ks__general__wilson__precinct.csv
+++ b/2012/20121106__ks__general__wilson__precinct.csv
@@ -1,0 +1,1509 @@
+county,precinct,office,district,party,candidate,votes,vtd
+WILSON,Cedar Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",204,000010
+WILSON,Cedar Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",204,000010
+WILSON,Center Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",221,000020
+WILSON,Center Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",221,000020
+WILSON,Chetopa Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",69,000030
+WILSON,Chetopa Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",69,000030
+WILSON,Clifton Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",115,000040
+WILSON,Clifton Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",115,000040
+WILSON,Colfax Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",167,000050
+WILSON,Colfax Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",167,000050
+WILSON,Duck Creek Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",31,000060
+WILSON,Duck Creek Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",31,000060
+WILSON,Fall River Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",171,000070
+WILSON,Fall River Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",171,000070
+WILSON,Fredonia Ward 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",208,000080
+WILSON,Fredonia Ward 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",208,000080
+WILSON,Fredonia Ward 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",87,000090
+WILSON,Fredonia Ward 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",87,000090
+WILSON,Fredonia Ward 3,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",89,00010A
+WILSON,Fredonia Ward 3,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",89,00010A
+WILSON,Fredonia Ward 3 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,00010B
+WILSON,Fredonia Ward 3 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,00010B
+WILSON,Fredonia Ward 4,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",435,000110
+WILSON,Fredonia Ward 4,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",435,000110
+WILSON,Guilford Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",60,000120
+WILSON,Guilford Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",60,000120
+WILSON,Neodesha Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",212,000130
+WILSON,Neodesha Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",212,000130
+WILSON,Neodesha Ward 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",160,00014A
+WILSON,Neodesha Ward 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",160,00014A
+WILSON,Neodesha Ward 1 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,00014B
+WILSON,Neodesha Ward 1 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,00014B
+WILSON,Neodesha Ward 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",153,000150
+WILSON,Neodesha Ward 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",153,000150
+WILSON,Neodesha Ward 3,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",135,000160
+WILSON,Neodesha Ward 3,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",135,000160
+WILSON,Neodesha Ward 4,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",294,000170
+WILSON,Neodesha Ward 4,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",294,000170
+WILSON,Newark Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",98,000180
+WILSON,Newark Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",98,000180
+WILSON,Pleasant Valley Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",88,000190
+WILSON,Pleasant Valley Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",88,000190
+WILSON,Prairie Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",45,000200
+WILSON,Prairie Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",45,000200
+WILSON,Talleyrand Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",58,000210
+WILSON,Talleyrand Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",58,000210
+WILSON,Verdigris Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",86,000220
+WILSON,Verdigris Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",86,000220
+WILSON,Webster Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",22,000230
+WILSON,Webster Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",22,000230
+WILSON,Neodesha Ward 1 Exclave 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,900030
+WILSON,Neodesha Ward 4 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,900040
+WILSON,Neodesha Ward 4 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",0,900040
+WILSON,Cedar Township,Kansas Senate,14,Democratic,"Fuson, Eden",36,000010
+WILSON,Cedar Township,Kansas Senate,14,Democratic,"Fuson, Eden",36,000010
+WILSON,Cedar Township,Kansas Senate,14,Republican,"Knox, Forrest J.",190,000010
+WILSON,Cedar Township,Kansas Senate,14,Republican,"Knox, Forrest J.",190,000010
+WILSON,Center Township,Kansas Senate,14,Democratic,"Fuson, Eden",82,000020
+WILSON,Center Township,Kansas Senate,14,Democratic,"Fuson, Eden",82,000020
+WILSON,Center Township,Kansas Senate,14,Republican,"Knox, Forrest J.",161,000020
+WILSON,Center Township,Kansas Senate,14,Republican,"Knox, Forrest J.",161,000020
+WILSON,Chetopa Township,Kansas Senate,14,Democratic,"Fuson, Eden",12,000030
+WILSON,Chetopa Township,Kansas Senate,14,Democratic,"Fuson, Eden",12,000030
+WILSON,Chetopa Township,Kansas Senate,14,Republican,"Knox, Forrest J.",69,000030
+WILSON,Chetopa Township,Kansas Senate,14,Republican,"Knox, Forrest J.",69,000030
+WILSON,Clifton Township,Kansas Senate,14,Democratic,"Fuson, Eden",39,000040
+WILSON,Clifton Township,Kansas Senate,14,Democratic,"Fuson, Eden",39,000040
+WILSON,Clifton Township,Kansas Senate,14,Republican,"Knox, Forrest J.",93,000040
+WILSON,Clifton Township,Kansas Senate,14,Republican,"Knox, Forrest J.",93,000040
+WILSON,Colfax Township,Kansas Senate,14,Democratic,"Fuson, Eden",35,000050
+WILSON,Colfax Township,Kansas Senate,14,Democratic,"Fuson, Eden",35,000050
+WILSON,Colfax Township,Kansas Senate,14,Republican,"Knox, Forrest J.",160,000050
+WILSON,Colfax Township,Kansas Senate,14,Republican,"Knox, Forrest J.",160,000050
+WILSON,Duck Creek Township,Kansas Senate,14,Democratic,"Fuson, Eden",7,000060
+WILSON,Duck Creek Township,Kansas Senate,14,Democratic,"Fuson, Eden",7,000060
+WILSON,Duck Creek Township,Kansas Senate,14,Republican,"Knox, Forrest J.",30,000060
+WILSON,Duck Creek Township,Kansas Senate,14,Republican,"Knox, Forrest J.",30,000060
+WILSON,Fall River Township,Kansas Senate,14,Democratic,"Fuson, Eden",49,000070
+WILSON,Fall River Township,Kansas Senate,14,Democratic,"Fuson, Eden",49,000070
+WILSON,Fall River Township,Kansas Senate,14,Republican,"Knox, Forrest J.",126,000070
+WILSON,Fall River Township,Kansas Senate,14,Republican,"Knox, Forrest J.",126,000070
+WILSON,Fredonia Ward 1,Kansas Senate,14,Democratic,"Fuson, Eden",80,000080
+WILSON,Fredonia Ward 1,Kansas Senate,14,Democratic,"Fuson, Eden",80,000080
+WILSON,Fredonia Ward 1,Kansas Senate,14,Republican,"Knox, Forrest J.",147,000080
+WILSON,Fredonia Ward 1,Kansas Senate,14,Republican,"Knox, Forrest J.",147,000080
+WILSON,Fredonia Ward 2,Kansas Senate,14,Democratic,"Fuson, Eden",24,000090
+WILSON,Fredonia Ward 2,Kansas Senate,14,Democratic,"Fuson, Eden",24,000090
+WILSON,Fredonia Ward 2,Kansas Senate,14,Republican,"Knox, Forrest J.",71,000090
+WILSON,Fredonia Ward 2,Kansas Senate,14,Republican,"Knox, Forrest J.",71,000090
+WILSON,Fredonia Ward 3,Kansas Senate,14,Democratic,"Fuson, Eden",33,00010A
+WILSON,Fredonia Ward 3,Kansas Senate,14,Democratic,"Fuson, Eden",33,00010A
+WILSON,Fredonia Ward 3,Kansas Senate,14,Republican,"Knox, Forrest J.",68,00010A
+WILSON,Fredonia Ward 3,Kansas Senate,14,Republican,"Knox, Forrest J.",68,00010A
+WILSON,Fredonia Ward 3 Exclave,Kansas Senate,14,Democratic,"Fuson, Eden",0,00010B
+WILSON,Fredonia Ward 3 Exclave,Kansas Senate,14,Democratic,"Fuson, Eden",0,00010B
+WILSON,Fredonia Ward 3 Exclave,Kansas Senate,14,Republican,"Knox, Forrest J.",0,00010B
+WILSON,Fredonia Ward 3 Exclave,Kansas Senate,14,Republican,"Knox, Forrest J.",0,00010B
+WILSON,Fredonia Ward 4,Kansas Senate,14,Democratic,"Fuson, Eden",178,000110
+WILSON,Fredonia Ward 4,Kansas Senate,14,Democratic,"Fuson, Eden",178,000110
+WILSON,Fredonia Ward 4,Kansas Senate,14,Republican,"Knox, Forrest J.",293,000110
+WILSON,Fredonia Ward 4,Kansas Senate,14,Republican,"Knox, Forrest J.",293,000110
+WILSON,Guilford Township,Kansas Senate,14,Democratic,"Fuson, Eden",18,000120
+WILSON,Guilford Township,Kansas Senate,14,Democratic,"Fuson, Eden",18,000120
+WILSON,Guilford Township,Kansas Senate,14,Republican,"Knox, Forrest J.",56,000120
+WILSON,Guilford Township,Kansas Senate,14,Republican,"Knox, Forrest J.",56,000120
+WILSON,Neodesha Township,Kansas Senate,14,Democratic,"Fuson, Eden",59,000130
+WILSON,Neodesha Township,Kansas Senate,14,Democratic,"Fuson, Eden",59,000130
+WILSON,Neodesha Township,Kansas Senate,14,Republican,"Knox, Forrest J.",180,000130
+WILSON,Neodesha Township,Kansas Senate,14,Republican,"Knox, Forrest J.",180,000130
+WILSON,Neodesha Ward 1,Kansas Senate,14,Democratic,"Fuson, Eden",49,00014A
+WILSON,Neodesha Ward 1,Kansas Senate,14,Democratic,"Fuson, Eden",49,00014A
+WILSON,Neodesha Ward 1,Kansas Senate,14,Republican,"Knox, Forrest J.",138,00014A
+WILSON,Neodesha Ward 1,Kansas Senate,14,Republican,"Knox, Forrest J.",138,00014A
+WILSON,Neodesha Ward 1 Exclave,Kansas Senate,14,Democratic,"Fuson, Eden",0,00014B
+WILSON,Neodesha Ward 1 Exclave,Kansas Senate,14,Democratic,"Fuson, Eden",0,00014B
+WILSON,Neodesha Ward 1 Exclave,Kansas Senate,14,Republican,"Knox, Forrest J.",0,00014B
+WILSON,Neodesha Ward 1 Exclave,Kansas Senate,14,Republican,"Knox, Forrest J.",0,00014B
+WILSON,Neodesha Ward 2,Kansas Senate,14,Democratic,"Fuson, Eden",65,000150
+WILSON,Neodesha Ward 2,Kansas Senate,14,Democratic,"Fuson, Eden",65,000150
+WILSON,Neodesha Ward 2,Kansas Senate,14,Republican,"Knox, Forrest J.",119,000150
+WILSON,Neodesha Ward 2,Kansas Senate,14,Republican,"Knox, Forrest J.",119,000150
+WILSON,Neodesha Ward 3,Kansas Senate,14,Democratic,"Fuson, Eden",45,000160
+WILSON,Neodesha Ward 3,Kansas Senate,14,Democratic,"Fuson, Eden",45,000160
+WILSON,Neodesha Ward 3,Kansas Senate,14,Republican,"Knox, Forrest J.",112,000160
+WILSON,Neodesha Ward 3,Kansas Senate,14,Republican,"Knox, Forrest J.",112,000160
+WILSON,Neodesha Ward 4,Kansas Senate,14,Democratic,"Fuson, Eden",107,000170
+WILSON,Neodesha Ward 4,Kansas Senate,14,Democratic,"Fuson, Eden",107,000170
+WILSON,Neodesha Ward 4,Kansas Senate,14,Republican,"Knox, Forrest J.",235,000170
+WILSON,Neodesha Ward 4,Kansas Senate,14,Republican,"Knox, Forrest J.",235,000170
+WILSON,Newark Township,Kansas Senate,14,Democratic,"Fuson, Eden",18,000180
+WILSON,Newark Township,Kansas Senate,14,Democratic,"Fuson, Eden",18,000180
+WILSON,Newark Township,Kansas Senate,14,Republican,"Knox, Forrest J.",101,000180
+WILSON,Newark Township,Kansas Senate,14,Republican,"Knox, Forrest J.",101,000180
+WILSON,Pleasant Valley Township,Kansas Senate,14,Democratic,"Fuson, Eden",28,000190
+WILSON,Pleasant Valley Township,Kansas Senate,14,Democratic,"Fuson, Eden",28,000190
+WILSON,Pleasant Valley Township,Kansas Senate,14,Republican,"Knox, Forrest J.",75,000190
+WILSON,Pleasant Valley Township,Kansas Senate,14,Republican,"Knox, Forrest J.",75,000190
+WILSON,Prairie Township,Kansas Senate,14,Democratic,"Fuson, Eden",10,000200
+WILSON,Prairie Township,Kansas Senate,14,Democratic,"Fuson, Eden",10,000200
+WILSON,Prairie Township,Kansas Senate,14,Republican,"Knox, Forrest J.",43,000200
+WILSON,Prairie Township,Kansas Senate,14,Republican,"Knox, Forrest J.",43,000200
+WILSON,Talleyrand Township,Kansas Senate,14,Democratic,"Fuson, Eden",19,000210
+WILSON,Talleyrand Township,Kansas Senate,14,Democratic,"Fuson, Eden",19,000210
+WILSON,Talleyrand Township,Kansas Senate,14,Republican,"Knox, Forrest J.",44,000210
+WILSON,Talleyrand Township,Kansas Senate,14,Republican,"Knox, Forrest J.",44,000210
+WILSON,Verdigris Township,Kansas Senate,14,Democratic,"Fuson, Eden",27,000220
+WILSON,Verdigris Township,Kansas Senate,14,Democratic,"Fuson, Eden",27,000220
+WILSON,Verdigris Township,Kansas Senate,14,Republican,"Knox, Forrest J.",71,000220
+WILSON,Verdigris Township,Kansas Senate,14,Republican,"Knox, Forrest J.",71,000220
+WILSON,Webster Township,Kansas Senate,14,Democratic,"Fuson, Eden",11,000230
+WILSON,Webster Township,Kansas Senate,14,Democratic,"Fuson, Eden",11,000230
+WILSON,Webster Township,Kansas Senate,14,Republican,"Knox, Forrest J.",14,000230
+WILSON,Webster Township,Kansas Senate,14,Republican,"Knox, Forrest J.",14,000230
+WILSON,Neodesha Ward 1 Exclave 2,Kansas Senate,14,Democratic,"Fuson, Eden",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,Kansas Senate,14,Democratic,"Fuson, Eden",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,Kansas Senate,14,Republican,"Knox, Forrest J.",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,Kansas Senate,14,Republican,"Knox, Forrest J.",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,Kansas Senate,14,Democratic,"Fuson, Eden",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,Kansas Senate,14,Democratic,"Fuson, Eden",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,Kansas Senate,14,Republican,"Knox, Forrest J.",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,Kansas Senate,14,Republican,"Knox, Forrest J.",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,Kansas Senate,14,Democratic,"Fuson, Eden",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,Kansas Senate,14,Democratic,"Fuson, Eden",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,Kansas Senate,14,Republican,"Knox, Forrest J.",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,Kansas Senate,14,Republican,"Knox, Forrest J.",0,900030
+WILSON,Neodesha Ward 4 Exclave,Kansas Senate,14,Democratic,"Fuson, Eden",0,900040
+WILSON,Neodesha Ward 4 Exclave,Kansas Senate,14,Democratic,"Fuson, Eden",0,900040
+WILSON,Neodesha Ward 4 Exclave,Kansas Senate,14,Republican,"Knox, Forrest J.",0,900040
+WILSON,Neodesha Ward 4 Exclave,Kansas Senate,14,Republican,"Knox, Forrest J.",0,900040
+WILSON,Cedar Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+WILSON,Cedar Township,President / Vice President,,Democratic,"Obama, Barack",34,000010
+WILSON,Cedar Township,President / Vice President,,Democratic,"Obama, Barack",34,000010
+WILSON,Cedar Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+WILSON,Cedar Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+WILSON,Cedar Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000010
+WILSON,Cedar Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000010
+WILSON,Cedar Township,President / Vice President,,Republican,"Romney, Mitt",191,000010
+WILSON,Cedar Township,President / Vice President,,Republican,"Romney, Mitt",191,000010
+WILSON,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+WILSON,Center Township,President / Vice President,,Democratic,"Obama, Barack",47,000020
+WILSON,Center Township,President / Vice President,,Democratic,"Obama, Barack",47,000020
+WILSON,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000020
+WILSON,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000020
+WILSON,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000020
+WILSON,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000020
+WILSON,Center Township,President / Vice President,,Republican,"Romney, Mitt",200,000020
+WILSON,Center Township,President / Vice President,,Republican,"Romney, Mitt",200,000020
+WILSON,Chetopa Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+WILSON,Chetopa Township,President / Vice President,,Democratic,"Obama, Barack",6,000030
+WILSON,Chetopa Township,President / Vice President,,Democratic,"Obama, Barack",6,000030
+WILSON,Chetopa Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+WILSON,Chetopa Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+WILSON,Chetopa Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+WILSON,Chetopa Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000030
+WILSON,Chetopa Township,President / Vice President,,Republican,"Romney, Mitt",74,000030
+WILSON,Chetopa Township,President / Vice President,,Republican,"Romney, Mitt",74,000030
+WILSON,Clifton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+WILSON,Clifton Township,President / Vice President,,Democratic,"Obama, Barack",26,000040
+WILSON,Clifton Township,President / Vice President,,Democratic,"Obama, Barack",26,000040
+WILSON,Clifton Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+WILSON,Clifton Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+WILSON,Clifton Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+WILSON,Clifton Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000040
+WILSON,Clifton Township,President / Vice President,,Republican,"Romney, Mitt",105,000040
+WILSON,Clifton Township,President / Vice President,,Republican,"Romney, Mitt",105,000040
+WILSON,Colfax Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+WILSON,Colfax Township,President / Vice President,,Democratic,"Obama, Barack",50,000050
+WILSON,Colfax Township,President / Vice President,,Democratic,"Obama, Barack",50,000050
+WILSON,Colfax Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000050
+WILSON,Colfax Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000050
+WILSON,Colfax Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+WILSON,Colfax Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+WILSON,Colfax Township,President / Vice President,,Republican,"Romney, Mitt",146,000050
+WILSON,Colfax Township,President / Vice President,,Republican,"Romney, Mitt",146,000050
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Goode, Virgil",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+WILSON,Duck Creek Township,President / Vice President,,Democratic,"Obama, Barack",6,000060
+WILSON,Duck Creek Township,President / Vice President,,Democratic,"Obama, Barack",6,000060
+WILSON,Duck Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+WILSON,Duck Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+WILSON,Duck Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+WILSON,Duck Creek Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000060
+WILSON,Duck Creek Township,President / Vice President,,Republican,"Romney, Mitt",32,000060
+WILSON,Duck Creek Township,President / Vice President,,Republican,"Romney, Mitt",32,000060
+WILSON,Fall River Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+WILSON,Fall River Township,President / Vice President,,Democratic,"Obama, Barack",19,000070
+WILSON,Fall River Township,President / Vice President,,Democratic,"Obama, Barack",19,000070
+WILSON,Fall River Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+WILSON,Fall River Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+WILSON,Fall River Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+WILSON,Fall River Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000070
+WILSON,Fall River Township,President / Vice President,,Republican,"Romney, Mitt",163,000070
+WILSON,Fall River Township,President / Vice President,,Republican,"Romney, Mitt",163,000070
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Christensen, Will",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,Democratic,"Obama, Barack",68,000080
+WILSON,Fredonia Ward 1,President / Vice President,,Democratic,"Obama, Barack",68,000080
+WILSON,Fredonia Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000080
+WILSON,Fredonia Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000080
+WILSON,Fredonia Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+WILSON,Fredonia Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",1,000080
+WILSON,Fredonia Ward 1,President / Vice President,,Republican,"Romney, Mitt",170,000080
+WILSON,Fredonia Ward 1,President / Vice President,,Republican,"Romney, Mitt",170,000080
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,Democratic,"Obama, Barack",19,000090
+WILSON,Fredonia Ward 2,President / Vice President,,Democratic,"Obama, Barack",19,000090
+WILSON,Fredonia Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+WILSON,Fredonia Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+WILSON,Fredonia Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,Republican,"Romney, Mitt",79,000090
+WILSON,Fredonia Ward 2,President / Vice President,,Republican,"Romney, Mitt",79,000090
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Christensen, Will",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,Democratic,"Obama, Barack",25,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,Democratic,"Obama, Barack",25,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",2,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",2,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",2,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",2,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,Republican,"Romney, Mitt",78,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,Republican,"Romney, Mitt",78,00010A
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00010B
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,Democratic,"Obama, Barack",116,000110
+WILSON,Fredonia Ward 4,President / Vice President,,Democratic,"Obama, Barack",116,000110
+WILSON,Fredonia Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",3,000110
+WILSON,Fredonia Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",3,000110
+WILSON,Fredonia Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",5,000110
+WILSON,Fredonia Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",5,000110
+WILSON,Fredonia Ward 4,President / Vice President,,Republican,"Romney, Mitt",360,000110
+WILSON,Fredonia Ward 4,President / Vice President,,Republican,"Romney, Mitt",360,000110
+WILSON,Guilford Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Ayers, Avery L",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Barnett, Andre",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Bush, Kent W",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Christensen, Will",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Duncan, Richard A",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Goode, Virgil",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Knill, Dennis J",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Reed, Jill A.",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Rogers, Rick L",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Stein, Jill E",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000120
+WILSON,Guilford Township,President / Vice President,,Democratic,"Obama, Barack",6,000120
+WILSON,Guilford Township,President / Vice President,,Democratic,"Obama, Barack",6,000120
+WILSON,Guilford Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+WILSON,Guilford Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+WILSON,Guilford Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+WILSON,Guilford Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000120
+WILSON,Guilford Township,President / Vice President,,Republican,"Romney, Mitt",66,000120
+WILSON,Guilford Township,President / Vice President,,Republican,"Romney, Mitt",66,000120
+WILSON,Neodesha Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Ayers, Avery L",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Barnett, Andre",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Bush, Kent W",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Christensen, Will",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Duncan, Richard A",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Goode, Virgil",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Knill, Dennis J",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Reed, Jill A.",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Rogers, Rick L",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Stein, Jill E",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000130
+WILSON,Neodesha Township,President / Vice President,,Democratic,"Obama, Barack",49,000130
+WILSON,Neodesha Township,President / Vice President,,Democratic,"Obama, Barack",49,000130
+WILSON,Neodesha Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000130
+WILSON,Neodesha Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000130
+WILSON,Neodesha Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000130
+WILSON,Neodesha Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000130
+WILSON,Neodesha Township,President / Vice President,,Republican,"Romney, Mitt",190,000130
+WILSON,Neodesha Township,President / Vice President,,Republican,"Romney, Mitt",190,000130
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Christensen, Will",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Christensen, Will",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Goode, Virgil",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,Democratic,"Obama, Barack",52,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,Democratic,"Obama, Barack",52,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",5,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",5,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",2,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,Republican,"Romney, Mitt",130,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,Republican,"Romney, Mitt",130,00014A
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Christensen, Will",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,00014B
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,Democratic,"Obama, Barack",61,000150
+WILSON,Neodesha Ward 2,President / Vice President,,Democratic,"Obama, Barack",61,000150
+WILSON,Neodesha Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",1,000150
+WILSON,Neodesha Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",1,000150
+WILSON,Neodesha Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+WILSON,Neodesha Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",1,000150
+WILSON,Neodesha Ward 2,President / Vice President,,Republican,"Romney, Mitt",124,000150
+WILSON,Neodesha Ward 2,President / Vice President,,Republican,"Romney, Mitt",124,000150
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Ayers, Avery L",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Barnett, Andre",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Barr, Roseanne C",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Bush, Kent W",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Christensen, Will",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Duncan, Richard A",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Goode, Virgil",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Knill, Dennis J",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Reed, Jill A.",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Rogers, Rick L",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Stein, Jill E",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Thorne, Kevin M",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Warner, Gerald L.",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,Democratic,"Obama, Barack",50,000160
+WILSON,Neodesha Ward 3,President / Vice President,,Democratic,"Obama, Barack",50,000160
+WILSON,Neodesha Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",3,000160
+WILSON,Neodesha Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",3,000160
+WILSON,Neodesha Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000160
+WILSON,Neodesha Ward 3,President / Vice President,,Reform,"Baldwin, Chuck",1,000160
+WILSON,Neodesha Ward 3,President / Vice President,,Republican,"Romney, Mitt",109,000160
+WILSON,Neodesha Ward 3,President / Vice President,,Republican,"Romney, Mitt",109,000160
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Ayers, Avery L",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Barnett, Andre",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Barr, Roseanne C",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Bush, Kent W",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Christensen, Will",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Duncan, Richard A",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Goode, Virgil",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Knill, Dennis J",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Reed, Jill A.",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Rogers, Rick L",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Stein, Jill E",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Thorne, Kevin M",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Warner, Gerald L.",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,Democratic,"Obama, Barack",100,000170
+WILSON,Neodesha Ward 4,President / Vice President,,Democratic,"Obama, Barack",100,000170
+WILSON,Neodesha Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",9,000170
+WILSON,Neodesha Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",9,000170
+WILSON,Neodesha Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",3,000170
+WILSON,Neodesha Ward 4,President / Vice President,,Reform,"Baldwin, Chuck",3,000170
+WILSON,Neodesha Ward 4,President / Vice President,,Republican,"Romney, Mitt",234,000170
+WILSON,Neodesha Ward 4,President / Vice President,,Republican,"Romney, Mitt",234,000170
+WILSON,Newark Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Ayers, Avery L",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Barnett, Andre",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Bush, Kent W",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Christensen, Will",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Duncan, Richard A",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Goode, Virgil",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Knill, Dennis J",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Reed, Jill A.",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Rogers, Rick L",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Stein, Jill E",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000180
+WILSON,Newark Township,President / Vice President,,Democratic,"Obama, Barack",15,000180
+WILSON,Newark Township,President / Vice President,,Democratic,"Obama, Barack",15,000180
+WILSON,Newark Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+WILSON,Newark Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+WILSON,Newark Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000180
+WILSON,Newark Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000180
+WILSON,Newark Township,President / Vice President,,Republican,"Romney, Mitt",104,000180
+WILSON,Newark Township,President / Vice President,,Republican,"Romney, Mitt",104,000180
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Ayers, Avery L",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Barnett, Andre",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Bush, Kent W",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Christensen, Will",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Duncan, Richard A",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Goode, Virgil",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Knill, Dennis J",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Reed, Jill A.",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Rogers, Rick L",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Stein, Jill E",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,Democratic,"Obama, Barack",21,000190
+WILSON,Pleasant Valley Township,President / Vice President,,Democratic,"Obama, Barack",21,000190
+WILSON,Pleasant Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000190
+WILSON,Pleasant Valley Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000190
+WILSON,Pleasant Valley Township,President / Vice President,,Republican,"Romney, Mitt",79,000190
+WILSON,Pleasant Valley Township,President / Vice President,,Republican,"Romney, Mitt",79,000190
+WILSON,Prairie Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Ayers, Avery L",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Barnett, Andre",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Bush, Kent W",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Christensen, Will",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Duncan, Richard A",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Goode, Virgil",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Knill, Dennis J",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Reed, Jill A.",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Rogers, Rick L",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Stein, Jill E",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000200
+WILSON,Prairie Township,President / Vice President,,Democratic,"Obama, Barack",4,000200
+WILSON,Prairie Township,President / Vice President,,Democratic,"Obama, Barack",4,000200
+WILSON,Prairie Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+WILSON,Prairie Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+WILSON,Prairie Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+WILSON,Prairie Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000200
+WILSON,Prairie Township,President / Vice President,,Republican,"Romney, Mitt",50,000200
+WILSON,Prairie Township,President / Vice President,,Republican,"Romney, Mitt",50,000200
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Ayers, Avery L",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Barnett, Andre",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Bush, Kent W",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Christensen, Will",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Duncan, Richard A",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Goode, Virgil",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Knill, Dennis J",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Reed, Jill A.",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Rogers, Rick L",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Stein, Jill E",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000210
+WILSON,Talleyrand Township,President / Vice President,,Democratic,"Obama, Barack",11,000210
+WILSON,Talleyrand Township,President / Vice President,,Democratic,"Obama, Barack",11,000210
+WILSON,Talleyrand Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+WILSON,Talleyrand Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+WILSON,Talleyrand Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000210
+WILSON,Talleyrand Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000210
+WILSON,Talleyrand Township,President / Vice President,,Republican,"Romney, Mitt",53,000210
+WILSON,Talleyrand Township,President / Vice President,,Republican,"Romney, Mitt",53,000210
+WILSON,Verdigris Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Ayers, Avery L",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Barnett, Andre",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Bush, Kent W",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Christensen, Will",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Duncan, Richard A",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Goode, Virgil",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Knill, Dennis J",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Reed, Jill A.",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Rogers, Rick L",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Stein, Jill E",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000220
+WILSON,Verdigris Township,President / Vice President,,Democratic,"Obama, Barack",25,000220
+WILSON,Verdigris Township,President / Vice President,,Democratic,"Obama, Barack",25,000220
+WILSON,Verdigris Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000220
+WILSON,Verdigris Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000220
+WILSON,Verdigris Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000220
+WILSON,Verdigris Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000220
+WILSON,Verdigris Township,President / Vice President,,Republican,"Romney, Mitt",71,000220
+WILSON,Verdigris Township,President / Vice President,,Republican,"Romney, Mitt",71,000220
+WILSON,Webster Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Ayers, Avery L",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Barnett, Andre",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Bush, Kent W",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Christensen, Will",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Duncan, Richard A",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Goode, Virgil",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Knill, Dennis J",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Reed, Jill A.",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Rogers, Rick L",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Stein, Jill E",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000230
+WILSON,Webster Township,President / Vice President,,Democratic,"Obama, Barack",8,000230
+WILSON,Webster Township,President / Vice President,,Democratic,"Obama, Barack",8,000230
+WILSON,Webster Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+WILSON,Webster Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+WILSON,Webster Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+WILSON,Webster Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000230
+WILSON,Webster Township,President / Vice President,,Republican,"Romney, Mitt",17,000230
+WILSON,Webster Township,President / Vice President,,Republican,"Romney, Mitt",17,000230
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Christensen, Will",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Christensen, Will",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Ayers, Avery L",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Barnett, Andre",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Barr, Roseanne C",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Bush, Kent W",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Christensen, Will",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Christensen, Will",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Duncan, Richard A",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Goode, Virgil",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Knill, Dennis J",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Reed, Jill A.",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Rogers, Rick L",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Stein, Jill E",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Thorne, Kevin M",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Warner, Gerald L.",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,Democratic,"Obama, Barack",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,Reform,"Baldwin, Chuck",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,Republican,"Romney, Mitt",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Ayers, Avery L",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Barnett, Andre",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Barr, Roseanne C",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Bush, Kent W",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Christensen, Will",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Christensen, Will",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Duncan, Richard A",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Goode, Virgil",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Knill, Dennis J",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Reed, Jill A.",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Rogers, Rick L",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Stein, Jill E",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Thorne, Kevin M",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Warner, Gerald L.",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,Democratic,"Obama, Barack",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,Reform,"Baldwin, Chuck",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,Republican,"Romney, Mitt",0,900030
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Ayers, Avery L",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Barnett, Andre",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Barr, Roseanne C",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Bush, Kent W",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Christensen, Will",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Duncan, Richard A",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Goode, Virgil",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Knill, Dennis J",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Reed, Jill A.",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Rogers, Rick L",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Stein, Jill E",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Thorne, Kevin M",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Warner, Gerald L.",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,Democratic,"Obama, Barack",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,Reform,"Baldwin, Chuck",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,Republican,"Romney, Mitt",0,900040
+WILSON,Cedar Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",28,000010
+WILSON,Cedar Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",28,000010
+WILSON,Cedar Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000010
+WILSON,Cedar Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000010
+WILSON,Cedar Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",188,000010
+WILSON,Cedar Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",188,000010
+WILSON,Center Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",40,000020
+WILSON,Center Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",40,000020
+WILSON,Center Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000020
+WILSON,Center Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000020
+WILSON,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",199,000020
+WILSON,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",199,000020
+WILSON,Chetopa Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",7,000030
+WILSON,Chetopa Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",7,000030
+WILSON,Chetopa Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000030
+WILSON,Chetopa Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000030
+WILSON,Chetopa Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",72,000030
+WILSON,Chetopa Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",72,000030
+WILSON,Clifton Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",20,000040
+WILSON,Clifton Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",20,000040
+WILSON,Clifton Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000040
+WILSON,Clifton Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000040
+WILSON,Clifton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",106,000040
+WILSON,Clifton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",106,000040
+WILSON,Colfax Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",39,000050
+WILSON,Colfax Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",39,000050
+WILSON,Colfax Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,000050
+WILSON,Colfax Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,000050
+WILSON,Colfax Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",147,000050
+WILSON,Colfax Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",147,000050
+WILSON,Duck Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",4,000060
+WILSON,Duck Creek Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",4,000060
+WILSON,Duck Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000060
+WILSON,Duck Creek Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000060
+WILSON,Duck Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",34,000060
+WILSON,Duck Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",34,000060
+WILSON,Fall River Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",20,000070
+WILSON,Fall River Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",20,000070
+WILSON,Fall River Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000070
+WILSON,Fall River Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000070
+WILSON,Fall River Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",148,000070
+WILSON,Fall River Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",148,000070
+WILSON,Fredonia Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",42,000080
+WILSON,Fredonia Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",42,000080
+WILSON,Fredonia Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,000080
+WILSON,Fredonia Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",13,000080
+WILSON,Fredonia Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",178,000080
+WILSON,Fredonia Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",178,000080
+WILSON,Fredonia Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",14,000090
+WILSON,Fredonia Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",14,000090
+WILSON,Fredonia Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000090
+WILSON,Fredonia Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000090
+WILSON,Fredonia Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",75,000090
+WILSON,Fredonia Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",75,000090
+WILSON,Fredonia Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",15,00010A
+WILSON,Fredonia Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",15,00010A
+WILSON,Fredonia Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,00010A
+WILSON,Fredonia Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,00010A
+WILSON,Fredonia Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",85,00010A
+WILSON,Fredonia Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",85,00010A
+WILSON,Fredonia Ward 3 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00010B
+WILSON,Fredonia Ward 3 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00010B
+WILSON,Fredonia Ward 3 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00010B
+WILSON,Fredonia Ward 3 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00010B
+WILSON,Fredonia Ward 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00010B
+WILSON,Fredonia Ward 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00010B
+WILSON,Fredonia Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",80,000110
+WILSON,Fredonia Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",80,000110
+WILSON,Fredonia Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",21,000110
+WILSON,Fredonia Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",21,000110
+WILSON,Fredonia Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",366,000110
+WILSON,Fredonia Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",366,000110
+WILSON,Guilford Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",6,000120
+WILSON,Guilford Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",6,000120
+WILSON,Guilford Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000120
+WILSON,Guilford Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,000120
+WILSON,Guilford Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",62,000120
+WILSON,Guilford Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",62,000120
+WILSON,Neodesha Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",36,000130
+WILSON,Neodesha Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",36,000130
+WILSON,Neodesha Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000130
+WILSON,Neodesha Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",11,000130
+WILSON,Neodesha Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",190,000130
+WILSON,Neodesha Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",190,000130
+WILSON,Neodesha Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",47,00014A
+WILSON,Neodesha Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",47,00014A
+WILSON,Neodesha Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,00014A
+WILSON,Neodesha Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,00014A
+WILSON,Neodesha Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",135,00014A
+WILSON,Neodesha Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",135,00014A
+WILSON,Neodesha Ward 1 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00014B
+WILSON,Neodesha Ward 1 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,00014B
+WILSON,Neodesha Ward 1 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00014B
+WILSON,Neodesha Ward 1 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,00014B
+WILSON,Neodesha Ward 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00014B
+WILSON,Neodesha Ward 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00014B
+WILSON,Neodesha Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",43,000150
+WILSON,Neodesha Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",43,000150
+WILSON,Neodesha Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000150
+WILSON,Neodesha Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",6,000150
+WILSON,Neodesha Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",137,000150
+WILSON,Neodesha Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",137,000150
+WILSON,Neodesha Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",41,000160
+WILSON,Neodesha Ward 3,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",41,000160
+WILSON,Neodesha Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000160
+WILSON,Neodesha Ward 3,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000160
+WILSON,Neodesha Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",109,000160
+WILSON,Neodesha Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",109,000160
+WILSON,Neodesha Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",87,000170
+WILSON,Neodesha Ward 4,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",87,000170
+WILSON,Neodesha Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000170
+WILSON,Neodesha Ward 4,United States House of Representatives,2,Libertarian,"Hawver, Dennis",12,000170
+WILSON,Neodesha Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",247,000170
+WILSON,Neodesha Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",247,000170
+WILSON,Newark Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",19,000180
+WILSON,Newark Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",19,000180
+WILSON,Newark Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000180
+WILSON,Newark Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",5,000180
+WILSON,Newark Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",93,000180
+WILSON,Newark Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",93,000180
+WILSON,Pleasant Valley Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",23,000190
+WILSON,Pleasant Valley Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",23,000190
+WILSON,Pleasant Valley Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000190
+WILSON,Pleasant Valley Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000190
+WILSON,Pleasant Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",80,000190
+WILSON,Pleasant Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",80,000190
+WILSON,Prairie Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",4,000200
+WILSON,Prairie Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",4,000200
+WILSON,Prairie Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000200
+WILSON,Prairie Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",1,000200
+WILSON,Prairie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,000200
+WILSON,Prairie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,000200
+WILSON,Talleyrand Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",9,000210
+WILSON,Talleyrand Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",9,000210
+WILSON,Talleyrand Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000210
+WILSON,Talleyrand Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000210
+WILSON,Talleyrand Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",53,000210
+WILSON,Talleyrand Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",53,000210
+WILSON,Verdigris Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",18,000220
+WILSON,Verdigris Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",18,000220
+WILSON,Verdigris Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000220
+WILSON,Verdigris Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000220
+WILSON,Verdigris Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",74,000220
+WILSON,Verdigris Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",74,000220
+WILSON,Webster Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",4,000230
+WILSON,Webster Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",4,000230
+WILSON,Webster Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000230
+WILSON,Webster Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000230
+WILSON,Webster Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",20,000230
+WILSON,Webster Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",20,000230
+WILSON,Neodesha Ward 1 Exclave 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+WILSON,Neodesha Ward 4 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900040
+WILSON,Neodesha Ward 4 Exclave,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",0,900040
+WILSON,Neodesha Ward 4 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900040
+WILSON,Neodesha Ward 4 Exclave,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,900040
+WILSON,Neodesha Ward 4 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900040
+WILSON,Neodesha Ward 4 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900040

--- a/2012/20121106__ks__general__woodson__precinct.csv
+++ b/2012/20121106__ks__general__woodson__precinct.csv
@@ -1,0 +1,235 @@
+county,precinct,office,district,party,candidate,votes,vtd
+WOODSON,Center Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",266,000010
+WOODSON,Liberty Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",74,000020
+WOODSON,Neosho Falls Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",34,000030
+WOODSON,North Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",32,000040
+WOODSON,Perry Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",38,000050
+WOODSON,Piqua Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",91,000060
+WOODSON,Toronto Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",209,000070
+WOODSON,Yates Center Ward 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",272,00008A
+WOODSON,Yates Center Ward 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry Paul",233,000090
+WOODSON,Center Township,Kansas Senate,14,Democratic,"Fuson, Eden",88,000010
+WOODSON,Center Township,Kansas Senate,14,Republican,"Knox, Forrest J.",212,000010
+WOODSON,Liberty Township,Kansas Senate,14,Democratic,"Fuson, Eden",19,000020
+WOODSON,Liberty Township,Kansas Senate,14,Republican,"Knox, Forrest J.",62,000020
+WOODSON,Neosho Falls Township,Kansas Senate,14,Democratic,"Fuson, Eden",20,000030
+WOODSON,Neosho Falls Township,Kansas Senate,14,Republican,"Knox, Forrest J.",21,000030
+WOODSON,North Township,Kansas Senate,14,Democratic,"Fuson, Eden",5,000040
+WOODSON,North Township,Kansas Senate,14,Republican,"Knox, Forrest J.",29,000040
+WOODSON,Perry Township,Kansas Senate,14,Democratic,"Fuson, Eden",13,000050
+WOODSON,Perry Township,Kansas Senate,14,Republican,"Knox, Forrest J.",32,000050
+WOODSON,Piqua Township,Kansas Senate,14,Democratic,"Fuson, Eden",24,000060
+WOODSON,Piqua Township,Kansas Senate,14,Republican,"Knox, Forrest J.",77,000060
+WOODSON,Toronto Township,Kansas Senate,14,Democratic,"Fuson, Eden",57,000070
+WOODSON,Toronto Township,Kansas Senate,14,Republican,"Knox, Forrest J.",172,000070
+WOODSON,Yates Center Ward 1,Kansas Senate,14,Democratic,"Fuson, Eden",101,00008A
+WOODSON,Yates Center Ward 1,Kansas Senate,14,Republican,"Knox, Forrest J.",206,00008A
+WOODSON,Yates Center Ward 2,Kansas Senate,14,Democratic,"Fuson, Eden",81,000090
+WOODSON,Yates Center Ward 2,Kansas Senate,14,Republican,"Knox, Forrest J.",185,000090
+WOODSON,Center Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Ayers, Avery L",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Barnett, Andre",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Bush, Kent W",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Christensen, Will",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Duncan, Richard A",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Goode, Virgil",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Knill, Dennis J",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Reed, Jill A.",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Rogers, Rick L",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Stein, Jill E",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000010
+WOODSON,Center Township,President / Vice President,,Democratic,"Obama, Barack",57,000010
+WOODSON,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000010
+WOODSON,Center Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000010
+WOODSON,Center Township,President / Vice President,,Republican,"Romney, Mitt",247,000010
+WOODSON,Liberty Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Ayers, Avery L",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Barnett, Andre",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Bush, Kent W",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Christensen, Will",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Duncan, Richard A",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Goode, Virgil",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Knill, Dennis J",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Reed, Jill A.",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Rogers, Rick L",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Stein, Jill E",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000020
+WOODSON,Liberty Township,President / Vice President,,Democratic,"Obama, Barack",19,000020
+WOODSON,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+WOODSON,Liberty Township,President / Vice President,,Reform,"Baldwin, Chuck",2,000020
+WOODSON,Liberty Township,President / Vice President,,Republican,"Romney, Mitt",61,000020
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Ayers, Avery L",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Barnett, Andre",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Bush, Kent W",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Christensen, Will",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Duncan, Richard A",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Goode, Virgil",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Knill, Dennis J",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Reed, Jill A.",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Rogers, Rick L",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Stein, Jill E",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,Democratic,"Obama, Barack",20,000030
+WOODSON,Neosho Falls Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+WOODSON,Neosho Falls Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,Republican,"Romney, Mitt",21,000030
+WOODSON,North Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Ayers, Avery L",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Barnett, Andre",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Bush, Kent W",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Christensen, Will",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Duncan, Richard A",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Goode, Virgil",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Knill, Dennis J",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Reed, Jill A.",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Rogers, Rick L",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Stein, Jill E",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000040
+WOODSON,North Township,President / Vice President,,Democratic,"Obama, Barack",4,000040
+WOODSON,North Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+WOODSON,North Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000040
+WOODSON,North Township,President / Vice President,,Republican,"Romney, Mitt",31,000040
+WOODSON,Perry Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",1,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Ayers, Avery L",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Barnett, Andre",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Bush, Kent W",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Christensen, Will",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Duncan, Richard A",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Goode, Virgil",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Knill, Dennis J",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Reed, Jill A.",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Rogers, Rick L",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Stein, Jill E",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000050
+WOODSON,Perry Township,President / Vice President,,Democratic,"Obama, Barack",9,000050
+WOODSON,Perry Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+WOODSON,Perry Township,President / Vice President,,Reform,"Baldwin, Chuck",0,000050
+WOODSON,Perry Township,President / Vice President,,Republican,"Romney, Mitt",36,000050
+WOODSON,Piqua Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Ayers, Avery L",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Barnett, Andre",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Bush, Kent W",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Christensen, Will",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Duncan, Richard A",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Goode, Virgil",1,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Knill, Dennis J",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Reed, Jill A.",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Rogers, Rick L",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Stein, Jill E",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000060
+WOODSON,Piqua Township,President / Vice President,,Democratic,"Obama, Barack",23,000060
+WOODSON,Piqua Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+WOODSON,Piqua Township,President / Vice President,,Reform,"Baldwin, Chuck",1,000060
+WOODSON,Piqua Township,President / Vice President,,Republican,"Romney, Mitt",78,000060
+WOODSON,Toronto Township,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Ayers, Avery L",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Barnett, Andre",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Barr, Roseanne C",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Bush, Kent W",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Christensen, Will",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Duncan, Richard A",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Goode, Virgil",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Knill, Dennis J",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Reed, Jill A.",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Rogers, Rick L",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Stein, Jill E",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Thorne, Kevin M",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Warner, Gerald L.",0,000070
+WOODSON,Toronto Township,President / Vice President,,Democratic,"Obama, Barack",67,000070
+WOODSON,Toronto Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000070
+WOODSON,Toronto Township,President / Vice President,,Reform,"Baldwin, Chuck",3,000070
+WOODSON,Toronto Township,President / Vice President,,Republican,"Romney, Mitt",157,000070
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Ayers, Avery L",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Barnett, Andre",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Barr, Roseanne C",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Bush, Kent W",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Christensen, Will",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Duncan, Richard A",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Goode, Virgil",2,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Knill, Dennis J",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Reed, Jill A.",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Rogers, Rick L",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Stein, Jill E",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Thorne, Kevin M",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Warner, Gerald L.",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,Democratic,"Obama, Barack",104,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",5,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,Reform,"Baldwin, Chuck",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,Republican,"Romney, Mitt",203,00008A
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Ayers, Avery L",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Barnett, Andre",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Barr, Roseanne C",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Bush, Kent W",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Christensen, Will",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Duncan, Richard A",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Goode, Virgil",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Knill, Dennis J",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Reed, Jill A.",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Rogers, Rick L",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Stein, Jill E",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Thorne, Kevin M",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Warner, Gerald L.",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,Democratic,"Obama, Barack",77,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,Reform,"Baldwin, Chuck",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,Republican,"Romney, Mitt",201,000090
+WOODSON,Center Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",47,000010
+WOODSON,Center Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000010
+WOODSON,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",246,000010
+WOODSON,Liberty Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",14,000020
+WOODSON,Liberty Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",4,000020
+WOODSON,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",62,000020
+WOODSON,Neosho Falls Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",13,000030
+WOODSON,Neosho Falls Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000030
+WOODSON,Neosho Falls Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",27,000030
+WOODSON,North Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",4,000040
+WOODSON,North Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",0,000040
+WOODSON,North Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",30,000040
+WOODSON,Perry Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",8,000050
+WOODSON,Perry Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",3,000050
+WOODSON,Perry Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",34,000050
+WOODSON,Piqua Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",20,000060
+WOODSON,Piqua Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",2,000060
+WOODSON,Piqua Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",82,000060
+WOODSON,Toronto Township,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",54,000070
+WOODSON,Toronto Township,United States House of Representatives,2,Libertarian,"Hawver, Dennis",9,000070
+WOODSON,Toronto Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",170,000070
+WOODSON,Yates Center Ward 1,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",78,00008A
+WOODSON,Yates Center Ward 1,United States House of Representatives,2,Libertarian,"Hawver, Dennis",7,00008A
+WOODSON,Yates Center Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",226,00008A
+WOODSON,Yates Center Ward 2,United States House of Representatives,2,Democratic,"Schlingensiepen, Tobias",54,000090
+WOODSON,Yates Center Ward 2,United States House of Representatives,2,Libertarian,"Hawver, Dennis",8,000090
+WOODSON,Yates Center Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",215,000090

--- a/2012/20121106__ks__general__wyandotte__precinct.csv
+++ b/2012/20121106__ks__general__wyandotte__precinct.csv
@@ -1,0 +1,3172 @@
+county,precinct,office,district,party,candidate,votes,vtd
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",328,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,Kansas House of Representatives,33,Republican,"Bukaty, Tony",307,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",1,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,Kansas House of Representatives,33,Republican,"Bukaty, Tony",1,120030
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",274,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,Kansas House of Representatives,33,Republican,"Bukaty, Tony",355,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",112,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,Kansas House of Representatives,33,Republican,"Bukaty, Tony",95,120050
+WYANDOTTE,Kansas City Ward 10 Precinct 03,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",43,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 06,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",319,120070
+WYANDOTTE,Kansas City Ward 11 Precinct 13,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",362,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,Kansas House of Representatives,33,Republican,"Bukaty, Tony",257,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 14,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",10,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,Kansas House of Representatives,33,Republican,"Bukaty, Tony",8,120090
+WYANDOTTE,Kansas City Ward 12 Precinct 11,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",114,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,Kansas House of Representatives,33,Republican,"Bukaty, Tony",75,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 10,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",212,120110
+WYANDOTTE,Kansas City Ward 14 Precinct 08,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",382,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",23,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",162,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 16,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",105,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",4,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",41,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 11,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",373,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",8,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",152,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 17,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",98,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",6,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",51,120150
+WYANDOTTE,Kansas City Ward 07 Precinct 05,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",106,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,Kansas House of Representatives,31,Republican,"Kelb, Tim",26,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 10,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",94,120170
+WYANDOTTE,Kansas City Ward 09 Precinct 01,Kansas House of Representatives,32,Democratic,"Peterson, Michael J. (Mike)",47,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 15,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",289,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 08,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",218,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,Kansas House of Representatives,33,Republican,"Bukaty, Tony",70,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 16,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",1,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 17,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",114,120220
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",331,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,Kansas House of Representatives,33,Republican,"Bukaty, Tony",299,600010
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",210,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,Kansas House of Representatives,33,Republican,"Bukaty, Tony",201,600020
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",460,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,Kansas House of Representatives,33,Republican,"Bukaty, Tony",423,600030
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",292,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,Kansas House of Representatives,33,Republican,"Bukaty, Tony",301,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",133,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,Kansas House of Representatives,33,Republican,"Bukaty, Tony",129,600050
+WYANDOTTE,Delaware Township 01,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",4,600060
+WYANDOTTE,Delaware Township 01,Kansas House of Representatives,33,Republican,"Bukaty, Tony",12,600060
+WYANDOTTE,Kansas City Ward 01 Precinct 01,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",163,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 02,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",172,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 03,Kansas House of Representatives,32,Democratic,"Peterson, Michael J. (Mike)",71,600110
+WYANDOTTE,Kansas City Ward 02 Precinct 01,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",193,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 02,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",179,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 03,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",63,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 04,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",196,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 05,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",335,600160
+WYANDOTTE,Kansas City Ward 03 Precinct 01,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",464,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 02,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",475,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 03,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",111,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 04,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",358,600200
+WYANDOTTE,Kansas City Ward 04 Precinct 01,Kansas House of Representatives,32,Democratic,"Peterson, Michael J. (Mike)",274,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 02,Kansas House of Representatives,32,Democratic,"Peterson, Michael J. (Mike)",74,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 03,Kansas House of Representatives,32,Democratic,"Peterson, Michael J. (Mike)",180,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 04,Kansas House of Representatives,32,Democratic,"Peterson, Michael J. (Mike)",327,600240
+WYANDOTTE,Kansas City Ward 05 Precinct 01,Kansas House of Representatives,32,Democratic,"Peterson, Michael J. (Mike)",243,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 02,Kansas House of Representatives,32,Democratic,"Peterson, Michael J. (Mike)",121,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 03,Kansas House of Representatives,32,Democratic,"Peterson, Michael J. (Mike)",118,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 04,Kansas House of Representatives,32,Democratic,"Peterson, Michael J. (Mike)",123,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 05,Kansas House of Representatives,32,Democratic,"Peterson, Michael J. (Mike)",158,600290
+WYANDOTTE,Kansas City Ward 06 Precinct 01,Kansas House of Representatives,32,Democratic,"Peterson, Michael J. (Mike)",179,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 02,Kansas House of Representatives,32,Democratic,"Peterson, Michael J. (Mike)",51,600310
+WYANDOTTE,Kansas City Ward 07 Precinct 01,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",200,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,Kansas House of Representatives,31,Republican,"Kelb, Tim",77,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 02,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",143,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,Kansas House of Representatives,31,Republican,"Kelb, Tim",46,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 03,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",275,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,Kansas House of Representatives,31,Republican,"Kelb, Tim",78,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 04,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",338,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 06,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",398,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,Kansas House of Representatives,31,Republican,"Kelb, Tim",145,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 07,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",209,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,Kansas House of Representatives,31,Republican,"Kelb, Tim",41,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 08,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",427,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 09,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",442,600400
+WYANDOTTE,Kansas City Ward 08 Precinct 01,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",294,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,Kansas House of Representatives,31,Republican,"Kelb, Tim",81,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 02,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",332,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,Kansas House of Representatives,31,Republican,"Kelb, Tim",77,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 03,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",512,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,Kansas House of Representatives,31,Republican,"Kelb, Tim",132,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 04,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",349,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,Kansas House of Representatives,31,Republican,"Kelb, Tim",113,600440
+WYANDOTTE,Kansas City Ward 09 Precinct 02,Kansas House of Representatives,32,Democratic,"Peterson, Michael J. (Mike)",238,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 03,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",284,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 04,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",89,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 05,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",14,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 06,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",279,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 07,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",334,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 09,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",129,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,Kansas House of Representatives,33,Republican,"Bukaty, Tony",76,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 10,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",416,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,Kansas House of Representatives,33,Republican,"Bukaty, Tony",179,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 11,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",509,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,Kansas House of Representatives,33,Republican,"Bukaty, Tony",151,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 12,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",365,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,Kansas House of Representatives,33,Republican,"Bukaty, Tony",191,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 13,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",242,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,Kansas House of Representatives,33,Republican,"Bukaty, Tony",150,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 14,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",310,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,Kansas House of Representatives,33,Republican,"Bukaty, Tony",207,600580
+WYANDOTTE,Kansas City Ward 10 Precinct 01,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",518,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 02,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",382,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 04,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",279,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 05,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",482,600630
+WYANDOTTE,Kansas City Ward 11 Precinct 01,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",466,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 02,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",408,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 03,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",528,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 04,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",432,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 05,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",405,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 06,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",417,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 07,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",313,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 08,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",448,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 09,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",405,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",16,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",67,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 10,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",472,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",7,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",79,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 11,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",576,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",25,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",177,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 12,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",78,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",5,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",32,600750
+WYANDOTTE,Kansas City Ward 12 Precinct 01,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",278,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,Kansas House of Representatives,31,Republican,"Kelb, Tim",142,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 02,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",134,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,Kansas House of Representatives,31,Republican,"Kelb, Tim",49,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 03,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",283,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,Kansas House of Representatives,31,Republican,"Kelb, Tim",169,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 04,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",308,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,Kansas House of Representatives,31,Republican,"Kelb, Tim",197,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 05,Kansas House of Representatives,31,Democratic,"Ruiz, Louis E.",229,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,Kansas House of Representatives,31,Republican,"Kelb, Tim",213,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 06,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",316,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 07,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",288,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 08,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",330,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 09,Kansas House of Representatives,37,Democratic,"Frownfelter, Stan",346,600850
+WYANDOTTE,Kansas City Ward 13 Precinct 01,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",547,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 02,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",362,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 03,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",361,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 04,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",310,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 05,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",366,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 06,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",332,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 07,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",240,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 08,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",317,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 09,Kansas House of Representatives,34,Democratic,"Winn, Valdenia C.",440,600950
+WYANDOTTE,Kansas City Ward 14 Precinct 01,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",304,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",36,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",200,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 02,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",209,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 03,Kansas House of Representatives,35,Democratic,"Henderson, Broderick",207,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 04,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",376,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",19,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",96,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 05,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",326,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",22,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",105,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 06,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",435,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",30,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",155,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 07,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",537,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",22,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",190,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 09,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",171,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",14,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",133,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 10,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",510,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",21,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",345,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 12,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",472,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",28,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",324,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 13,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",460,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",17,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",217,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 14,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",465,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",27,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",455,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 15,Kansas House of Representatives,36,Democratic,"Moore, Kathy Wolfe",538,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,Kansas House of Representatives,36,Libertarian,"Caldwell, Jeff",24,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,Kansas House of Representatives,36,Republican,"Shipp, Shawn A.",487,601100
+WYANDOTTE,Lake Quivira City Precinct 01,Kansas House of Representatives,33,Democratic,"Burroughs, Tom",15,601110
+WYANDOTTE,Lake Quivira City Precinct 01,Kansas House of Representatives,33,Republican,"Bukaty, Tony",19,601110
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,Kansas Senate,5,Democratic,"Kultala, Kelly",344,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,Kansas Senate,5,Republican,"Fitzgerald, Steve",309,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,Kansas Senate,6,Democratic,"Pettey, Pat",1,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,Kansas Senate,6,Republican,"Steineger, Chris",1,120030
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,Kansas Senate,5,Democratic,"Kultala, Kelly",271,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,Kansas Senate,5,Republican,"Fitzgerald, Steve",369,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,Kansas Senate,6,Democratic,"Pettey, Pat",109,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,Kansas Senate,6,Republican,"Steineger, Chris",101,120050
+WYANDOTTE,Kansas City Ward 10 Precinct 03,Kansas Senate,4,Democratic,"Haley, David",50,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,Kansas Senate,4,Republican,"Ward, Joe",3,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 06,Kansas Senate,4,Democratic,"Haley, David",348,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,Kansas Senate,4,Republican,"Ward, Joe",29,120070
+WYANDOTTE,Kansas City Ward 11 Precinct 13,Kansas Senate,5,Democratic,"Kultala, Kelly",385,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,Kansas Senate,5,Republican,"Fitzgerald, Steve",251,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 14,Kansas Senate,6,Democratic,"Pettey, Pat",11,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,Kansas Senate,6,Republican,"Steineger, Chris",7,120090
+WYANDOTTE,Kansas City Ward 12 Precinct 11,Kansas Senate,6,Democratic,"Pettey, Pat",76,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,Kansas Senate,6,Republican,"Steineger, Chris",117,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 10,Kansas Senate,6,Democratic,"Pettey, Pat",126,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,Kansas Senate,6,Republican,"Steineger, Chris",208,120110
+WYANDOTTE,Kansas City Ward 14 Precinct 08,Kansas Senate,5,Democratic,"Kultala, Kelly",383,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,Kansas Senate,5,Republican,"Fitzgerald, Steve",181,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 16,Kansas Senate,6,Democratic,"Pettey, Pat",96,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,Kansas Senate,6,Republican,"Steineger, Chris",54,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 11,Kansas Senate,5,Democratic,"Kultala, Kelly",348,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,Kansas Senate,5,Republican,"Fitzgerald, Steve",189,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 17,Kansas Senate,6,Democratic,"Pettey, Pat",90,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,Kansas Senate,6,Republican,"Steineger, Chris",63,120150
+WYANDOTTE,Kansas City Ward 07 Precinct 05,Kansas Senate,6,Democratic,"Pettey, Pat",102,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,Kansas Senate,6,Republican,"Steineger, Chris",41,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 10,Kansas Senate,6,Democratic,"Pettey, Pat",99,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,Kansas Senate,6,Republican,"Steineger, Chris",23,120170
+WYANDOTTE,Kansas City Ward 09 Precinct 01,Kansas Senate,4,Democratic,"Haley, David",40,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,Kansas Senate,4,Republican,"Ward, Joe",30,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 15,Kansas Senate,4,Democratic,"Haley, David",267,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,Kansas Senate,4,Republican,"Ward, Joe",111,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 08,Kansas Senate,4,Democratic,"Haley, David",221,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,Kansas Senate,4,Republican,"Ward, Joe",73,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 16,Kansas Senate,4,Democratic,"Haley, David",1,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,Kansas Senate,4,Republican,"Ward, Joe",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 17,Kansas Senate,4,Democratic,"Haley, David",121,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,Kansas Senate,4,Republican,"Ward, Joe",6,120220
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,Kansas Senate,5,Democratic,"Kultala, Kelly",324,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,Kansas Senate,5,Republican,"Fitzgerald, Steve",310,600010
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,Kansas Senate,5,Democratic,"Kultala, Kelly",226,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,Kansas Senate,5,Republican,"Fitzgerald, Steve",200,600020
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,Kansas Senate,5,Democratic,"Kultala, Kelly",473,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,Kansas Senate,5,Republican,"Fitzgerald, Steve",430,600030
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,Kansas Senate,5,Democratic,"Kultala, Kelly",300,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,Kansas Senate,5,Republican,"Fitzgerald, Steve",306,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,Kansas Senate,5,Democratic,"Kultala, Kelly",131,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,Kansas Senate,5,Republican,"Fitzgerald, Steve",133,600050
+WYANDOTTE,Delaware Township 01,Kansas Senate,5,Democratic,"Kultala, Kelly",5,600060
+WYANDOTTE,Delaware Township 01,Kansas Senate,5,Republican,"Fitzgerald, Steve",12,600060
+WYANDOTTE,Kansas City Ward 01 Precinct 01,Kansas Senate,4,Democratic,"Haley, David",184,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,Kansas Senate,4,Republican,"Ward, Joe",11,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 02,Kansas Senate,4,Democratic,"Haley, David",199,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,Kansas Senate,4,Republican,"Ward, Joe",8,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 03,Kansas Senate,4,Democratic,"Haley, David",68,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,Kansas Senate,4,Republican,"Ward, Joe",22,600110
+WYANDOTTE,Kansas City Ward 02 Precinct 01,Kansas Senate,4,Democratic,"Haley, David",195,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,Kansas Senate,4,Republican,"Ward, Joe",51,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 02,Kansas Senate,4,Democratic,"Haley, David",195,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,Kansas Senate,4,Republican,"Ward, Joe",10,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 03,Kansas Senate,4,Democratic,"Haley, David",70,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,Kansas Senate,4,Republican,"Ward, Joe",4,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 04,Kansas Senate,4,Democratic,"Haley, David",210,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,Kansas Senate,4,Republican,"Ward, Joe",12,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 05,Kansas Senate,4,Democratic,"Haley, David",349,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,Kansas Senate,4,Republican,"Ward, Joe",18,600160
+WYANDOTTE,Kansas City Ward 03 Precinct 01,Kansas Senate,4,Democratic,"Haley, David",509,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,Kansas Senate,4,Republican,"Ward, Joe",20,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 02,Kansas Senate,4,Democratic,"Haley, David",556,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,Kansas Senate,4,Republican,"Ward, Joe",9,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 03,Kansas Senate,4,Democratic,"Haley, David",130,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,Kansas Senate,4,Republican,"Ward, Joe",7,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 04,Kansas Senate,4,Democratic,"Haley, David",395,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,Kansas Senate,4,Republican,"Ward, Joe",16,600200
+WYANDOTTE,Kansas City Ward 04 Precinct 01,Kansas Senate,4,Democratic,"Haley, David",272,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,Kansas Senate,4,Republican,"Ward, Joe",76,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 02,Kansas Senate,4,Democratic,"Haley, David",65,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,Kansas Senate,4,Republican,"Ward, Joe",30,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 03,Kansas Senate,4,Democratic,"Haley, David",158,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,Kansas Senate,4,Republican,"Ward, Joe",63,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 04,Kansas Senate,6,Democratic,"Pettey, Pat",295,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,Kansas Senate,6,Republican,"Steineger, Chris",136,600240
+WYANDOTTE,Kansas City Ward 05 Precinct 01,Kansas Senate,4,Democratic,"Haley, David",221,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,Kansas Senate,4,Republican,"Ward, Joe",66,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 02,Kansas Senate,6,Democratic,"Pettey, Pat",116,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,Kansas Senate,6,Republican,"Steineger, Chris",30,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 03,Kansas Senate,6,Democratic,"Pettey, Pat",109,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,Kansas Senate,6,Republican,"Steineger, Chris",28,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 04,Kansas Senate,6,Democratic,"Pettey, Pat",113,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,Kansas Senate,6,Republican,"Steineger, Chris",42,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 05,Kansas Senate,6,Democratic,"Pettey, Pat",151,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,Kansas Senate,6,Republican,"Steineger, Chris",64,600290
+WYANDOTTE,Kansas City Ward 06 Precinct 01,Kansas Senate,6,Democratic,"Pettey, Pat",159,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,Kansas Senate,6,Republican,"Steineger, Chris",79,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 02,Kansas Senate,6,Democratic,"Pettey, Pat",40,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,Kansas Senate,6,Republican,"Steineger, Chris",35,600310
+WYANDOTTE,Kansas City Ward 07 Precinct 01,Kansas Senate,6,Democratic,"Pettey, Pat",187,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,Kansas Senate,6,Republican,"Steineger, Chris",97,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 02,Kansas Senate,6,Democratic,"Pettey, Pat",133,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,Kansas Senate,6,Republican,"Steineger, Chris",59,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 03,Kansas Senate,6,Democratic,"Pettey, Pat",253,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,Kansas Senate,6,Republican,"Steineger, Chris",112,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 04,Kansas Senate,6,Democratic,"Pettey, Pat",267,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,Kansas Senate,6,Republican,"Steineger, Chris",250,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 06,Kansas Senate,6,Democratic,"Pettey, Pat",408,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,Kansas Senate,6,Republican,"Steineger, Chris",150,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 07,Kansas Senate,6,Democratic,"Pettey, Pat",206,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,Kansas Senate,6,Republican,"Steineger, Chris",55,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 08,Kansas Senate,6,Democratic,"Pettey, Pat",375,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,Kansas Senate,6,Republican,"Steineger, Chris",229,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 09,Kansas Senate,6,Democratic,"Pettey, Pat",333,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,Kansas Senate,6,Republican,"Steineger, Chris",263,600400
+WYANDOTTE,Kansas City Ward 08 Precinct 01,Kansas Senate,6,Democratic,"Pettey, Pat",283,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,Kansas Senate,6,Republican,"Steineger, Chris",93,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 02,Kansas Senate,6,Democratic,"Pettey, Pat",325,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,Kansas Senate,6,Republican,"Steineger, Chris",90,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 03,Kansas Senate,6,Democratic,"Pettey, Pat",442,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,Kansas Senate,6,Republican,"Steineger, Chris",213,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 04,Kansas Senate,6,Democratic,"Pettey, Pat",338,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,Kansas Senate,6,Republican,"Steineger, Chris",131,600440
+WYANDOTTE,Kansas City Ward 09 Precinct 02,Kansas Senate,6,Democratic,"Pettey, Pat",212,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,Kansas Senate,6,Republican,"Steineger, Chris",125,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 03,Kansas Senate,4,Democratic,"Haley, David",263,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,Kansas Senate,4,Republican,"Ward, Joe",108,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 04,Kansas Senate,4,Democratic,"Haley, David",87,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,Kansas Senate,4,Republican,"Ward, Joe",37,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 05,Kansas Senate,6,Democratic,"Pettey, Pat",5,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,Kansas Senate,6,Republican,"Steineger, Chris",25,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 06,Kansas Senate,4,Democratic,"Haley, David",298,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,Kansas Senate,4,Republican,"Ward, Joe",63,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 07,Kansas Senate,6,Democratic,"Pettey, Pat",292,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,Kansas Senate,6,Republican,"Steineger, Chris",185,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 09,Kansas Senate,6,Democratic,"Pettey, Pat",123,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,Kansas Senate,6,Republican,"Steineger, Chris",88,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 10,Kansas Senate,6,Democratic,"Pettey, Pat",400,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,Kansas Senate,6,Republican,"Steineger, Chris",206,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 11,Kansas Senate,6,Democratic,"Pettey, Pat",525,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,Kansas Senate,6,Republican,"Steineger, Chris",152,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 12,Kansas Senate,6,Democratic,"Pettey, Pat",343,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,Kansas Senate,6,Republican,"Steineger, Chris",226,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 13,Kansas Senate,6,Democratic,"Pettey, Pat",223,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,Kansas Senate,6,Republican,"Steineger, Chris",167,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 14,Kansas Senate,6,Democratic,"Pettey, Pat",291,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,Kansas Senate,6,Republican,"Steineger, Chris",240,600580
+WYANDOTTE,Kansas City Ward 10 Precinct 01,Kansas Senate,4,Democratic,"Haley, David",554,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,Kansas Senate,4,Republican,"Ward, Joe",19,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 02,Kansas Senate,4,Democratic,"Haley, David",429,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,Kansas Senate,4,Republican,"Ward, Joe",18,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 04,Kansas Senate,4,Democratic,"Haley, David",307,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,Kansas Senate,4,Republican,"Ward, Joe",17,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 05,Kansas Senate,4,Democratic,"Haley, David",473,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,Kansas Senate,4,Republican,"Ward, Joe",118,600630
+WYANDOTTE,Kansas City Ward 11 Precinct 01,Kansas Senate,4,Democratic,"Haley, David",489,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,Kansas Senate,4,Republican,"Ward, Joe",77,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 02,Kansas Senate,4,Democratic,"Haley, David",419,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,Kansas Senate,4,Republican,"Ward, Joe",60,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 03,Kansas Senate,4,Democratic,"Haley, David",511,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,Kansas Senate,4,Republican,"Ward, Joe",118,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 04,Kansas Senate,4,Democratic,"Haley, David",430,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,Kansas Senate,4,Republican,"Ward, Joe",91,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 05,Kansas Senate,4,Democratic,"Haley, David",417,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,Kansas Senate,4,Republican,"Ward, Joe",100,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 06,Kansas Senate,4,Democratic,"Haley, David",439,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,Kansas Senate,4,Republican,"Ward, Joe",52,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 07,Kansas Senate,4,Democratic,"Haley, David",300,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,Kansas Senate,4,Republican,"Ward, Joe",88,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 08,Kansas Senate,4,Democratic,"Haley, David",461,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,Kansas Senate,4,Republican,"Ward, Joe",62,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 09,Kansas Senate,4,Democratic,"Haley, David",402,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,Kansas Senate,4,Republican,"Ward, Joe",96,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 10,Kansas Senate,4,Democratic,"Haley, David",446,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,Kansas Senate,4,Republican,"Ward, Joe",117,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 11,Kansas Senate,4,Democratic,"Haley, David",529,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,Kansas Senate,4,Republican,"Ward, Joe",246,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 12,Kansas Senate,6,Democratic,"Pettey, Pat",72,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,Kansas Senate,6,Republican,"Steineger, Chris",41,600750
+WYANDOTTE,Kansas City Ward 12 Precinct 01,Kansas Senate,6,Democratic,"Pettey, Pat",256,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,Kansas Senate,6,Republican,"Steineger, Chris",170,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 02,Kansas Senate,6,Democratic,"Pettey, Pat",132,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,Kansas Senate,6,Republican,"Steineger, Chris",58,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 03,Kansas Senate,6,Democratic,"Pettey, Pat",273,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,Kansas Senate,6,Republican,"Steineger, Chris",192,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 04,Kansas Senate,6,Democratic,"Pettey, Pat",314,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,Kansas Senate,6,Republican,"Steineger, Chris",206,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 05,Kansas Senate,6,Democratic,"Pettey, Pat",222,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,Kansas Senate,6,Republican,"Steineger, Chris",234,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 06,Kansas Senate,6,Democratic,"Pettey, Pat",264,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,Kansas Senate,6,Republican,"Steineger, Chris",176,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 07,Kansas Senate,6,Democratic,"Pettey, Pat",223,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,Kansas Senate,6,Republican,"Steineger, Chris",167,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 08,Kansas Senate,6,Democratic,"Pettey, Pat",273,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,Kansas Senate,6,Republican,"Steineger, Chris",187,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 09,Kansas Senate,6,Democratic,"Pettey, Pat",297,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,Kansas Senate,6,Republican,"Steineger, Chris",202,600850
+WYANDOTTE,Kansas City Ward 13 Precinct 01,Kansas Senate,4,Democratic,"Haley, David",559,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,Kansas Senate,4,Republican,"Ward, Joe",79,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 02,Kansas Senate,4,Democratic,"Haley, David",330,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,Kansas Senate,4,Republican,"Ward, Joe",149,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 03,Kansas Senate,4,Democratic,"Haley, David",362,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,Kansas Senate,4,Republican,"Ward, Joe",85,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 04,Kansas Senate,4,Democratic,"Haley, David",339,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,Kansas Senate,4,Republican,"Ward, Joe",27,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 05,Kansas Senate,4,Democratic,"Haley, David",338,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,Kansas Senate,4,Republican,"Ward, Joe",144,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 06,Kansas Senate,4,Democratic,"Haley, David",337,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,Kansas Senate,4,Republican,"Ward, Joe",117,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 07,Kansas Senate,4,Democratic,"Haley, David",187,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,Kansas Senate,4,Republican,"Ward, Joe",163,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 08,Kansas Senate,4,Democratic,"Haley, David",290,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,Kansas Senate,4,Republican,"Ward, Joe",121,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 09,Kansas Senate,4,Democratic,"Haley, David",424,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,Kansas Senate,4,Republican,"Ward, Joe",123,600950
+WYANDOTTE,Kansas City Ward 14 Precinct 01,Kansas Senate,4,Democratic,"Haley, David",278,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,Kansas Senate,4,Republican,"Ward, Joe",265,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 02,Kansas Senate,4,Democratic,"Haley, David",184,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,Kansas Senate,4,Republican,"Ward, Joe",94,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 03,Kansas Senate,4,Democratic,"Haley, David",191,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,Kansas Senate,4,Republican,"Ward, Joe",80,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 04,Kansas Senate,4,Democratic,"Haley, David",388,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,Kansas Senate,4,Republican,"Ward, Joe",110,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 05,Kansas Senate,4,Democratic,"Haley, David",291,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,Kansas Senate,4,Republican,"Ward, Joe",162,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 06,Kansas Senate,4,Democratic,"Haley, David",372,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,Kansas Senate,4,Republican,"Ward, Joe",246,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 07,Kansas Senate,4,Democratic,"Haley, David",480,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,Kansas Senate,4,Republican,"Ward, Joe",267,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 09,Kansas Senate,5,Democratic,"Kultala, Kelly",153,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,Kansas Senate,5,Republican,"Fitzgerald, Steve",166,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 10,Kansas Senate,5,Democratic,"Kultala, Kelly",486,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,Kansas Senate,5,Republican,"Fitzgerald, Steve",385,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 12,Kansas Senate,5,Democratic,"Kultala, Kelly",448,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,Kansas Senate,5,Republican,"Fitzgerald, Steve",374,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 13,Kansas Senate,5,Democratic,"Kultala, Kelly",459,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,Kansas Senate,5,Republican,"Fitzgerald, Steve",225,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 14,Kansas Senate,5,Democratic,"Kultala, Kelly",483,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,Kansas Senate,5,Republican,"Fitzgerald, Steve",464,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 15,Kansas Senate,5,Democratic,"Kultala, Kelly",503,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,Kansas Senate,5,Republican,"Fitzgerald, Steve",547,601100
+WYANDOTTE,Lake Quivira City Precinct 01,Kansas Senate,10,Democratic,"Greene, Mark J.",14,601110
+WYANDOTTE,Lake Quivira City Precinct 01,Kansas Senate,10,Republican,"Pilcher-Cook, Mary",21,601110
+WYANDOTTE,ADVANCED,Kansas Senate,4,Democratic,"Haley, David",0,999998
+WYANDOTTE,ADVANCED,Kansas Senate,4,Republican,"Ward, Joe",0,999998
+WYANDOTTE,ADVANCED,Kansas Senate,5,Democratic,"Kultala, Kelly",0,999998
+WYANDOTTE,ADVANCED,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,999998
+WYANDOTTE,ADVANCED,Kansas Senate,6,Democratic,"Pettey, Pat",0,999998
+WYANDOTTE,ADVANCED,Kansas Senate,6,Republican,"Steineger, Chris",0,999998
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",319,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",15,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",7,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",359,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",1,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",0,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",2,120030
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",246,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",8,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",5,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",416,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",98,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",9,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",0,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",114,120050
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",54,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",0,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",1,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Ayers, Avery L",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Barnett, Andre",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Barr, Roseanne C",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Bush, Kent W",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Christensen, Will",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Duncan, Richard A",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Goode, Virgil",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Knill, Dennis J",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Reed, Jill A.",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Rogers, Rick L",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Stein, Jill E",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Thorne, Kevin M",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,write - in,"Warner, Gerald L.",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,Democratic,"Obama, Barack",365,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",1,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,Reform,"Baldwin, Chuck",0,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,President / Vice President,,Republican,"Romney, Mitt",28,120070
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Ayers, Avery L",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Barnett, Andre",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Barr, Roseanne C",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Bush, Kent W",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Christensen, Will",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Duncan, Richard A",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Goode, Virgil",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Knill, Dennis J",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Reed, Jill A.",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Rogers, Rick L",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Stein, Jill E",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Thorne, Kevin M",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,write - in,"Warner, Gerald L.",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,Democratic,"Obama, Barack",367,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,Libertarian,"Johnson, Gary",10,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,Reform,"Baldwin, Chuck",0,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,President / Vice President,,Republican,"Romney, Mitt",283,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Ayers, Avery L",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Barnett, Andre",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Barr, Roseanne C",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Bush, Kent W",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Christensen, Will",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Duncan, Richard A",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Goode, Virgil",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Knill, Dennis J",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Reed, Jill A.",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Rogers, Rick L",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Stein, Jill E",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Thorne, Kevin M",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,write - in,"Warner, Gerald L.",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,Democratic,"Obama, Barack",11,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,Libertarian,"Johnson, Gary",1,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,Reform,"Baldwin, Chuck",0,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,President / Vice President,,Republican,"Romney, Mitt",6,120090
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Ayers, Avery L",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Barnett, Andre",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Barr, Roseanne C",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Bush, Kent W",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Christensen, Will",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Duncan, Richard A",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Goode, Virgil",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Hoefling, Tom",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Knill, Dennis J",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Reed, Jill A.",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Rogers, Rick L",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Stein, Jill E",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Thorne, Kevin M",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,write - in,"Warner, Gerald L.",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,Democratic,"Obama, Barack",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,Reform,"Baldwin, Chuck",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 10 H33 A,President / Vice President,,Republican,"Romney, Mitt",0,12010A
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Ayers, Avery L",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Barnett, Andre",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Barr, Roseanne C",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Bush, Kent W",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Christensen, Will",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Duncan, Richard A",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Goode, Virgil",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Knill, Dennis J",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Reed, Jill A.",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Rogers, Rick L",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Stein, Jill E",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Thorne, Kevin M",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,write - in,"Warner, Gerald L.",0,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,Democratic,"Obama, Barack",85,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",1,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,Reform,"Baldwin, Chuck",1,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,President / Vice President,,Republican,"Romney, Mitt",114,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Ayers, Avery L",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Barnett, Andre",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Barr, Roseanne C",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Bush, Kent W",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Christensen, Will",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Duncan, Richard A",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Goode, Virgil",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Knill, Dennis J",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Reed, Jill A.",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Rogers, Rick L",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Stein, Jill E",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Thorne, Kevin M",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,write - in,"Warner, Gerald L.",0,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,Democratic,"Obama, Barack",139,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",5,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,Reform,"Baldwin, Chuck",1,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,President / Vice President,,Republican,"Romney, Mitt",197,120110
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Ayers, Avery L",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Barnett, Andre",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Barr, Roseanne C",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Bush, Kent W",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Christensen, Will",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Duncan, Richard A",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Goode, Virgil",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Knill, Dennis J",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Reed, Jill A.",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Rogers, Rick L",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Stein, Jill E",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Thorne, Kevin M",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,write - in,"Warner, Gerald L.",0,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,Democratic,"Obama, Barack",372,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",4,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,Reform,"Baldwin, Chuck",1,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,President / Vice President,,Republican,"Romney, Mitt",205,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Ayers, Avery L",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Barnett, Andre",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Barr, Roseanne C",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Bush, Kent W",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Christensen, Will",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Duncan, Richard A",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Goode, Virgil",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Hoefling, Tom",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Knill, Dennis J",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Reed, Jill A.",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Rogers, Rick L",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Stein, Jill E",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Thorne, Kevin M",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,write - in,"Warner, Gerald L.",0,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,Democratic,"Obama, Barack",90,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,Libertarian,"Johnson, Gary",1,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,Reform,"Baldwin, Chuck",1,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,President / Vice President,,Republican,"Romney, Mitt",66,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Ayers, Avery L",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Barnett, Andre",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Barr, Roseanne C",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Bush, Kent W",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Christensen, Will",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Duncan, Richard A",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Goode, Virgil",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Knill, Dennis J",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Reed, Jill A.",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Rogers, Rick L",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Stein, Jill E",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Thorne, Kevin M",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,write - in,"Warner, Gerald L.",0,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,Democratic,"Obama, Barack",323,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",3,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,Reform,"Baldwin, Chuck",1,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,President / Vice President,,Republican,"Romney, Mitt",229,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Ayers, Avery L",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Barnett, Andre",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Barr, Roseanne C",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Bush, Kent W",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Christensen, Will",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Duncan, Richard A",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Goode, Virgil",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Hoefling, Tom",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Knill, Dennis J",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Reed, Jill A.",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Rogers, Rick L",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Stein, Jill E",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Thorne, Kevin M",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,write - in,"Warner, Gerald L.",0,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,Democratic,"Obama, Barack",76,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,Libertarian,"Johnson, Gary",1,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,Reform,"Baldwin, Chuck",2,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,President / Vice President,,Republican,"Romney, Mitt",81,120150
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,Democratic,"Obama, Barack",114,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",1,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",0,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,President / Vice President,,Republican,"Romney, Mitt",30,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Ayers, Avery L",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Barnett, Andre",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Barr, Roseanne C",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Bush, Kent W",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Christensen, Will",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Duncan, Richard A",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Goode, Virgil",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Knill, Dennis J",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Reed, Jill A.",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Rogers, Rick L",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Stein, Jill E",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Thorne, Kevin M",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,write - in,"Warner, Gerald L.",0,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,Democratic,"Obama, Barack",95,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",2,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,Reform,"Baldwin, Chuck",2,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,President / Vice President,,Republican,"Romney, Mitt",30,120170
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",42,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",2,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",0,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",30,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Ayers, Avery L",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Barnett, Andre",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Barr, Roseanne C",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Bush, Kent W",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Christensen, Will",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Duncan, Richard A",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Goode, Virgil",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Hoefling, Tom",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Knill, Dennis J",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Reed, Jill A.",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Rogers, Rick L",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Stein, Jill E",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Thorne, Kevin M",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,write - in,"Warner, Gerald L.",0,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,Democratic,"Obama, Barack",290,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,Libertarian,"Johnson, Gary",4,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,Reform,"Baldwin, Chuck",2,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,President / Vice President,,Republican,"Romney, Mitt",106,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Ayers, Avery L",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Barnett, Andre",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Barr, Roseanne C",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Bush, Kent W",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Christensen, Will",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Duncan, Richard A",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Goode, Virgil",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Knill, Dennis J",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Reed, Jill A.",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Rogers, Rick L",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Stein, Jill E",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Thorne, Kevin M",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,write - in,"Warner, Gerald L.",0,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,Democratic,"Obama, Barack",226,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",4,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,Reform,"Baldwin, Chuck",1,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,President / Vice President,,Republican,"Romney, Mitt",79,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Ayers, Avery L",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Barnett, Andre",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Barr, Roseanne C",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Bush, Kent W",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Christensen, Will",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Duncan, Richard A",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Goode, Virgil",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Hoefling, Tom",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Knill, Dennis J",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Reed, Jill A.",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Rogers, Rick L",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Stein, Jill E",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Thorne, Kevin M",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,write - in,"Warner, Gerald L.",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,Democratic,"Obama, Barack",1,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,Libertarian,"Johnson, Gary",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,Reform,"Baldwin, Chuck",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,President / Vice President,,Republican,"Romney, Mitt",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Ayers, Avery L",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Barnett, Andre",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Barr, Roseanne C",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Bush, Kent W",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Christensen, Will",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Duncan, Richard A",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Goode, Virgil",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Hoefling, Tom",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Knill, Dennis J",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Reed, Jill A.",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Rogers, Rick L",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Stein, Jill E",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Thorne, Kevin M",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,write - in,"Warner, Gerald L.",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,Democratic,"Obama, Barack",131,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,Libertarian,"Johnson, Gary",1,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,Reform,"Baldwin, Chuck",0,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,President / Vice President,,Republican,"Romney, Mitt",6,120220
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",318,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",15,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",5,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",338,600010
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",198,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",13,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",4,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",241,600020
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",454,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",15,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",7,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",461,600030
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",277,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",15,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",2,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",339,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",125,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",2,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",1,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",140,600050
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Ayers, Avery L",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Barnett, Andre",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Bush, Kent W",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Christensen, Will",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Duncan, Richard A",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Goode, Virgil",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Hoefling, Tom",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Knill, Dennis J",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Reed, Jill A.",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Rogers, Rick L",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Stein, Jill E",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,Democratic,"Obama, Barack",5,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,Libertarian,"Johnson, Gary",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,Reform,"Baldwin, Chuck",0,600060
+WYANDOTTE,Delaware Township 01,President / Vice President,,Republican,"Romney, Mitt",12,600060
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",205,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",4,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",0,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",2,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",218,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",0,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",7,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",71,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",2,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",0,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",23,600110
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",203,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",9,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",0,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",41,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",207,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",1,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",1,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",6,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",75,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",0,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",3,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",229,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",0,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",1,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",7,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,Democratic,"Obama, Barack",380,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",1,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",3,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,President / Vice President,,Republican,"Romney, Mitt",15,600160
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",544,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",0,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",13,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",610,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",1,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",1,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",2,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",135,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",1,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",1,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",6,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",428,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",0,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",11,600200
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",277,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",4,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",5,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",87,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",79,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",4,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",1,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",17,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",185,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",5,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",2,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",48,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",281,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",20,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",2,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",148,600240
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",242,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",2,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",2,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",67,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",140,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",3,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",0,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",18,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",127,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",1,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",2,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",22,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",124,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",1,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",0,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",38,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,Democratic,"Obama, Barack",164,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",7,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",2,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,President / Vice President,,Republican,"Romney, Mitt",60,600290
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",164,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",10,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",0,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",86,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",47,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",0,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",34,600310
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",199,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",10,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",0,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",90,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",142,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",1,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",0,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",60,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",292,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",0,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",95,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",275,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",13,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",4,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",256,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Ayers, Avery L",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Barnett, Andre",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Barr, Roseanne C",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Bush, Kent W",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Christensen, Will",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Duncan, Richard A",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Goode, Virgil",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Knill, Dennis J",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Reed, Jill A.",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Rogers, Rick L",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Stein, Jill E",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Thorne, Kevin M",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,write - in,"Warner, Gerald L.",0,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,Democratic,"Obama, Barack",420,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",7,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,Reform,"Baldwin, Chuck",2,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,President / Vice President,,Republican,"Romney, Mitt",153,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Ayers, Avery L",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Barnett, Andre",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Barr, Roseanne C",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Bush, Kent W",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Christensen, Will",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Duncan, Richard A",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Goode, Virgil",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Knill, Dennis J",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Reed, Jill A.",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Rogers, Rick L",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Stein, Jill E",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Thorne, Kevin M",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,write - in,"Warner, Gerald L.",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,Democratic,"Obama, Barack",232,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",4,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,Reform,"Baldwin, Chuck",0,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,President / Vice President,,Republican,"Romney, Mitt",42,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Ayers, Avery L",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Barnett, Andre",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Barr, Roseanne C",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Bush, Kent W",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Christensen, Will",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Duncan, Richard A",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Goode, Virgil",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Knill, Dennis J",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Reed, Jill A.",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Rogers, Rick L",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Stein, Jill E",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Thorne, Kevin M",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,write - in,"Warner, Gerald L.",0,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,Democratic,"Obama, Barack",384,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",13,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,Reform,"Baldwin, Chuck",2,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,President / Vice President,,Republican,"Romney, Mitt",225,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Ayers, Avery L",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Barnett, Andre",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Barr, Roseanne C",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Bush, Kent W",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Christensen, Will",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Duncan, Richard A",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Goode, Virgil",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Knill, Dennis J",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Reed, Jill A.",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Rogers, Rick L",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Stein, Jill E",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Thorne, Kevin M",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,write - in,"Warner, Gerald L.",0,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,Democratic,"Obama, Barack",379,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",10,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,Reform,"Baldwin, Chuck",5,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,President / Vice President,,Republican,"Romney, Mitt",222,600400
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",298,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",11,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",0,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",90,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",346,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",11,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",1,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",78,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",481,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",24,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",0,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",167,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",365,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",18,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",0,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",114,600440
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",220,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",5,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",4,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",126,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",288,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",2,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",3,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",115,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",81,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",4,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",0,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",46,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,Democratic,"Obama, Barack",6,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",0,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,President / Vice President,,Republican,"Romney, Mitt",24,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Ayers, Avery L",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Barnett, Andre",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Barr, Roseanne C",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Bush, Kent W",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Christensen, Will",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Duncan, Richard A",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Goode, Virgil",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Knill, Dennis J",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Reed, Jill A.",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Rogers, Rick L",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Stein, Jill E",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Thorne, Kevin M",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,write - in,"Warner, Gerald L.",0,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,Democratic,"Obama, Barack",307,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",7,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,Reform,"Baldwin, Chuck",1,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,President / Vice President,,Republican,"Romney, Mitt",64,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Ayers, Avery L",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Barnett, Andre",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Barr, Roseanne C",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Bush, Kent W",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Christensen, Will",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Duncan, Richard A",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Goode, Virgil",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Knill, Dennis J",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Reed, Jill A.",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Rogers, Rick L",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Stein, Jill E",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Thorne, Kevin M",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,write - in,"Warner, Gerald L.",0,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,Democratic,"Obama, Barack",316,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",6,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,Reform,"Baldwin, Chuck",5,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,President / Vice President,,Republican,"Romney, Mitt",186,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Ayers, Avery L",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Barnett, Andre",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Barr, Roseanne C",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Bush, Kent W",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Christensen, Will",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Duncan, Richard A",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Goode, Virgil",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Knill, Dennis J",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Reed, Jill A.",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Rogers, Rick L",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Stein, Jill E",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Thorne, Kevin M",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,write - in,"Warner, Gerald L.",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,Democratic,"Obama, Barack",133,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",3,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,Reform,"Baldwin, Chuck",0,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,President / Vice President,,Republican,"Romney, Mitt",90,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Ayers, Avery L",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Barnett, Andre",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Barr, Roseanne C",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Bush, Kent W",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Christensen, Will",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Duncan, Richard A",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Goode, Virgil",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Knill, Dennis J",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Reed, Jill A.",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Rogers, Rick L",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Stein, Jill E",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Thorne, Kevin M",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,write - in,"Warner, Gerald L.",0,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,Democratic,"Obama, Barack",418,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",8,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,Reform,"Baldwin, Chuck",2,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,President / Vice President,,Republican,"Romney, Mitt",198,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Ayers, Avery L",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Barnett, Andre",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Barr, Roseanne C",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Bush, Kent W",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Christensen, Will",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Duncan, Richard A",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Goode, Virgil",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Knill, Dennis J",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Reed, Jill A.",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Rogers, Rick L",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Stein, Jill E",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Thorne, Kevin M",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,write - in,"Warner, Gerald L.",0,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,Democratic,"Obama, Barack",540,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",6,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,Reform,"Baldwin, Chuck",1,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,President / Vice President,,Republican,"Romney, Mitt",157,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Ayers, Avery L",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Barnett, Andre",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Barr, Roseanne C",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Bush, Kent W",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Christensen, Will",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Duncan, Richard A",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Goode, Virgil",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Hoefling, Tom",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Knill, Dennis J",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Reed, Jill A.",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Rogers, Rick L",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Stein, Jill E",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Thorne, Kevin M",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,write - in,"Warner, Gerald L.",0,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,Democratic,"Obama, Barack",369,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,Libertarian,"Johnson, Gary",8,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,Reform,"Baldwin, Chuck",3,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,President / Vice President,,Republican,"Romney, Mitt",215,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Ayers, Avery L",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Barnett, Andre",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Barr, Roseanne C",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Bush, Kent W",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Christensen, Will",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Duncan, Richard A",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Goode, Virgil",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Hoefling, Tom",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Knill, Dennis J",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Reed, Jill A.",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Rogers, Rick L",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Stein, Jill E",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Thorne, Kevin M",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,write - in,"Warner, Gerald L.",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,Democratic,"Obama, Barack",230,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,Libertarian,"Johnson, Gary",9,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,Reform,"Baldwin, Chuck",0,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,President / Vice President,,Republican,"Romney, Mitt",173,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Ayers, Avery L",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Barnett, Andre",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Barr, Roseanne C",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Bush, Kent W",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Christensen, Will",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Duncan, Richard A",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Goode, Virgil",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Hoefling, Tom",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Knill, Dennis J",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Reed, Jill A.",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Rogers, Rick L",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Stein, Jill E",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Thorne, Kevin M",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,write - in,"Warner, Gerald L.",0,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,Democratic,"Obama, Barack",312,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,Libertarian,"Johnson, Gary",9,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,Reform,"Baldwin, Chuck",6,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,President / Vice President,,Republican,"Romney, Mitt",232,600580
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",593,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",3,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",0,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",12,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",464,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",0,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",8,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",318,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",1,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",0,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",23,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,Democratic,"Obama, Barack",496,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",5,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",2,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,President / Vice President,,Republican,"Romney, Mitt",113,600630
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",515,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",4,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",1,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",71,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",438,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",2,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",0,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",49,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",571,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",4,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",2,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",112,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",470,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",6,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",3,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",76,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,Democratic,"Obama, Barack",464,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",3,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",3,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,President / Vice President,,Republican,"Romney, Mitt",94,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Ayers, Avery L",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Barnett, Andre",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Barr, Roseanne C",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Bush, Kent W",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Christensen, Will",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Duncan, Richard A",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Goode, Virgil",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Knill, Dennis J",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Reed, Jill A.",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Rogers, Rick L",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Stein, Jill E",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Thorne, Kevin M",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,write - in,"Warner, Gerald L.",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,Democratic,"Obama, Barack",475,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",1,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,Reform,"Baldwin, Chuck",0,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,President / Vice President,,Republican,"Romney, Mitt",44,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Ayers, Avery L",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Barnett, Andre",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Barr, Roseanne C",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Bush, Kent W",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Christensen, Will",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Duncan, Richard A",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Goode, Virgil",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Knill, Dennis J",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Reed, Jill A.",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Rogers, Rick L",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Stein, Jill E",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Thorne, Kevin M",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,write - in,"Warner, Gerald L.",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,Democratic,"Obama, Barack",314,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",8,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,Reform,"Baldwin, Chuck",0,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,President / Vice President,,Republican,"Romney, Mitt",85,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Ayers, Avery L",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Barnett, Andre",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Barr, Roseanne C",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Bush, Kent W",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Christensen, Will",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Duncan, Richard A",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Goode, Virgil",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Knill, Dennis J",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Reed, Jill A.",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Rogers, Rick L",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Stein, Jill E",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Thorne, Kevin M",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,write - in,"Warner, Gerald L.",0,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,Democratic,"Obama, Barack",502,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",4,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,Reform,"Baldwin, Chuck",1,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,President / Vice President,,Republican,"Romney, Mitt",51,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Ayers, Avery L",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Barnett, Andre",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Barr, Roseanne C",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Bush, Kent W",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Christensen, Will",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Duncan, Richard A",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Goode, Virgil",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Knill, Dennis J",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Reed, Jill A.",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Rogers, Rick L",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Stein, Jill E",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Thorne, Kevin M",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,write - in,"Warner, Gerald L.",0,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,Democratic,"Obama, Barack",429,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",6,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,Reform,"Baldwin, Chuck",2,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,President / Vice President,,Republican,"Romney, Mitt",91,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Ayers, Avery L",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Barnett, Andre",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Barr, Roseanne C",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Bush, Kent W",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Christensen, Will",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Duncan, Richard A",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Goode, Virgil",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Knill, Dennis J",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Reed, Jill A.",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Rogers, Rick L",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Stein, Jill E",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Thorne, Kevin M",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,write - in,"Warner, Gerald L.",0,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,Democratic,"Obama, Barack",475,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",3,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,Reform,"Baldwin, Chuck",2,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,President / Vice President,,Republican,"Romney, Mitt",109,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Ayers, Avery L",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Barnett, Andre",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Barr, Roseanne C",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Bush, Kent W",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Christensen, Will",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Duncan, Richard A",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Goode, Virgil",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Knill, Dennis J",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Reed, Jill A.",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Rogers, Rick L",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Stein, Jill E",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Thorne, Kevin M",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,write - in,"Warner, Gerald L.",0,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,Democratic,"Obama, Barack",552,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",4,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,Reform,"Baldwin, Chuck",1,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,President / Vice President,,Republican,"Romney, Mitt",246,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Ayers, Avery L",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Barnett, Andre",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Barr, Roseanne C",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Bush, Kent W",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Christensen, Will",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Duncan, Richard A",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Goode, Virgil",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Hoefling, Tom",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Knill, Dennis J",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Reed, Jill A.",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Rogers, Rick L",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Stein, Jill E",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Thorne, Kevin M",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,write - in,"Warner, Gerald L.",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,Democratic,"Obama, Barack",67,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,Libertarian,"Johnson, Gary",1,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,Reform,"Baldwin, Chuck",0,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,President / Vice President,,Republican,"Romney, Mitt",50,600750
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",288,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",9,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",3,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",142,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",150,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",8,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",1,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",46,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",284,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",7,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",3,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",191,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",291,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",18,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",4,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",220,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,Democratic,"Obama, Barack",221,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",7,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",3,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,President / Vice President,,Republican,"Romney, Mitt",239,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Ayers, Avery L",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Barnett, Andre",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Barr, Roseanne C",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Bush, Kent W",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Christensen, Will",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Duncan, Richard A",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Goode, Virgil",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Knill, Dennis J",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Reed, Jill A.",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Rogers, Rick L",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Stein, Jill E",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Thorne, Kevin M",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,write - in,"Warner, Gerald L.",0,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,Democratic,"Obama, Barack",256,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",13,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,Reform,"Baldwin, Chuck",2,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,President / Vice President,,Republican,"Romney, Mitt",194,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Ayers, Avery L",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Barnett, Andre",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Barr, Roseanne C",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Bush, Kent W",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Christensen, Will",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Duncan, Richard A",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Goode, Virgil",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Knill, Dennis J",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Reed, Jill A.",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Rogers, Rick L",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Stein, Jill E",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Thorne, Kevin M",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,write - in,"Warner, Gerald L.",0,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,Democratic,"Obama, Barack",230,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",12,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,Reform,"Baldwin, Chuck",5,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,President / Vice President,,Republican,"Romney, Mitt",167,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Ayers, Avery L",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Barnett, Andre",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Barr, Roseanne C",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Bush, Kent W",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Christensen, Will",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Duncan, Richard A",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Goode, Virgil",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Knill, Dennis J",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Reed, Jill A.",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Rogers, Rick L",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Stein, Jill E",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Thorne, Kevin M",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,write - in,"Warner, Gerald L.",0,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,Democratic,"Obama, Barack",274,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",16,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,Reform,"Baldwin, Chuck",3,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,President / Vice President,,Republican,"Romney, Mitt",191,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Ayers, Avery L",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Barnett, Andre",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Barr, Roseanne C",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Bush, Kent W",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Christensen, Will",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Duncan, Richard A",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Goode, Virgil",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Knill, Dennis J",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Reed, Jill A.",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Rogers, Rick L",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Stein, Jill E",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Thorne, Kevin M",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,write - in,"Warner, Gerald L.",0,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,Democratic,"Obama, Barack",287,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",10,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,Reform,"Baldwin, Chuck",1,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,President / Vice President,,Republican,"Romney, Mitt",224,600850
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",595,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",1,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",2,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",70,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",362,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",14,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",2,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",138,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",385,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",7,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",3,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",76,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",352,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",2,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",3,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",21,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,Democratic,"Obama, Barack",359,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",6,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",1,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,President / Vice President,,Republican,"Romney, Mitt",147,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Ayers, Avery L",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Barnett, Andre",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Barr, Roseanne C",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Bush, Kent W",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Christensen, Will",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Duncan, Richard A",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Goode, Virgil",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Knill, Dennis J",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Reed, Jill A.",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Rogers, Rick L",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Stein, Jill E",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Thorne, Kevin M",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,write - in,"Warner, Gerald L.",0,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,Democratic,"Obama, Barack",337,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",13,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,Reform,"Baldwin, Chuck",2,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,President / Vice President,,Republican,"Romney, Mitt",129,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Ayers, Avery L",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Barnett, Andre",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Barr, Roseanne C",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Bush, Kent W",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Christensen, Will",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Duncan, Richard A",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Goode, Virgil",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Knill, Dennis J",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Reed, Jill A.",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Rogers, Rick L",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Stein, Jill E",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Thorne, Kevin M",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,write - in,"Warner, Gerald L.",0,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,Democratic,"Obama, Barack",203,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",5,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,Reform,"Baldwin, Chuck",4,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,President / Vice President,,Republican,"Romney, Mitt",150,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Ayers, Avery L",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Barnett, Andre",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Barr, Roseanne C",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Bush, Kent W",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Christensen, Will",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Duncan, Richard A",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Goode, Virgil",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Knill, Dennis J",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Reed, Jill A.",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Rogers, Rick L",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Stein, Jill E",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Thorne, Kevin M",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,write - in,"Warner, Gerald L.",0,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,Democratic,"Obama, Barack",306,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",3,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,Reform,"Baldwin, Chuck",4,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,President / Vice President,,Republican,"Romney, Mitt",124,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Ayers, Avery L",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Barnett, Andre",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Barr, Roseanne C",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Bush, Kent W",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Christensen, Will",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Duncan, Richard A",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Goode, Virgil",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Knill, Dennis J",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Reed, Jill A.",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Rogers, Rick L",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Stein, Jill E",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Thorne, Kevin M",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,write - in,"Warner, Gerald L.",0,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,Democratic,"Obama, Barack",449,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",6,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,Reform,"Baldwin, Chuck",1,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,President / Vice President,,Republican,"Romney, Mitt",115,600950
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,Democratic,"Obama, Barack",296,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",12,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",4,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,President / Vice President,,Republican,"Romney, Mitt",262,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Ayers, Avery L",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Barnett, Andre",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Barr, Roseanne C",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Bush, Kent W",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Christensen, Will",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Duncan, Richard A",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Goode, Virgil",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Knill, Dennis J",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Reed, Jill A.",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Rogers, Rick L",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Stein, Jill E",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Thorne, Kevin M",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,write - in,"Warner, Gerald L.",0,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,Democratic,"Obama, Barack",195,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",5,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,Reform,"Baldwin, Chuck",2,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,President / Vice President,,Republican,"Romney, Mitt",85,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Ayers, Avery L",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Barnett, Andre",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Barr, Roseanne C",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Bush, Kent W",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Christensen, Will",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Duncan, Richard A",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Goode, Virgil",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Knill, Dennis J",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Reed, Jill A.",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Rogers, Rick L",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Stein, Jill E",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Thorne, Kevin M",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,write - in,"Warner, Gerald L.",0,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,Democratic,"Obama, Barack",191,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",3,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,Reform,"Baldwin, Chuck",1,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,President / Vice President,,Republican,"Romney, Mitt",79,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Ayers, Avery L",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Barnett, Andre",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Barr, Roseanne C",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Bush, Kent W",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Christensen, Will",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Duncan, Richard A",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Goode, Virgil",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Knill, Dennis J",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Reed, Jill A.",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Rogers, Rick L",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Stein, Jill E",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Thorne, Kevin M",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,write - in,"Warner, Gerald L.",0,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,Democratic,"Obama, Barack",400,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",5,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,Reform,"Baldwin, Chuck",1,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,President / Vice President,,Republican,"Romney, Mitt",113,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Ayers, Avery L",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Barnett, Andre",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Barr, Roseanne C",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Bush, Kent W",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Christensen, Will",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Duncan, Richard A",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Goode, Virgil",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Knill, Dennis J",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Reed, Jill A.",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Rogers, Rick L",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Stein, Jill E",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Thorne, Kevin M",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,write - in,"Warner, Gerald L.",0,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,Democratic,"Obama, Barack",317,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",7,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,Reform,"Baldwin, Chuck",5,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,President / Vice President,,Republican,"Romney, Mitt",151,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Ayers, Avery L",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Barnett, Andre",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Barr, Roseanne C",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Bush, Kent W",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Christensen, Will",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Duncan, Richard A",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Goode, Virgil",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Knill, Dennis J",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Reed, Jill A.",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Rogers, Rick L",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Stein, Jill E",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Thorne, Kevin M",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,write - in,"Warner, Gerald L.",0,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,Democratic,"Obama, Barack",418,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",9,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,Reform,"Baldwin, Chuck",3,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,President / Vice President,,Republican,"Romney, Mitt",224,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Ayers, Avery L",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Barnett, Andre",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Barr, Roseanne C",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Bush, Kent W",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Christensen, Will",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Duncan, Richard A",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Goode, Virgil",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Knill, Dennis J",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Reed, Jill A.",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Rogers, Rick L",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Stein, Jill E",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Thorne, Kevin M",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,write - in,"Warner, Gerald L.",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,Democratic,"Obama, Barack",515,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",4,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,Reform,"Baldwin, Chuck",0,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,President / Vice President,,Republican,"Romney, Mitt",258,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Ayers, Avery L",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Barnett, Andre",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Barr, Roseanne C",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Bush, Kent W",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Christensen, Will",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Duncan, Richard A",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Goode, Virgil",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Knill, Dennis J",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Reed, Jill A.",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Rogers, Rick L",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Stein, Jill E",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Thorne, Kevin M",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,write - in,"Warner, Gerald L.",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,Democratic,"Obama, Barack",125,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",4,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,Reform,"Baldwin, Chuck",0,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,President / Vice President,,Republican,"Romney, Mitt",189,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Ayers, Avery L",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Barnett, Andre",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Barr, Roseanne C",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Bush, Kent W",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Christensen, Will",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Duncan, Richard A",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Goode, Virgil",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Knill, Dennis J",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Reed, Jill A.",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Rogers, Rick L",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Stein, Jill E",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Thorne, Kevin M",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,write - in,"Warner, Gerald L.",0,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,Democratic,"Obama, Barack",436,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",2,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,Reform,"Baldwin, Chuck",4,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,President / Vice President,,Republican,"Romney, Mitt",460,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Ayers, Avery L",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Barnett, Andre",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Barr, Roseanne C",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Bush, Kent W",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Christensen, Will",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Duncan, Richard A",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Goode, Virgil",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Hoefling, Tom",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Knill, Dennis J",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Reed, Jill A.",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Rogers, Rick L",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Stein, Jill E",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Thorne, Kevin M",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,write - in,"Warner, Gerald L.",0,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,Democratic,"Obama, Barack",388,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,Libertarian,"Johnson, Gary",11,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,Reform,"Baldwin, Chuck",2,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,President / Vice President,,Republican,"Romney, Mitt",449,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Ayers, Avery L",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Barnett, Andre",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Barr, Roseanne C",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Bush, Kent W",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Christensen, Will",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Duncan, Richard A",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Goode, Virgil",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Hoefling, Tom",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Knill, Dennis J",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Reed, Jill A.",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Rogers, Rick L",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Stein, Jill E",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Thorne, Kevin M",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,write - in,"Warner, Gerald L.",0,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,Democratic,"Obama, Barack",413,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,Libertarian,"Johnson, Gary",6,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,Reform,"Baldwin, Chuck",7,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,President / Vice President,,Republican,"Romney, Mitt",290,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Ayers, Avery L",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Barnett, Andre",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Barr, Roseanne C",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Bush, Kent W",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Christensen, Will",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Duncan, Richard A",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Goode, Virgil",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Hoefling, Tom",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Knill, Dennis J",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Reed, Jill A.",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Rogers, Rick L",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Stein, Jill E",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Thorne, Kevin M",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,write - in,"Warner, Gerald L.",0,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,Democratic,"Obama, Barack",419,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,Libertarian,"Johnson, Gary",7,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,Reform,"Baldwin, Chuck",4,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,President / Vice President,,Republican,"Romney, Mitt",548,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Ayers, Avery L",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Barnett, Andre",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Barr, Roseanne C",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Bush, Kent W",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Christensen, Will",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Duncan, Richard A",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Goode, Virgil",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Hoefling, Tom",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Knill, Dennis J",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Reed, Jill A.",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Rogers, Rick L",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Stein, Jill E",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Thorne, Kevin M",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,write - in,"Warner, Gerald L.",0,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,Democratic,"Obama, Barack",419,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,Libertarian,"Johnson, Gary",7,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,Reform,"Baldwin, Chuck",3,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,President / Vice President,,Republican,"Romney, Mitt",651,601100
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Ayers, Avery L",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Barnett, Andre",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Barr, Roseanne C",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Bush, Kent W",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Christensen, Will",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Duncan, Richard A",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Goode, Virgil",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Knill, Dennis J",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Reed, Jill A.",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Rogers, Rick L",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Stein, Jill E",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Thorne, Kevin M",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Tittle, Sheila and/or Samm",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,write - in,"Warner, Gerald L.",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,Democratic,"Obama, Barack",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,Democratic,"Obama, Barack",8,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,Reform,"Baldwin, Chuck",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,Republican,"Romney, Mitt",0,601110
+WYANDOTTE,Lake Quivira City Precinct 01,President / Vice President,,Republican,"Romney, Mitt",27,601110
+WYANDOTTE,ADVANCED,President / Vice President,,write - in,"Anderson, Ross ""Rocky"" C",2,999998
+WYANDOTTE,ADVANCED,President / Vice President,,write - in,"Barnett, Andre",1,999998
+WYANDOTTE,ADVANCED,President / Vice President,,write - in,"Barr, Roseanne C",2,999998
+WYANDOTTE,ADVANCED,President / Vice President,,write - in,"Goode, Virgil",13,999998
+WYANDOTTE,ADVANCED,President / Vice President,,write - in,"Hoefling, Tom",1,999998
+WYANDOTTE,ADVANCED,President / Vice President,,write - in,"Stein, Jill E",24,999998
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",219,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",386,120020
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",1,120030
+WYANDOTTE,Edwardsville Ward 01 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",1,120030
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",153,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",420,120040
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",83,120050
+WYANDOTTE,Edwardsville Ward 02 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",105,120050
+WYANDOTTE,Kansas City Ward 10 Precinct 03,United States House of Representatives,3,Libertarian,"Balam, Joel",26,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",7,120060
+WYANDOTTE,Kansas City Ward 10 Precinct 06,United States House of Representatives,3,Libertarian,"Balam, Joel",172,120070
+WYANDOTTE,Kansas City Ward 10 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",75,120070
+WYANDOTTE,Kansas City Ward 11 Precinct 13,United States House of Representatives,3,Libertarian,"Balam, Joel",212,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",330,120080
+WYANDOTTE,Kansas City Ward 11 Precinct 14,United States House of Representatives,3,Libertarian,"Balam, Joel",7,120090
+WYANDOTTE,Kansas City Ward 11 Precinct 14,United States House of Representatives,3,Republican,"Yoder, Kevin",8,120090
+WYANDOTTE,Kansas City Ward 12 Precinct 11,United States House of Representatives,3,Libertarian,"Balam, Joel",51,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",123,120100
+WYANDOTTE,Kansas City Ward 12 Precinct 10,United States House of Representatives,3,Libertarian,"Balam, Joel",104,120110
+WYANDOTTE,Kansas City Ward 12 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",208,120110
+WYANDOTTE,Kansas City Ward 14 Precinct 08,United States House of Representatives,3,Libertarian,"Balam, Joel",201,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",258,120120
+WYANDOTTE,Kansas City Ward 14 Precinct 16,United States House of Representatives,3,Libertarian,"Balam, Joel",47,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 16,United States House of Representatives,3,Republican,"Yoder, Kevin",72,120130
+WYANDOTTE,Kansas City Ward 14 Precinct 11,United States House of Representatives,3,Libertarian,"Balam, Joel",154,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",270,120140
+WYANDOTTE,Kansas City Ward 14 Precinct 17,United States House of Representatives,3,Libertarian,"Balam, Joel",44,120150
+WYANDOTTE,Kansas City Ward 14 Precinct 17,United States House of Representatives,3,Republican,"Yoder, Kevin",79,120150
+WYANDOTTE,Kansas City Ward 07 Precinct 05,United States House of Representatives,3,Libertarian,"Balam, Joel",57,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",47,120160
+WYANDOTTE,Kansas City Ward 07 Precinct 10,United States House of Representatives,3,Libertarian,"Balam, Joel",53,120170
+WYANDOTTE,Kansas City Ward 07 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",48,120170
+WYANDOTTE,Kansas City Ward 09 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",21,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",42,120180
+WYANDOTTE,Kansas City Ward 09 Precinct 15,United States House of Representatives,3,Libertarian,"Balam, Joel",161,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 15,United States House of Representatives,3,Republican,"Yoder, Kevin",160,120190
+WYANDOTTE,Kansas City Ward 09 Precinct 08,United States House of Representatives,3,Libertarian,"Balam, Joel",120,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",103,120200
+WYANDOTTE,Kansas City Ward 09 Precinct 16,United States House of Representatives,3,Libertarian,"Balam, Joel",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 16,United States House of Representatives,3,Republican,"Yoder, Kevin",0,120210
+WYANDOTTE,Kansas City Ward 09 Precinct 17,United States House of Representatives,3,Libertarian,"Balam, Joel",70,120220
+WYANDOTTE,Kansas City Ward 09 Precinct 17,United States House of Representatives,3,Republican,"Yoder, Kevin",18,120220
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",195,600010
+WYANDOTTE,Bonner Springs Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",362,600010
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",125,600020
+WYANDOTTE,Bonner Springs Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",241,600020
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",271,600030
+WYANDOTTE,Bonner Springs Ward 03 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",529,600030
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",188,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",355,600040
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",83,600050
+WYANDOTTE,Bonner Springs Ward 04 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",153,600050
+WYANDOTTE,Delaware Township 01,United States House of Representatives,3,Libertarian,"Balam, Joel",3,600060
+WYANDOTTE,Delaware Township 01,United States House of Representatives,3,Republican,"Yoder, Kevin",14,600060
+WYANDOTTE,Kansas City Ward 01 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",92,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",40,600090
+WYANDOTTE,Kansas City Ward 01 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",86,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",31,600100
+WYANDOTTE,Kansas City Ward 01 Precinct 03,United States House of Representatives,3,Libertarian,"Balam, Joel",38,600110
+WYANDOTTE,Kansas City Ward 01 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",36,600110
+WYANDOTTE,Kansas City Ward 02 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",110,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",77,600120
+WYANDOTTE,Kansas City Ward 02 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",95,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",37,600130
+WYANDOTTE,Kansas City Ward 02 Precinct 03,United States House of Representatives,3,Libertarian,"Balam, Joel",34,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",9,600140
+WYANDOTTE,Kansas City Ward 02 Precinct 04,United States House of Representatives,3,Libertarian,"Balam, Joel",102,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",29,600150
+WYANDOTTE,Kansas City Ward 02 Precinct 05,United States House of Representatives,3,Libertarian,"Balam, Joel",168,600160
+WYANDOTTE,Kansas City Ward 02 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",71,600160
+WYANDOTTE,Kansas City Ward 03 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",251,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",81,600170
+WYANDOTTE,Kansas City Ward 03 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",292,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",62,600180
+WYANDOTTE,Kansas City Ward 03 Precinct 03,United States House of Representatives,3,Libertarian,"Balam, Joel",56,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",19,600190
+WYANDOTTE,Kansas City Ward 03 Precinct 04,United States House of Representatives,3,Libertarian,"Balam, Joel",182,600200
+WYANDOTTE,Kansas City Ward 03 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",59,600200
+WYANDOTTE,Kansas City Ward 04 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",163,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",112,600210
+WYANDOTTE,Kansas City Ward 04 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",38,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",34,600220
+WYANDOTTE,Kansas City Ward 04 Precinct 03,United States House of Representatives,3,Libertarian,"Balam, Joel",101,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",77,600230
+WYANDOTTE,Kansas City Ward 04 Precinct 04,United States House of Representatives,3,Libertarian,"Balam, Joel",164,600240
+WYANDOTTE,Kansas City Ward 04 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",199,600240
+WYANDOTTE,Kansas City Ward 05 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",135,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",87,600250
+WYANDOTTE,Kansas City Ward 05 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",65,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",39,600260
+WYANDOTTE,Kansas City Ward 05 Precinct 03,United States House of Representatives,3,Libertarian,"Balam, Joel",72,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",42,600270
+WYANDOTTE,Kansas City Ward 05 Precinct 04,United States House of Representatives,3,Libertarian,"Balam, Joel",66,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",56,600280
+WYANDOTTE,Kansas City Ward 05 Precinct 05,United States House of Representatives,3,Libertarian,"Balam, Joel",99,600290
+WYANDOTTE,Kansas City Ward 05 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",84,600290
+WYANDOTTE,Kansas City Ward 06 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",92,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",94,600300
+WYANDOTTE,Kansas City Ward 06 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",28,600310
+WYANDOTTE,Kansas City Ward 06 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",35,600310
+WYANDOTTE,Kansas City Ward 07 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",126,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",114,600320
+WYANDOTTE,Kansas City Ward 07 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",91,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",81,600330
+WYANDOTTE,Kansas City Ward 07 Precinct 03,United States House of Representatives,3,Libertarian,"Balam, Joel",139,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",155,600340
+WYANDOTTE,Kansas City Ward 07 Precinct 04,United States House of Representatives,3,Libertarian,"Balam, Joel",156,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",292,600350
+WYANDOTTE,Kansas City Ward 07 Precinct 06,United States House of Representatives,3,Libertarian,"Balam, Joel",245,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",217,600370
+WYANDOTTE,Kansas City Ward 07 Precinct 07,United States House of Representatives,3,Libertarian,"Balam, Joel",114,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",79,600380
+WYANDOTTE,Kansas City Ward 07 Precinct 08,United States House of Representatives,3,Libertarian,"Balam, Joel",220,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",282,600390
+WYANDOTTE,Kansas City Ward 07 Precinct 09,United States House of Representatives,3,Libertarian,"Balam, Joel",224,600400
+WYANDOTTE,Kansas City Ward 07 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",282,600400
+WYANDOTTE,Kansas City Ward 08 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",195,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",106,600410
+WYANDOTTE,Kansas City Ward 08 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",236,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",108,600420
+WYANDOTTE,Kansas City Ward 08 Precinct 03,United States House of Representatives,3,Libertarian,"Balam, Joel",341,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",203,600430
+WYANDOTTE,Kansas City Ward 08 Precinct 04,United States House of Representatives,3,Libertarian,"Balam, Joel",240,600440
+WYANDOTTE,Kansas City Ward 08 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",165,600440
+WYANDOTTE,Kansas City Ward 09 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",141,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",157,600460
+WYANDOTTE,Kansas City Ward 09 Precinct 03,United States House of Representatives,3,Libertarian,"Balam, Joel",167,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",148,600470
+WYANDOTTE,Kansas City Ward 09 Precinct 04,United States House of Representatives,3,Libertarian,"Balam, Joel",54,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",43,600480
+WYANDOTTE,Kansas City Ward 09 Precinct 05,United States House of Representatives,3,Libertarian,"Balam, Joel",6,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",20,600490
+WYANDOTTE,Kansas City Ward 09 Precinct 06,United States House of Representatives,3,Libertarian,"Balam, Joel",161,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",106,600500
+WYANDOTTE,Kansas City Ward 09 Precinct 07,United States House of Representatives,3,Libertarian,"Balam, Joel",174,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",212,600510
+WYANDOTTE,Kansas City Ward 09 Precinct 09,United States House of Representatives,3,Libertarian,"Balam, Joel",79,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",105,600530
+WYANDOTTE,Kansas City Ward 09 Precinct 10,United States House of Representatives,3,Libertarian,"Balam, Joel",236,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",237,600540
+WYANDOTTE,Kansas City Ward 09 Precinct 11,United States House of Representatives,3,Libertarian,"Balam, Joel",295,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",228,600550
+WYANDOTTE,Kansas City Ward 09 Precinct 12,United States House of Representatives,3,Libertarian,"Balam, Joel",221,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",265,600560
+WYANDOTTE,Kansas City Ward 09 Precinct 13,United States House of Representatives,3,Libertarian,"Balam, Joel",141,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",190,600570
+WYANDOTTE,Kansas City Ward 09 Precinct 14,United States House of Representatives,3,Libertarian,"Balam, Joel",193,600580
+WYANDOTTE,Kansas City Ward 09 Precinct 14,United States House of Representatives,3,Republican,"Yoder, Kevin",269,600580
+WYANDOTTE,Kansas City Ward 10 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",287,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",74,600590
+WYANDOTTE,Kansas City Ward 10 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",202,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",56,600600
+WYANDOTTE,Kansas City Ward 10 Precinct 04,United States House of Representatives,3,Libertarian,"Balam, Joel",157,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",66,600620
+WYANDOTTE,Kansas City Ward 10 Precinct 05,United States House of Representatives,3,Libertarian,"Balam, Joel",256,600630
+WYANDOTTE,Kansas City Ward 10 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",180,600630
+WYANDOTTE,Kansas City Ward 11 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",247,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",158,600640
+WYANDOTTE,Kansas City Ward 11 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",189,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",129,600650
+WYANDOTTE,Kansas City Ward 11 Precinct 03,United States House of Representatives,3,Libertarian,"Balam, Joel",270,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",206,600660
+WYANDOTTE,Kansas City Ward 11 Precinct 04,United States House of Representatives,3,Libertarian,"Balam, Joel",224,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",145,600670
+WYANDOTTE,Kansas City Ward 11 Precinct 05,United States House of Representatives,3,Libertarian,"Balam, Joel",229,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",154,600680
+WYANDOTTE,Kansas City Ward 11 Precinct 06,United States House of Representatives,3,Libertarian,"Balam, Joel",225,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",98,600690
+WYANDOTTE,Kansas City Ward 11 Precinct 07,United States House of Representatives,3,Libertarian,"Balam, Joel",159,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",121,600700
+WYANDOTTE,Kansas City Ward 11 Precinct 08,United States House of Representatives,3,Libertarian,"Balam, Joel",243,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",134,600710
+WYANDOTTE,Kansas City Ward 11 Precinct 09,United States House of Representatives,3,Libertarian,"Balam, Joel",210,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",142,600720
+WYANDOTTE,Kansas City Ward 11 Precinct 10,United States House of Representatives,3,Libertarian,"Balam, Joel",222,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",184,600730
+WYANDOTTE,Kansas City Ward 11 Precinct 11,United States House of Representatives,3,Libertarian,"Balam, Joel",270,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 11,United States House of Representatives,3,Republican,"Yoder, Kevin",339,600740
+WYANDOTTE,Kansas City Ward 11 Precinct 12,United States House of Representatives,3,Libertarian,"Balam, Joel",40,600750
+WYANDOTTE,Kansas City Ward 11 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",57,600750
+WYANDOTTE,Kansas City Ward 12 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",191,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",187,600770
+WYANDOTTE,Kansas City Ward 12 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",95,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",72,600780
+WYANDOTTE,Kansas City Ward 12 Precinct 03,United States House of Representatives,3,Libertarian,"Balam, Joel",199,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",221,600790
+WYANDOTTE,Kansas City Ward 12 Precinct 04,United States House of Representatives,3,Libertarian,"Balam, Joel",202,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",247,600800
+WYANDOTTE,Kansas City Ward 12 Precinct 05,United States House of Representatives,3,Libertarian,"Balam, Joel",123,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",278,600810
+WYANDOTTE,Kansas City Ward 12 Precinct 06,United States House of Representatives,3,Libertarian,"Balam, Joel",150,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",237,600820
+WYANDOTTE,Kansas City Ward 12 Precinct 07,United States House of Representatives,3,Libertarian,"Balam, Joel",144,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",215,600830
+WYANDOTTE,Kansas City Ward 12 Precinct 08,United States House of Representatives,3,Libertarian,"Balam, Joel",173,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",229,600840
+WYANDOTTE,Kansas City Ward 12 Precinct 09,United States House of Representatives,3,Libertarian,"Balam, Joel",168,600850
+WYANDOTTE,Kansas City Ward 12 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",263,600850
+WYANDOTTE,Kansas City Ward 13 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",260,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",155,600870
+WYANDOTTE,Kansas City Ward 13 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",194,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",191,600880
+WYANDOTTE,Kansas City Ward 13 Precinct 03,United States House of Representatives,3,Libertarian,"Balam, Joel",196,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",138,600890
+WYANDOTTE,Kansas City Ward 13 Precinct 04,United States House of Representatives,3,Libertarian,"Balam, Joel",149,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",63,600900
+WYANDOTTE,Kansas City Ward 13 Precinct 05,United States House of Representatives,3,Libertarian,"Balam, Joel",200,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",182,600910
+WYANDOTTE,Kansas City Ward 13 Precinct 06,United States House of Representatives,3,Libertarian,"Balam, Joel",196,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",165,600920
+WYANDOTTE,Kansas City Ward 13 Precinct 07,United States House of Representatives,3,Libertarian,"Balam, Joel",125,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",183,600930
+WYANDOTTE,Kansas City Ward 13 Precinct 08,United States House of Representatives,3,Libertarian,"Balam, Joel",163,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 08,United States House of Representatives,3,Republican,"Yoder, Kevin",156,600940
+WYANDOTTE,Kansas City Ward 13 Precinct 09,United States House of Representatives,3,Libertarian,"Balam, Joel",216,600950
+WYANDOTTE,Kansas City Ward 13 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",187,600950
+WYANDOTTE,Kansas City Ward 14 Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",172,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",312,600960
+WYANDOTTE,Kansas City Ward 14 Precinct 02,United States House of Representatives,3,Libertarian,"Balam, Joel",113,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 02,United States House of Representatives,3,Republican,"Yoder, Kevin",114,600970
+WYANDOTTE,Kansas City Ward 14 Precinct 03,United States House of Representatives,3,Libertarian,"Balam, Joel",102,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 03,United States House of Representatives,3,Republican,"Yoder, Kevin",103,600980
+WYANDOTTE,Kansas City Ward 14 Precinct 04,United States House of Representatives,3,Libertarian,"Balam, Joel",215,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 04,United States House of Representatives,3,Republican,"Yoder, Kevin",163,600990
+WYANDOTTE,Kansas City Ward 14 Precinct 05,United States House of Representatives,3,Libertarian,"Balam, Joel",167,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 05,United States House of Representatives,3,Republican,"Yoder, Kevin",190,601000
+WYANDOTTE,Kansas City Ward 14 Precinct 06,United States House of Representatives,3,Libertarian,"Balam, Joel",219,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 06,United States House of Representatives,3,Republican,"Yoder, Kevin",294,601010
+WYANDOTTE,Kansas City Ward 14 Precinct 07,United States House of Representatives,3,Libertarian,"Balam, Joel",241,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 07,United States House of Representatives,3,Republican,"Yoder, Kevin",325,601020
+WYANDOTTE,Kansas City Ward 14 Precinct 09,United States House of Representatives,3,Libertarian,"Balam, Joel",86,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 09,United States House of Representatives,3,Republican,"Yoder, Kevin",194,601040
+WYANDOTTE,Kansas City Ward 14 Precinct 10,United States House of Representatives,3,Libertarian,"Balam, Joel",225,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 10,United States House of Representatives,3,Republican,"Yoder, Kevin",517,601050
+WYANDOTTE,Kansas City Ward 14 Precinct 12,United States House of Representatives,3,Libertarian,"Balam, Joel",224,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 12,United States House of Representatives,3,Republican,"Yoder, Kevin",492,601070
+WYANDOTTE,Kansas City Ward 14 Precinct 13,United States House of Representatives,3,Libertarian,"Balam, Joel",232,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 13,United States House of Representatives,3,Republican,"Yoder, Kevin",361,601080
+WYANDOTTE,Kansas City Ward 14 Precinct 14,United States House of Representatives,3,Libertarian,"Balam, Joel",235,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 14,United States House of Representatives,3,Republican,"Yoder, Kevin",581,601090
+WYANDOTTE,Kansas City Ward 14 Precinct 15,United States House of Representatives,3,Libertarian,"Balam, Joel",232,601100
+WYANDOTTE,Kansas City Ward 14 Precinct 15,United States House of Representatives,3,Republican,"Yoder, Kevin",682,601100
+WYANDOTTE,Lake Quivira City Precinct 01,United States House of Representatives,3,Libertarian,"Balam, Joel",7,601110
+WYANDOTTE,Lake Quivira City Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",25,601110
+WYANDOTTE,ADVANCED,United States House of Representatives,3,Libertarian,"Balam, Joel",0,999998
+WYANDOTTE,ADVANCED,United States House of Representatives,3,Republican,"Yoder, Kevin",0,999998

--- a/src/parse-csv.rb
+++ b/src/parse-csv.rb
@@ -90,6 +90,10 @@ end
 ARGV.each do |filename|
   puts filename
   CSV.foreach(filename, headers: true, header_converters: [:downcase], encoding: 'bom|utf-8') do |row|
+    if !row['county']
+      puts "No county in row: #{row.inspect}"
+      next
+    end
     write_to_csv(csv_out_file(row['county']), row)
   end
 end


### PR DESCRIPTION
This does 2 things:

* parses 2012 SOS sources-ks files into separate precinct files
* preserves existing results for Johnson, Sedgwick and Shawnee counties in separate precinct files, since those counties did not have VTD data in the SOS sources-ks