### PR TITLE
Remove "summary" result lines as misleading

### DIFF
--- a/2014/20141104__ks__general__harvey__precinct.csv
+++ b/2014/20141104__ks__general__harvey__precinct.csv
@@ -506,7 +506,6 @@ Harvey,14-Newton City W4P1,Secretary of State,,R,Kris Kobach,195
 Harvey,15-Newton City W4P2,Secretary of State,,R,Kris Kobach,380
 Harvey,16-Newton City W4P3,Secretary of State,,R,Kris Kobach,291
 Harvey,17-Newton City W4P4,Secretary of State,,R,Kris Kobach,115
-Harvey,Newton City,Secretary of State,,R,Kris Kobach,3133
 Harvey,1-Halstead  City W1P1,Secretary of State,,R,Kris Kobach,173
 Harvey,2-Halstead  City W2P1,Secretary of State,,R,Kris Kobach,208
 Harvey,3-Hesston  City W1P1,Secretary of State,,R,Kris Kobach,364
@@ -545,7 +544,6 @@ Harvey,14-Newton City W4P1,Secretary of State,,D,Jean Schodorf,193
 Harvey,15-Newton City W4P2,Secretary of State,,D,Jean Schodorf,367
 Harvey,16-Newton City W4P3,Secretary of State,,D,Jean Schodorf,239
 Harvey,17-Newton City W4P4,Secretary of State,,D,Jean Schodorf,103
-Harvey,Newton City,Secretary of State,,D,Jean Schodorf,2597
 Harvey,1-Halstead  City W1P1,Secretary of State,,D,Jean Schodorf,94
 Harvey,2-Halstead  City W2P1,Secretary of State,,D,Jean Schodorf,146
 Harvey,3-Hesston  City W1P1,Secretary of State,,D,Jean Schodorf,320
@@ -584,7 +582,6 @@ Harvey,14-Newton City W4P1,Attorney General,,R,Derek Schmidt,250
 Harvey,15-Newton City W4P2,Attorney General,,R,Derek Schmidt,479
 Harvey,16-Newton City W4P3,Attorney General,,R,Derek Schmidt,348
 Harvey,17-Newton City W4P4,Attorney General,,R,Derek Schmidt,142
-Harvey,Newton City,Attorney General,,R,Derek Schmidt,3718
 Harvey,1-Halstead  City W1P1,Attorney General,,R,Derek Schmidt,194
 Harvey,2-Halstead  City W2P1,Attorney General,,R,Derek Schmidt,254
 Harvey,3-Hesston  City W1P1,Attorney General,,R,Derek Schmidt,478
@@ -623,7 +620,6 @@ Harvey,14-Newton City W4P1,Attorney General,,D,A J Kotich,134
 Harvey,15-Newton City W4P2,Attorney General,,D,A J Kotich,255
 Harvey,16-Newton City W4P3,Attorney General,,D,A J Kotich,175
 Harvey,17-Newton City W4P4,Attorney General,,D,A J Kotich,76
-Harvey,Newton City,Attorney General,,D,A J Kotich,1921
 Harvey,1-Halstead  City W1P1,Attorney General,,D,A J Kotich,72
 Harvey,2-Halstead  City W2P1,Attorney General,,D,A J Kotich,94
 Harvey,3-Hesston  City W1P1,Attorney General,,D,A J Kotich,187
@@ -662,7 +658,6 @@ Harvey,14-Newton City W4P1,State Treasurer,,R,Ron Estes,248
 Harvey,15-Newton City W4P2,State Treasurer,,R,Ron Estes,484
 Harvey,16-Newton City W4P3,State Treasurer,,R,Ron Estes,348
 Harvey,17-Newton City W4P4,State Treasurer,,R,Ron Estes,139
-Harvey,Newton City,State Treasurer,,R,Ron Estes,3750
 Harvey,1-Halstead  City W1P1,State Treasurer,,R,Ron Estes,204
 Harvey,2-Halstead  City W2P1,State Treasurer,,R,Ron Estes,249
 Harvey,3-Hesston  City W1P1,State Treasurer,,R,Ron Estes,479
@@ -701,7 +696,6 @@ Harvey,14-Newton City W4P1,State Treasurer,,D,Carmen Alldritt,135
 Harvey,15-Newton City W4P2,State Treasurer,,D,Carmen Alldritt,246
 Harvey,16-Newton City W4P3,State Treasurer,,D,Carmen Alldritt,174
 Harvey,17-Newton City W4P4,State Treasurer,,D,Carmen Alldritt,76
-Harvey,Newton City,State Treasurer,,D,Carmen Alldritt,1878
 Harvey,1-Halstead  City W1P1,State Treasurer,,D,Carmen Alldritt,60
 Harvey,2-Halstead  City W2P1,State Treasurer,,D,Carmen Alldritt,100
 Harvey,3-Hesston  City W1P1,State Treasurer,,D,Carmen Alldritt,183
@@ -740,7 +734,6 @@ Harvey,14-Newton City W4P1,Insurance Commissioner,,R,Ken Selzer,229
 Harvey,15-Newton City W4P2,Insurance Commissioner,,R,Ken Selzer,446
 Harvey,16-Newton City W4P3,Insurance Commissioner,,R,Ken Selzer,323
 Harvey,17-Newton City W4P4,Insurance Commissioner,,R,Ken Selzer,125
-Harvey,Newton City,Insurance Commissioner,,R,Ken Selzer,3475
 Harvey,1-Halstead  City W1P1,Insurance Commissioner,,R,Ken Selzer,189
 Harvey,2-Halstead  City W2P1,Insurance Commissioner,,R,Ken Selzer,228
 Harvey,3-Hesston  City W1P1,Insurance Commissioner,,R,Ken Selzer,456
@@ -779,7 +772,6 @@ Harvey,14-Newton City W4P1,Insurance Commissioner,,D,Dennis Anderson,157
 Harvey,15-Newton City W4P2,Insurance Commissioner,,D,Dennis Anderson,286
 Harvey,16-Newton City W4P3,Insurance Commissioner,,D,Dennis Anderson,191
 Harvey,17-Newton City W4P4,Insurance Commissioner,,D,Dennis Anderson,86
-Harvey,Newton City,Insurance Commissioner,,D,Dennis Anderson,2127
 Harvey,1-Halstead  City W1P1,Insurance Commissioner,,D,Dennis Anderson,73
 Harvey,2-Halstead  City W2P1,Insurance Commissioner,,D,Dennis Anderson,124
 Harvey,3-Hesston  City W1P1,Insurance Commissioner,,D,Dennis Anderson,213


### PR DESCRIPTION
Not sure if these were in the original sources or added during parsing, but I find these summary lines misleading because there is nothing indicating they are summaries.